### PR TITLE
feat: update OakQuizCheckbox feedback state

### DIFF
--- a/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.stories.tsx
+++ b/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.stories.tsx
@@ -9,10 +9,15 @@ const meta: Meta<typeof OakQuizCheckBox> = {
   component: OakQuizCheckBox,
   tags: ["autodocs"],
   title: "components/integrated/OakQuizCheckBox",
-  argTypes: {},
+  argTypes: {
+    feedback: {
+      options: ["correct", "incorrect", null],
+      control: { type: "select" },
+    },
+  },
   parameters: {
     controls: {
-      include: ["isFeedback", "isCorrect", "disabled", "defaultChecked"],
+      include: ["feedback", "disabled", "defaultChecked"],
     },
   },
 };
@@ -32,7 +37,7 @@ export const Default: Story = {
   },
   parameters: {
     controls: {
-      include: ["isFeedback", "isCorrect", "disabled", "defaultChecked"],
+      include: ["disabled", "defaultChecked", "feedback"],
     },
   },
 };
@@ -58,7 +63,7 @@ export const WithImage: Story = {
   },
   parameters: {
     controls: {
-      include: ["isFeedback", "isCorrect", "disabled"],
+      include: ["disabled", "feedback"],
     },
   },
 };
@@ -104,7 +109,7 @@ export const WithImageNoDims: Story = {
   args: {},
   parameters: {
     controls: {
-      include: ["isFeedback", "isCorrect", "disabled"],
+      include: ["disabled", "feedback"],
     },
   },
 };
@@ -159,35 +164,35 @@ export const Feedback: Story = {
       <OakQuizCheckBox
         {...args}
         id="checkbox-test-default-7"
-        isFeedback={true}
         defaultChecked={true}
-        isCorrect={true}
+        feedback={"correct"}
         value="correctly selected"
       />
       <OakQuizCheckBox
         {...args}
         id="checkbox-test-default-8"
-        isFeedback={true}
         defaultChecked={true}
+        feedback={"incorrect"}
         value="incorrectly selected"
       />
       <OakQuizCheckBox
         {...args}
         id="checkbox-test-default-9"
-        isFeedback={true}
-        isCorrect={true}
+        feedback={"correct"}
         value="correctly not selected"
       />
       <OakQuizCheckBox
         {...args}
         id="checkbox-test-default-10"
-        isFeedback={true}
+        feedback={"incorrect"}
         value="incorrectly not selected"
       />
     </OakFlex>
   ),
   args: {},
   parameters: {
-    controls: {},
+    controls: {
+      include: [],
+    },
   },
 };

--- a/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.stories.tsx
+++ b/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.stories.tsx
@@ -169,7 +169,6 @@ export const Feedback: Story = {
         id="checkbox-test-default-8"
         isFeedback={true}
         defaultChecked={true}
-        disabled={true}
         value="incorrectly selected"
       />
       <OakQuizCheckBox

--- a/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.stories.tsx
+++ b/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.stories.tsx
@@ -147,3 +147,48 @@ export const PreChecked: Story = {
     },
   },
 };
+
+export const Feedback: Story = {
+  render: (args) => (
+    <OakFlex
+      $pa="inner-padding-l"
+      $background={"bg-neutral"}
+      $flexDirection={"column"}
+      $gap={"space-between-m"}
+    >
+      <OakQuizCheckBox
+        {...args}
+        id="checkbox-test-default-7"
+        isFeedback={true}
+        defaultChecked={true}
+        isCorrect={true}
+        value="correctly selected"
+      />
+      <OakQuizCheckBox
+        {...args}
+        id="checkbox-test-default-8"
+        isFeedback={true}
+        defaultChecked={true}
+        disabled={true}
+        value="incorrectly selected"
+      />
+      <OakQuizCheckBox
+        {...args}
+        id="checkbox-test-default-9"
+        isFeedback={true}
+        isCorrect={true}
+        value="correctly not selected"
+      />
+      <OakQuizCheckBox
+        {...args}
+        id="checkbox-test-default-10"
+        isFeedback={true}
+        value="incorrectly not selected"
+      />
+    </OakFlex>
+  ),
+  args: {},
+  parameters: {
+    controls: {},
+  },
+};

--- a/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.test.tsx
+++ b/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.test.tsx
@@ -103,11 +103,18 @@ describe("OakQuizCheckBox", () => {
     expect(getByAltText("Incorrect")).toBeInTheDocument();
   });
 
-  it("does not render a checkbox when in feedback mode", () => {
-    const { queryByRole } = renderWithTheme(
-      <OakQuizCheckBox id="checkbox-1" value="Option 1" isFeedback />,
+  it("is disabled when in feedback mode ", () => {
+    const onChange = jest.fn();
+    const { getByRole } = renderWithTheme(
+      <OakQuizCheckBox
+        id="checkbox-1"
+        value="Option 1"
+        isFeedback
+        onChange={onChange}
+      />,
     );
-    expect(queryByRole("checkbox")).not.toBeInTheDocument();
+    getByRole("checkbox").click();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("is initially checked when defaultChecked is true", () => {

--- a/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.test.tsx
+++ b/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.test.tsx
@@ -91,14 +91,18 @@ describe("OakQuizCheckBox", () => {
 
   it("renders a tick when isCorrect is true and isFeedback is true", () => {
     const { getByAltText } = renderWithTheme(
-      <OakQuizCheckBox id="checkbox-1" value="Option 1" isCorrect isFeedback />,
+      <OakQuizCheckBox id="checkbox-1" value="Option 1" feedback={"correct"} />,
     );
     expect(getByAltText("Correct")).toBeInTheDocument();
   });
 
   it("renders a cross when isCorrect is false and isFeedback is true", () => {
     const { getByAltText } = renderWithTheme(
-      <OakQuizCheckBox id="checkbox-1" value="Option 1" isFeedback />,
+      <OakQuizCheckBox
+        id="checkbox-1"
+        value="Option 1"
+        feedback={"incorrect"}
+      />,
     );
     expect(getByAltText("Incorrect")).toBeInTheDocument();
   });
@@ -109,7 +113,7 @@ describe("OakQuizCheckBox", () => {
       <OakQuizCheckBox
         id="checkbox-1"
         value="Option 1"
-        isFeedback
+        feedback={"incorrect"}
         onChange={onChange}
       />,
     );

--- a/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.tsx
+++ b/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.tsx
@@ -138,8 +138,7 @@ const StyledFlexBox = styled(OakFlex)<StyledFlexBoxProps>`
 `;
 
 export type OakQuizCheckBoxProps = BaseCheckBoxProps & {
-  isFeedback?: boolean;
-  isCorrect?: boolean;
+  feedback?: "correct" | "incorrect" | null;
   image?: React.JSX.Element;
   innerRef?: React.RefObject<HTMLInputElement>;
 };
@@ -149,16 +148,10 @@ const StyledOverlay = styled(OakBox)`
 `;
 
 export const OakQuizCheckBox = (props: OakQuizCheckBoxProps) => {
-  const {
-    id,
-    value,
-    isFeedback,
-    isCorrect,
-    image,
-    disabled,
-    innerRef,
-    ...rest
-  } = props;
+  const { id, value, feedback, image, disabled, innerRef, ...rest } = props;
+
+  const isFeedback = !!feedback;
+  const isCorrect = feedback === "correct";
 
   const defaultRef = useRef<HTMLInputElement>(null);
   const inputRef = innerRef ?? defaultRef;

--- a/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.tsx
+++ b/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.tsx
@@ -187,7 +187,7 @@ export const OakQuizCheckBox = (props: OakQuizCheckBoxProps) => {
   );
 
   const backgroundColor: OakCombinedColorToken =
-    disabled && !isFeedback ? "bg-primary" : "bg-neutral-stronger";
+    disabled && !isFeedback ? "bg-neutral-stronger" : "bg-primary";
 
   const feedbackBgColor: OakCombinedColorToken = isCorrect
     ? "bg-correct"

--- a/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.tsx
+++ b/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.tsx
@@ -230,7 +230,7 @@ export const OakQuizCheckBox = (props: OakQuizCheckBoxProps) => {
         htmlFor={id}
         labelGap={"space-between-s"}
         labelAlignItems={"center"}
-        $color={disabled || isFeedback ? "text-disabled" : "text-primary"}
+        $color={disabled && !isFeedback ? "text-disabled" : "text-primary"}
         $font={"body-1"}
         disabled={disabled}
       >

--- a/src/components/integrated/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
+++ b/src/components/integrated/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
         >
           <input
             className="sc-cPiKLX sc-fPXMVe hmjKFt gWbGHr"
+            disabled={false}
             id="checkbox-1"
             name="checkbox-1"
             onMouseEnter={[Function]}

--- a/src/components/integrated/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
+++ b/src/components/integrated/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
     className="sc-aXZVg sc-gEvEer PqAkw dnJeoC"
   >
     <div
-      className="sc-aXZVg sc-gEvEer sc-ikkxIA bTBOZx ksSdnF fQHFKu"
+      className="sc-aXZVg sc-gEvEer sc-ikkxIA ilPKdM ksSdnF fQHFKu"
       onClick={[Function]}
     >
       <div

--- a/src/components/integrated/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
+++ b/src/components/integrated/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
     className="sc-aXZVg sc-gEvEer PqAkw dnJeoC"
   >
     <div
-      className="sc-aXZVg sc-gEvEer sc-ikkxIA ilPKdM ksSdnF kpNdsI"
+      className="sc-aXZVg sc-gEvEer sc-ikkxIA bTBOZx ksSdnF fQHFKu"
       onClick={[Function]}
     >
       <div

--- a/src/styles/theme/color.ts
+++ b/src/styles/theme/color.ts
@@ -106,6 +106,8 @@ export const oakUiRoleTokens = [
   "bg-decorative5-main",
   "bg-decorative5-subdued",
   "bg-decorative5-very-subdued",
+  "bg-correct",
+  "bg-incorrect",
   "icon-main",
   "icon-inverted",
   "icon-disabled",

--- a/src/styles/theme/default.theme.ts
+++ b/src/styles/theme/default.theme.ts
@@ -40,6 +40,8 @@ export const oakDefaultTheme: OakTheme = {
     "bg-decorative5-main": "lemon",
     "bg-decorative5-subdued": "lemon50",
     "bg-decorative5-very-subdued": "lemon30",
+    "bg-correct": "mint50",
+    "bg-incorrect": "red30",
     "icon-main": "white",
     "icon-inverted": "black",
     "icon-disabled": "grey50",


### PR DESCRIPTION
Implements new designs to visually represent the following states:

![image](https://github.com/oaknational/oak-components/assets/1030540/931d5a0a-e685-4341-9034-135393da4a34)

### to test

look at 

https://deploy-preview-45--lively-meringue-8ebd43.netlify.app/?path=/docs/components-integrated-oakquizcheckbox--docs

- check all states rendered corrrectly

run 

```npm run test```