### PR TITLE
feat(PUPIL-86) Add `OakTextInput`

### DIFF
--- a/src/components/base/InternalTextInput/InternalTextInput.stories.tsx
+++ b/src/components/base/InternalTextInput/InternalTextInput.stories.tsx
@@ -3,30 +3,16 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import { InternalTextInput } from "./InternalTextInput";
 
-/**
- *
- * An unstyled input to be used as a basis for UI input components.
- * The following callbacks are available for tracking focus events:
- *
- *  ### onFocus
- * `(e: FocusEvent<HTMLInputElement>) => void;`
- *  ### onBlur
- * `(e: FocusEvent<HTMLInputElement>) => void;`
- *  ### onInitialFocus
- * `(e: FocusEvent<HTMLInputElement>) => void;`<br>
- *  occurs only when the input is focused for the first time
- *
- */
+import { sizeArgTypes } from "@/storybook-helpers/sizeStyleHelpers";
+import { spacingArgTypes } from "@/storybook-helpers/spacingStyleHelpers";
 
 const meta: Meta<typeof InternalTextInput> = {
   component: InternalTextInput,
   tags: ["autodocs"],
   title: "components/base/InternalTextInput",
-  argTypes: {},
-  parameters: {
-    controls: {
-      include: [],
-    },
+  argTypes: {
+    ...sizeArgTypes,
+    ...spacingArgTypes,
   },
 };
 export default meta;
@@ -37,8 +23,4 @@ export const Default: Story = {
   render: (args) => (
     <InternalTextInput {...args} placeholder="placeholder text" type="text" />
   ),
-  args: {},
-  parameters: {
-    controls: { include: [] },
-  },
 };

--- a/src/components/base/InternalTextInput/InternalTextInput.stories.tsx
+++ b/src/components/base/InternalTextInput/InternalTextInput.stories.tsx
@@ -3,16 +3,14 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import { InternalTextInput } from "./InternalTextInput";
 
-import { sizeArgTypes } from "@/storybook-helpers/sizeStyleHelpers";
-import { spacingArgTypes } from "@/storybook-helpers/spacingStyleHelpers";
-
 const meta: Meta<typeof InternalTextInput> = {
   component: InternalTextInput,
   tags: ["autodocs"],
   title: "components/base/InternalTextInput",
-  argTypes: {
-    ...sizeArgTypes,
-    ...spacingArgTypes,
+  parameters: {
+    controls: {
+      include: [],
+    },
   },
 };
 export default meta;

--- a/src/components/base/InternalTextInput/InternalTextInput.test.tsx
+++ b/src/components/base/InternalTextInput/InternalTextInput.test.tsx
@@ -55,6 +55,20 @@ describe("InternalTextInput", () => {
     expect(onInitialFocus).toHaveBeenCalled();
   });
 
+  it("calls onFocus when onInitialFocus is also defined", () => {
+    const onFocus = jest.fn();
+    const onInitialFocus = jest.fn();
+    const { getByTestId } = render(
+      <InternalTextInput
+        data-testid="test"
+        onFocus={onFocus}
+        onInitialFocus={onInitialFocus}
+      />,
+    );
+    getByTestId("test").focus();
+    expect(onFocus).toHaveBeenCalled();
+  });
+
   it("doesn't call onInitialFocus only when focused for subsequent times", () => {
     const onInitialFocus = jest.fn();
     const { getByTestId } = render(

--- a/src/components/base/InternalTextInput/InternalTextInput.tsx
+++ b/src/components/base/InternalTextInput/InternalTextInput.tsx
@@ -33,6 +33,7 @@ const StyledInput = styled.input`
   font-family: inherit;
   background: transparent;
   outline: none;
+  color: inherit;
 
   @media (max-width: ${getBreakpoint("small")}px) {
     /* iOS zooms in on inputs with font sizes <16px on mobile */
@@ -68,7 +69,7 @@ export type InternalTextInputProps = StyledInputProps & {
  * An unstyled input to be used as a basis for UI input components.
  * Supports all the props of a regular `HTMLInputElement`
  *
- * The CSS `outline` is disabled so a focus ring must be applied by the consuming component.
+ * 🚨 The CSS `outline` is disabled so a focus ring must be applied by the consuming component.
  *
  * The following callbacks are available for tracking focus events:
  *

--- a/src/components/base/InternalTextInput/InternalTextInput.tsx
+++ b/src/components/base/InternalTextInput/InternalTextInput.tsx
@@ -8,11 +8,16 @@ import styled from "styled-components";
 
 import { parseColor } from "@/styles/helpers/parseColor";
 import { getBreakpoint } from "@/styles/utils/responsiveStyle";
+import { SpacingStyleProps, spacingStyle } from "@/styles/utils/spacingStyle";
+import { SizeStyleProps, sizeStyle } from "@/styles/utils/sizeStyle";
 
 type StyledInputProps = Omit<
   DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
   "ref"
->;
+> &
+  SpacingStyleProps &
+  SizeStyleProps;
+
 /**
  * Using `appearance none !important;` here because many style resets will set this
  * value to textfield, causing some browsers to implement undesirable styles.
@@ -26,6 +31,8 @@ const StyledInput = styled.input`
   border-color: transparent;
   box-shadow: none;
   font-family: inherit;
+  background: transparent;
+  outline: none;
 
   @media (max-width: ${getBreakpoint("small")}px) {
     /* iOS zooms in on inputs with font sizes <16px on mobile */
@@ -43,16 +50,39 @@ const StyledInput = styled.input`
   ::-webkit-search-results-decoration {
     appearance: none;
   }
+
+  ${spacingStyle}
+  ${sizeStyle}
 `;
 
 export type InternalTextInputProps = StyledInputProps & {
-  onFocus?: (e: FocusEvent<HTMLInputElement>) => void;
-  onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  /**
+   * Fired only when the input is focused for the first time
+   */
   onInitialFocus?: (e: FocusEvent<HTMLInputElement>) => void;
 };
 
+/**
+ *
+ * An unstyled input to be used as a basis for UI input components.
+ * Supports all the props of a regular `HTMLInputElement`
+ *
+ * The CSS `outline` is disabled so a focus ring must be applied by the consuming component.
+ *
+ * The following callbacks are available for tracking focus events:
+ *
+ *  ### onFocus
+ * `(e: FocusEvent<HTMLInputElement>) => void;`
+ *  ### onBlur
+ * `(e: FocusEvent<HTMLInputElement>) => void;`
+ *  ### onInitialFocus
+ * `(e: FocusEvent<HTMLInputElement>) => void;`<br>
+ *  occurs only when the input is focused for the first time
+ *
+ */
 export const InternalTextInput = (props: InternalTextInputProps) => {
-  const { onInitialFocus, onBlur, onFocus, ...rest } = props;
+  const { onInitialFocus, onFocus, ...rest } = props;
 
   const hadInitialFocused = useRef(false);
 
@@ -65,11 +95,5 @@ export const InternalTextInput = (props: InternalTextInputProps) => {
     }
   };
 
-  const handleOnBlur = (e: FocusEvent<HTMLInputElement>) => {
-    if (props.onBlur) props.onBlur(e);
-  };
-
-  return (
-    <StyledInput {...rest} onFocus={handleOnFocus} onBlur={handleOnBlur} />
-  );
+  return <StyledInput {...rest} onFocus={handleOnFocus} />;
 };

--- a/src/components/base/InternalTextInput/InternalTextInput.tsx
+++ b/src/components/base/InternalTextInput/InternalTextInput.tsx
@@ -56,7 +56,10 @@ const StyledInput = styled.input`
   ${sizeStyle}
 `;
 
-export type InternalTextInputProps = StyledInputProps & {
+export type InternalTextInputProps = Omit<StyledInputProps, "placeholder"> & {
+  /**
+   * A textual hint or example to display before a value has been entered
+   */
   placeholder?: string;
   /**
    * Fired only when the input is focused for the first time

--- a/src/components/base/InternalTextInput/InternalTextInput.tsx
+++ b/src/components/base/InternalTextInput/InternalTextInput.tsx
@@ -91,7 +91,9 @@ export const InternalTextInput = (props: InternalTextInputProps) => {
     if (!hadInitialFocused.current && props.onInitialFocus) {
       props.onInitialFocus(e);
       hadInitialFocused.current = true;
-    } else if (props.onFocus) {
+    }
+
+    if (props.onFocus) {
       props.onFocus(e);
     }
   };

--- a/src/components/base/InternalTextInput/__snapshots__/InternalTextInput.test.tsx.snap
+++ b/src/components/base/InternalTextInput/__snapshots__/InternalTextInput.test.tsx.snap
@@ -2,8 +2,7 @@
 
 exports[`InternalTextInput matches snapshot 1`] = `
 <input
-  className="sc-aXZVg dVeUxO"
-  onBlur={[Function]}
+  className="sc-aXZVg gKrgSR"
   onFocus={[Function]}
 />
 `;

--- a/src/components/ui/OakTextInput/OakTextInput.stories.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.stories.tsx
@@ -48,3 +48,15 @@ export const ReadOnly: Story = {
     <OakTextInput {...args} readOnly value="A fine text value" />
   ),
 };
+
+export const Valid: Story = {
+  render: (args) => (
+    <OakTextInput {...args} validity="valid" value="A fine text value" />
+  ),
+};
+
+export const Invalid: Story = {
+  render: (args) => (
+    <OakTextInput {...args} validity="invalid" value="A fine text value" />
+  ),
+};

--- a/src/components/ui/OakTextInput/OakTextInput.stories.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.stories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakTextInput } from "./OakTextInput";
+
+import { sizeArgTypes } from "@/storybook-helpers/sizeStyleHelpers";
+
+const meta: Meta<typeof OakTextInput> = {
+  component: OakTextInput,
+  tags: ["autodocs"],
+  title: "components/ui/OakTextInput",
+  argTypes: {
+    $width: sizeArgTypes["$width"],
+    $maxWidth: sizeArgTypes["$maxWidth"],
+  },
+  args: {
+    placeholder: "Placeholder text",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof OakTextInput>;
+
+export const Default: Story = {
+  render: (args) => <OakTextInput {...args} />,
+};
+
+export const WithStyling: Story = {
+  render: (args) => <OakTextInput {...args} />,
+  args: {
+    value: "a test value",
+    $background: "aqua",
+    $color: "blue",
+    $borderColor: "blue",
+    $hoverBackground: "aqua110",
+    $focusRingDropShadows: ["drop-shadow-wide-yellow"],
+  },
+};
+
+export const Disabled: Story = {
+  render: (args) => (
+    <OakTextInput {...args} disabled value="A fine text value" />
+  ),
+};
+
+export const ReadOnly: Story = {
+  render: (args) => (
+    <OakTextInput {...args} readOnly value="A fine text value" />
+  ),
+};

--- a/src/components/ui/OakTextInput/OakTextInput.stories.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.stories.tsx
@@ -21,8 +21,8 @@ const meta: Meta<typeof OakTextInput> = {
         "disabled",
         "readOnly",
         "width",
-        "endEnhancerIconName",
-        "startEnhancerIconName",
+        "iconName",
+        "isTrailingIcon",
       ],
     },
   },
@@ -38,23 +38,15 @@ export const Default: Story = {
   render: (args) => <OakTextInput {...args} />,
 };
 
-export const WithStartEnhancer: Story = {
+export const WithIcon: Story = {
   render: (args) => (
-    <OakTextInput
-      {...args}
-      value="A fine text value"
-      startEnhancerIconName="search"
-    />
+    <OakTextInput {...args} value="A fine text value" iconName="search" />
   ),
 };
 
-export const WithEndEnhancer: Story = {
+export const WithTrailingIcon: Story = {
   render: (args) => (
-    <OakTextInput
-      {...args}
-      value="A fine text value"
-      endEnhancerIconName="search"
-    />
+    <OakTextInput {...args} value="A fine text value" iconName="search" />
   ),
 };
 
@@ -86,44 +78,41 @@ export const Invalid: Story = {
   render: () => <OakTextInput validity="invalid" value="A fine text value" />,
 };
 
-export const ValidWithStartEnhancer: Story = {
+export const ValidWithIcon: Story = {
   render: () => (
-    <OakTextInput
-      validity="valid"
-      value="A fine text value"
-      startEnhancerIconName="tick"
-    />
+    <OakTextInput validity="valid" value="A fine text value" iconName="tick" />
   ),
 };
 
-export const InvalidWithEndEnhancer: Story = {
+export const InvalidWithIcon: Story = {
   render: () => (
     <OakTextInput
       validity="invalid"
       value="A fine text value"
-      endEnhancerIconName="cross"
+      iconName="cross"
     />
   ),
 };
 
-export const ReadOnlyValidWithStartEnhancer: Story = {
+export const ReadOnlyValidWithIcon: Story = {
   render: () => (
     <OakTextInput
       validity="valid"
       value="A fine text value"
-      startEnhancerIconName="tick"
+      iconName="tick"
       readOnly
     />
   ),
 };
 
-export const ReadOnlyInvalidWithEndEnhancer: Story = {
+export const ReadOnlyInvalidTrailingIcon: Story = {
   render: (args) => (
     <OakTextInput
       {...args}
       validity="invalid"
       value="A fine text value"
-      endEnhancerIconName="cross"
+      iconName="cross"
+      isTrailingIcon
       readOnly
     />
   ),

--- a/src/components/ui/OakTextInput/OakTextInput.stories.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.stories.tsx
@@ -10,8 +10,8 @@ const meta: Meta<typeof OakTextInput> = {
   tags: ["autodocs"],
   title: "components/ui/OakTextInput",
   argTypes: {
-    $width: sizeArgTypes["$width"],
-    $maxWidth: sizeArgTypes["$maxWidth"],
+    width: sizeArgTypes["$width"],
+    maxWidth: sizeArgTypes["$maxWidth"],
   },
   args: {
     placeholder: "Placeholder text",
@@ -49,11 +49,11 @@ export const WithStyling: Story = {
   render: (args) => <OakTextInput {...args} />,
   args: {
     value: "a test value",
-    $background: "aqua",
-    $color: "blue",
-    $borderColor: "blue",
-    $hoverBackground: "aqua110",
-    $focusRingDropShadows: ["drop-shadow-wide-yellow"],
+    background: "aqua",
+    color: "blue",
+    borderColor: "blue",
+    hoverBackground: "aqua110",
+    focusRingDropShadows: ["drop-shadow-wide-yellow"],
   },
 };
 

--- a/src/components/ui/OakTextInput/OakTextInput.stories.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.stories.tsx
@@ -11,7 +11,20 @@ const meta: Meta<typeof OakTextInput> = {
   title: "components/ui/OakTextInput",
   argTypes: {
     width: sizeArgTypes["$width"],
-    maxWidth: sizeArgTypes["$maxWidth"],
+  },
+  parameters: {
+    controls: {
+      include: [
+        "placeholder",
+        "value",
+        "validity",
+        "disabled",
+        "readOnly",
+        "width",
+        "endEnhancerIconName",
+        "startEnhancerIconName",
+      ],
+    },
   },
   args: {
     placeholder: "Placeholder text",

--- a/src/components/ui/OakTextInput/OakTextInput.stories.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.stories.tsx
@@ -25,6 +25,26 @@ export const Default: Story = {
   render: (args) => <OakTextInput {...args} />,
 };
 
+export const WithStartEnhancer: Story = {
+  render: (args) => (
+    <OakTextInput
+      {...args}
+      value="A fine text value"
+      startEnhancerIconName="search"
+    />
+  ),
+};
+
+export const WithEndEnhancer: Story = {
+  render: (args) => (
+    <OakTextInput
+      {...args}
+      value="A fine text value"
+      endEnhancerIconName="search"
+    />
+  ),
+};
+
 export const WithStyling: Story = {
   render: (args) => <OakTextInput {...args} />,
   args: {
@@ -58,5 +78,27 @@ export const Valid: Story = {
 export const Invalid: Story = {
   render: (args) => (
     <OakTextInput {...args} validity="invalid" value="A fine text value" />
+  ),
+};
+
+export const ValidWithStartEnhancer: Story = {
+  render: (args) => (
+    <OakTextInput
+      {...args}
+      validity="valid"
+      value="A fine text value"
+      startEnhancerIconName="tick"
+    />
+  ),
+};
+
+export const InvalidWithEndEnhancer: Story = {
+  render: (args) => (
+    <OakTextInput
+      {...args}
+      validity="invalid"
+      value="A fine text value"
+      endEnhancerIconName="cross"
+    />
   ),
 };

--- a/src/components/ui/OakTextInput/OakTextInput.stories.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.stories.tsx
@@ -58,33 +58,24 @@ export const WithStyling: Story = {
 };
 
 export const Disabled: Story = {
-  render: (args) => (
-    <OakTextInput {...args} disabled value="A fine text value" />
-  ),
+  render: () => <OakTextInput disabled value="A fine text value" />,
 };
 
 export const ReadOnly: Story = {
-  render: (args) => (
-    <OakTextInput {...args} readOnly value="A fine text value" />
-  ),
+  render: () => <OakTextInput readOnly value="A fine text value" />,
 };
 
 export const Valid: Story = {
-  render: (args) => (
-    <OakTextInput {...args} validity="valid" value="A fine text value" />
-  ),
+  render: () => <OakTextInput validity="valid" value="A fine text value" />,
 };
 
 export const Invalid: Story = {
-  render: (args) => (
-    <OakTextInput {...args} validity="invalid" value="A fine text value" />
-  ),
+  render: () => <OakTextInput validity="invalid" value="A fine text value" />,
 };
 
 export const ValidWithStartEnhancer: Story = {
-  render: (args) => (
+  render: () => (
     <OakTextInput
-      {...args}
       validity="valid"
       value="A fine text value"
       startEnhancerIconName="tick"
@@ -93,12 +84,34 @@ export const ValidWithStartEnhancer: Story = {
 };
 
 export const InvalidWithEndEnhancer: Story = {
+  render: () => (
+    <OakTextInput
+      validity="invalid"
+      value="A fine text value"
+      endEnhancerIconName="cross"
+    />
+  ),
+};
+
+export const ReadOnlyValidWithStartEnhancer: Story = {
+  render: () => (
+    <OakTextInput
+      validity="valid"
+      value="A fine text value"
+      startEnhancerIconName="tick"
+      readOnly
+    />
+  ),
+};
+
+export const ReadOnlyInvalidWithEndEnhancer: Story = {
   render: (args) => (
     <OakTextInput
       {...args}
       validity="invalid"
       value="A fine text value"
       endEnhancerIconName="cross"
+      readOnly
     />
   ),
 };

--- a/src/components/ui/OakTextInput/OakTextInput.test.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+import { ThemeProvider } from "styled-components";
+
+import { OakTextInput } from "./OakTextInput";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { oakDefaultTheme } from "@/styles";
+
+describe("OakTextInput", () => {
+  it("renders", () => {
+    const { getByTestId } = renderWithTheme(
+      <OakTextInput
+        defaultValue="A nice text value"
+        data-testid="text-input"
+      />,
+    );
+
+    expect(getByTestId("text-input")).toBeInTheDocument();
+  });
+
+  it("matches snapshot", () => {
+    const tree = create(
+      <ThemeProvider theme={oakDefaultTheme}>
+        <OakTextInput defaultValue="A nice text value" />,
+      </ThemeProvider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -22,53 +22,57 @@ type StyledTextInputWrapperProps = {
   $readOnlyColor: OakCombinedColorToken;
 };
 
-export type OakTextInputProps = Pick<
-  InternalTextInputProps,
-  "$width" | "$maxWidth" | "onInitialFocus"
-> &
-  Partial<StyledTextInputWrapperProps> & {
-    id?: string;
-    type?: "text" | "password" | "number" | "email" | "tel";
-    /**
-     * Disables user input and updates the appearance accordingly.
-     */
-    disabled?: boolean;
-    /**
-     * Makes the input read-only. Preventing the user from changing the value.
-     */
-    readOnly?: boolean;
-    /**
-     * Sets the value. Use this in controlled components;
-     */
-    value?: string;
-    /**
-     * Sets the initial value. Use this for an uncontrolled component;
-     */
-    defaultValue?: string;
-    /**
-     * Used to target the input element in tests.
-     */
-    "data-testid"?: string;
-    placeholder?: string;
-    onChange?: ChangeEventHandler<HTMLInputElement>;
-    /**
-     * Alters the appearance of the input field to indicate whether the input is valid or invalid.
-     */
-    validity?: "valid" | "invalid";
-    $iconColor?: OakCombinedColorToken;
-    $validBorderColor?: OakCombinedColorToken;
-    $invalidBorderColor?: OakCombinedColorToken;
-    $validIconColor?: OakCombinedColorToken;
-    $invalidIconColor?: OakCombinedColorToken;
-    startEnhancerIconName?: OakIconName;
-    endEnhancerIconName?: OakIconName;
-  };
+export type OakTextInputProps = {
+  id?: string;
+  type?: "text" | "password" | "number" | "email" | "tel";
+  /**
+   * Disables user input and updates the appearance accordingly.
+   */
+  disabled?: boolean;
+  /**
+   * Makes the input read-only. Preventing the user from changing the value.
+   */
+  readOnly?: boolean;
+  /**
+   * Sets the value. Use this in controlled components;
+   */
+  value?: string;
+  /**
+   * Sets the initial value. Use this for an uncontrolled component;
+   */
+  defaultValue?: string;
+  /**
+   * Used to target the input element in tests.
+   */
+  "data-testid"?: string;
+  placeholder?: string;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  /**
+   * Alters the appearance of the input field to indicate whether the input is valid or invalid.
+   */
+  validity?: "valid" | "invalid";
+  /**
+   * Displays an icon at the start of the input.
+   */
+  startEnhancerIconName?: OakIconName;
+  /**
+   * Displays an icon at the end of the input.
+   */
+  endEnhancerIconName?: OakIconName;
+  $iconColor?: OakCombinedColorToken;
+  $validBorderColor?: OakCombinedColorToken;
+  $invalidBorderColor?: OakCombinedColorToken;
+  $validIconColor?: OakCombinedColorToken;
+  $invalidIconColor?: OakCombinedColorToken;
+} & Partial<StyledTextInputWrapperProps> &
+  Pick<InternalTextInputProps, "$width" | "$maxWidth" | "onInitialFocus">;
 
 const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
-  cursor: default;
+  &:hover {
+    cursor: text;
+  }
 
   &:focus-within:not(:has(input:disabled, input:read-only)) {
-    cursor: text;
     box-shadow: ${(props) =>
       props.$focusRingDropShadows
         .map((dropShadow) => parseDropShadow(dropShadow))
@@ -79,7 +83,6 @@ const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
 
   @media (hover: hover) {
     &:hover:not(:focus-within, :has(input:read-only)) {
-      cursor: text;
       background: ${(props) => parseColor(props.$hoverBackground)};
     }
   }
@@ -163,7 +166,7 @@ export const OakTextInput = ({
       $alignItems="center"
       $position="relative"
       $gap="space-between-s"
-      $ph="inner-padding-s"
+      $ph="inner-padding-l"
       onClick={(event) => {
         event.currentTarget.querySelector("input")?.focus();
       }}

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -84,7 +84,7 @@ const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
     cursor: text;
   }
 
-  &:focus-within:not(:has(input:disabled, input:read-only)) {
+  &:focus-within {
     box-shadow: ${(props) =>
       props.$focusRingDropShadows
         .map((dropShadow) => parseDropShadow(dropShadow))
@@ -94,7 +94,7 @@ const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
   background: ${(props) => parseColor(props.$background)};
 
   @media (hover: hover) {
-    &:hover:not(:focus-within, :has(input:read-only)) {
+    &:hover:not(:focus-within) {
       background: ${(props) => parseColor(props.$hoverBackground)};
     }
   }

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -51,6 +51,9 @@ export type OakTextInputProps = Pick<
     "data-testid"?: string;
     placeholder?: string;
     onChange?: ChangeEventHandler<HTMLInputElement>;
+    validity?: "valid" | "invalid";
+    $validBorderColor?: OakCombinedColorToken;
+    $invalidBorderColor?: OakCombinedColorToken;
   };
 
 const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
@@ -97,8 +100,25 @@ export const OakTextInput = ({
   $color = "text-primary",
   $disabledColor = "text-disabled",
   $readOnlyColor = "text-subdued",
+  validity,
+  $validBorderColor = "border-success",
+  $invalidBorderColor = "border-error",
   ...props
 }: OakTextInputProps) => {
+  let borderColor: OakCombinedColorToken;
+
+  switch (validity) {
+    case "valid":
+      borderColor = $validBorderColor;
+      break;
+    case "invalid":
+      borderColor = $invalidBorderColor;
+      break;
+    default:
+      borderColor = $borderColor;
+      break;
+  }
+
   return (
     <StyledTextInputWrapper
       $width="fit-content"
@@ -106,7 +126,7 @@ export const OakTextInput = ({
       $borderStyle="solid"
       $borderRadius="border-radius-s"
       $ba="border-solid-m"
-      $borderColor={$borderColor}
+      $borderColor={borderColor}
       $focusRingDropShadows={$focusRingDropShadows}
       $background={$background}
       $hoverBackground={$hoverBackground}

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -124,19 +124,23 @@ export const OakTextInput = ({
 }: OakTextInputProps) => {
   let borderColor: OakCombinedColorToken;
   let iconColor: OakCombinedColorToken;
+  let readOnlyBorderColor: OakCombinedColorToken;
 
   switch (validity) {
     case "valid":
       borderColor = $validBorderColor;
       iconColor = $validIconColor;
+      readOnlyBorderColor = $validBorderColor;
       break;
     case "invalid":
       borderColor = $invalidBorderColor;
       iconColor = $invalidIconColor;
+      readOnlyBorderColor = $invalidBorderColor;
       break;
     default:
       borderColor = $borderColor;
       iconColor = $iconColor;
+      readOnlyBorderColor = $readOnlyBorderColor;
       break;
   }
 
@@ -152,7 +156,7 @@ export const OakTextInput = ({
       $background={$background}
       $hoverBackground={$hoverBackground}
       $disabledBackgroundColor={$disabledBackgroundColor}
-      $readOnlyBorderColor={$readOnlyBorderColor}
+      $readOnlyBorderColor={readOnlyBorderColor}
       $disabledColor={$disabledColor}
       $readOnlyColor={$readOnlyColor}
       $color={$color}

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -52,13 +52,15 @@ export type OakTextInputProps = {
    */
   validity?: "valid" | "invalid";
   /**
-   * Displays an icon at the start of the input.
+   * Adds an icon to the input
+   *
+   * Defaults to the start of the input
    */
-  startEnhancerIconName?: OakIconName;
+  iconName?: OakIconName;
   /**
-   * Displays an icon at the end of the input.
+   * Position the icon at the end of the input
    */
-  endEnhancerIconName?: OakIconName;
+  isTrailingIcon?: boolean;
   iconColor?: OakCombinedColorToken;
   validBorderColor?: OakCombinedColorToken;
   invalidBorderColor?: OakCombinedColorToken;
@@ -131,8 +133,8 @@ export const OakTextInput = ({
   invalidBorderColor = "border-error",
   validIconColor = "icon-success",
   invalidIconColor = "border-error",
-  startEnhancerIconName,
-  endEnhancerIconName,
+  iconName,
+  isTrailingIcon = false,
   width,
   maxWidth,
   ...props
@@ -183,9 +185,9 @@ export const OakTextInput = ({
         event.currentTarget.querySelector("input")?.focus();
       }}
     >
-      {startEnhancerIconName && (
+      {!isTrailingIcon && iconName && (
         <OakIcon
-          iconName={startEnhancerIconName}
+          iconName={iconName}
           $colorFilter={finalIconColor}
           $pointerEvents="none"
         />
@@ -198,9 +200,9 @@ export const OakTextInput = ({
         $pv="inner-padding-l"
         $height="all-spacing-12"
       />
-      {endEnhancerIconName && (
+      {isTrailingIcon && iconName && (
         <OakIcon
-          iconName={endEnhancerIconName}
+          iconName={iconName}
           $colorFilter={finalIconColor}
           $pointerEvents="none"
         />

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -9,6 +9,7 @@ import {
 import { OakFlex, OakIcon, OakIconName } from "@/components/base";
 import { OakCombinedColorToken, OakDropShadowToken } from "@/styles";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
+import { SizeStyleProps } from "@/styles/utils/sizeStyle";
 
 type StyledTextInputWrapperProps = {
   $color: OakCombinedColorToken;
@@ -45,7 +46,6 @@ export type OakTextInputProps = {
    * Used to target the input element in tests.
    */
   "data-testid"?: string;
-  placeholder?: string;
   onChange?: ChangeEventHandler<HTMLInputElement>;
   /**
    * Alters the appearance of the input field to indicate whether the input is valid or invalid.
@@ -59,13 +59,23 @@ export type OakTextInputProps = {
    * Displays an icon at the end of the input.
    */
   endEnhancerIconName?: OakIconName;
-  $iconColor?: OakCombinedColorToken;
-  $validBorderColor?: OakCombinedColorToken;
-  $invalidBorderColor?: OakCombinedColorToken;
-  $validIconColor?: OakCombinedColorToken;
-  $invalidIconColor?: OakCombinedColorToken;
-} & Partial<StyledTextInputWrapperProps> &
-  Pick<InternalTextInputProps, "$width" | "$maxWidth" | "onInitialFocus">;
+  iconColor?: OakCombinedColorToken;
+  validBorderColor?: OakCombinedColorToken;
+  invalidBorderColor?: OakCombinedColorToken;
+  validIconColor?: OakCombinedColorToken;
+  invalidIconColor?: OakCombinedColorToken;
+  color?: OakCombinedColorToken;
+  hoverBackground?: OakCombinedColorToken;
+  background?: OakCombinedColorToken;
+  borderColor?: OakCombinedColorToken;
+  focusRingDropShadows?: OakDropShadowToken[];
+  disabledBackgroundColor?: OakCombinedColorToken;
+  readOnlyBorderColor?: OakCombinedColorToken;
+  disabledColor?: OakCombinedColorToken;
+  readOnlyColor?: OakCombinedColorToken;
+  width?: SizeStyleProps["$width"];
+  maxWidth?: SizeStyleProps["$maxWidth"];
+} & Pick<InternalTextInputProps, "onInitialFocus" | "placeholder">;
 
 const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
   &:hover {
@@ -103,47 +113,49 @@ const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
  */
 export const OakTextInput = ({
   type = "text",
-  $borderColor = "border-primary",
-  $readOnlyBorderColor = "border-neutral",
-  $focusRingDropShadows = [
+  borderColor = "border-primary",
+  readOnlyBorderColor = "border-neutral",
+  focusRingDropShadows = [
     "drop-shadow-centered-yellow",
     "drop-shadow-centered-grey",
   ],
-  $background = "bg-primary",
-  $hoverBackground = "bg-neutral",
-  $disabledBackgroundColor = "bg-neutral",
-  $color = "text-primary",
-  $disabledColor = "text-disabled",
-  $readOnlyColor = "text-subdued",
+  background = "bg-primary",
+  hoverBackground = "bg-neutral",
+  disabledBackgroundColor = "bg-neutral",
+  color = "text-primary",
+  disabledColor = "text-disabled",
+  readOnlyColor = "text-subdued",
   validity,
-  $iconColor = "icon-inverted",
-  $validBorderColor = "border-success",
-  $invalidBorderColor = "border-error",
-  $validIconColor = "icon-success",
-  $invalidIconColor = "border-error",
+  iconColor = "icon-inverted",
+  validBorderColor = "border-success",
+  invalidBorderColor = "border-error",
+  validIconColor = "icon-success",
+  invalidIconColor = "border-error",
   startEnhancerIconName,
   endEnhancerIconName,
+  width,
+  maxWidth,
   ...props
 }: OakTextInputProps) => {
-  let borderColor: OakCombinedColorToken;
-  let iconColor: OakCombinedColorToken;
-  let readOnlyBorderColor: OakCombinedColorToken;
+  let finalBorderColor: OakCombinedColorToken;
+  let finalIconColor: OakCombinedColorToken;
+  let finalReadOnlyBorderColor: OakCombinedColorToken;
 
   switch (validity) {
     case "valid":
-      borderColor = $validBorderColor;
-      iconColor = $validIconColor;
-      readOnlyBorderColor = $validBorderColor;
+      finalBorderColor = validBorderColor;
+      finalIconColor = validIconColor;
+      finalReadOnlyBorderColor = validBorderColor;
       break;
     case "invalid":
-      borderColor = $invalidBorderColor;
-      iconColor = $invalidIconColor;
-      readOnlyBorderColor = $invalidBorderColor;
+      finalBorderColor = invalidBorderColor;
+      finalIconColor = invalidIconColor;
+      finalReadOnlyBorderColor = invalidBorderColor;
       break;
     default:
-      borderColor = $borderColor;
-      iconColor = $iconColor;
-      readOnlyBorderColor = $readOnlyBorderColor;
+      finalBorderColor = borderColor;
+      finalIconColor = iconColor;
+      finalReadOnlyBorderColor = readOnlyBorderColor;
       break;
   }
 
@@ -154,15 +166,15 @@ export const OakTextInput = ({
       $borderStyle="solid"
       $borderRadius="border-radius-s"
       $ba="border-solid-m"
-      $borderColor={borderColor}
-      $focusRingDropShadows={$focusRingDropShadows}
-      $background={$background}
-      $hoverBackground={$hoverBackground}
-      $disabledBackgroundColor={$disabledBackgroundColor}
-      $readOnlyBorderColor={readOnlyBorderColor}
-      $disabledColor={$disabledColor}
-      $readOnlyColor={$readOnlyColor}
-      $color={$color}
+      $borderColor={finalBorderColor}
+      $focusRingDropShadows={focusRingDropShadows}
+      $background={background}
+      $hoverBackground={hoverBackground}
+      $disabledBackgroundColor={disabledBackgroundColor}
+      $readOnlyBorderColor={finalReadOnlyBorderColor}
+      $disabledColor={disabledColor}
+      $readOnlyColor={readOnlyColor}
+      $color={color}
       $alignItems="center"
       $position="relative"
       $gap="space-between-s"
@@ -174,20 +186,22 @@ export const OakTextInput = ({
       {startEnhancerIconName && (
         <OakIcon
           iconName={startEnhancerIconName}
-          $colorFilter={iconColor}
+          $colorFilter={finalIconColor}
           $pointerEvents="none"
         />
       )}
       <InternalTextInput
         type={type}
         {...props}
+        $width={width}
+        $maxWidth={maxWidth}
         $pv="inner-padding-l"
         $height="all-spacing-12"
       />
       {endEnhancerIconName && (
         <OakIcon
           iconName={endEnhancerIconName}
-          $colorFilter={iconColor}
+          $colorFilter={finalIconColor}
           $pointerEvents="none"
         />
       )}

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -6,7 +6,7 @@ import {
   InternalTextInput,
   InternalTextInputProps,
 } from "@/components/base/InternalTextInput";
-import { OakFlex } from "@/components/base";
+import { OakFlex, OakIcon, OakIconName } from "@/components/base";
 import { OakCombinedColorToken, OakDropShadowToken } from "@/styles";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 
@@ -30,11 +30,11 @@ export type OakTextInputProps = Pick<
     id?: string;
     type?: "text" | "password" | "number" | "email" | "tel";
     /**
-     * Disables input updating the appearance accordingly.
+     * Disables user input and updates the appearance accordingly.
      */
     disabled?: boolean;
     /**
-     * Marks the input as read-only. Preventing the user from changing the value.
+     * Makes the input read-only. Preventing the user from changing the value.
      */
     readOnly?: boolean;
     /**
@@ -51,13 +51,24 @@ export type OakTextInputProps = Pick<
     "data-testid"?: string;
     placeholder?: string;
     onChange?: ChangeEventHandler<HTMLInputElement>;
+    /**
+     * Alters the appearance of the input field to indicate whether the input is valid or invalid.
+     */
     validity?: "valid" | "invalid";
+    $iconColor?: OakCombinedColorToken;
     $validBorderColor?: OakCombinedColorToken;
     $invalidBorderColor?: OakCombinedColorToken;
+    $validIconColor?: OakCombinedColorToken;
+    $invalidIconColor?: OakCombinedColorToken;
+    startEnhancerIconName?: OakIconName;
+    endEnhancerIconName?: OakIconName;
   };
 
 const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
-  &:focus-within:not(:has(:disabled, :read-only)) {
+  cursor: default;
+
+  &:focus-within:not(:has(input:disabled, input:read-only)) {
+    cursor: text;
     box-shadow: ${(props) =>
       props.$focusRingDropShadows
         .map((dropShadow) => parseDropShadow(dropShadow))
@@ -67,17 +78,18 @@ const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
   background: ${(props) => parseColor(props.$background)};
 
   @media (hover: hover) {
-    &:hover:not(:focus-within, :has(:read-only)) {
+    &:hover:not(:focus-within, :has(input:read-only)) {
+      cursor: text;
       background: ${(props) => parseColor(props.$hoverBackground)};
     }
   }
 
-  &:has(:read-only) {
+  &:has(input:read-only) {
     border-color: ${(props) => parseColor(props.$readOnlyBorderColor)};
     color: ${(props) => parseColor(props.$readOnlyColor)};
   }
 
-  &:has(:disabled) {
+  &:has(input:disabled) {
     background: ${(props) => parseColor(props.$disabledBackgroundColor)};
     color: ${(props) => parseColor(props.$disabledColor)};
   }
@@ -101,21 +113,30 @@ export const OakTextInput = ({
   $disabledColor = "text-disabled",
   $readOnlyColor = "text-subdued",
   validity,
+  $iconColor = "icon-inverted",
   $validBorderColor = "border-success",
   $invalidBorderColor = "border-error",
+  $validIconColor = "icon-success",
+  $invalidIconColor = "border-error",
+  startEnhancerIconName,
+  endEnhancerIconName,
   ...props
 }: OakTextInputProps) => {
   let borderColor: OakCombinedColorToken;
+  let iconColor: OakCombinedColorToken;
 
   switch (validity) {
     case "valid":
       borderColor = $validBorderColor;
+      iconColor = $validIconColor;
       break;
     case "invalid":
       borderColor = $invalidBorderColor;
+      iconColor = $invalidIconColor;
       break;
     default:
       borderColor = $borderColor;
+      iconColor = $iconColor;
       break;
   }
 
@@ -135,13 +156,34 @@ export const OakTextInput = ({
       $disabledColor={$disabledColor}
       $readOnlyColor={$readOnlyColor}
       $color={$color}
+      $alignItems="center"
+      $position="relative"
+      $gap="space-between-s"
+      $ph="inner-padding-s"
+      onClick={(event) => {
+        event.currentTarget.querySelector("input")?.focus();
+      }}
     >
+      {startEnhancerIconName && (
+        <OakIcon
+          iconName={startEnhancerIconName}
+          $colorFilter={iconColor}
+          $pointerEvents="none"
+        />
+      )}
       <InternalTextInput
         type={type}
         {...props}
-        $pa="inner-padding-l"
+        $pv="inner-padding-l"
         $height="all-spacing-12"
       />
+      {endEnhancerIconName && (
+        <OakIcon
+          iconName={endEnhancerIconName}
+          $colorFilter={iconColor}
+          $pointerEvents="none"
+        />
+      )}
     </StyledTextInputWrapper>
   );
 };

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEventHandler } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { parseColor } from "@/styles/helpers/parseColor";
 import {
@@ -21,6 +21,8 @@ type StyledTextInputWrapperProps = {
   $readOnlyBorderColor: OakCombinedColorToken;
   $disabledColor: OakCombinedColorToken;
   $readOnlyColor: OakCombinedColorToken;
+  $disabled: boolean;
+  $readOnly: boolean;
 };
 
 export type OakTextInputProps = {
@@ -99,15 +101,19 @@ const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
     }
   }
 
-  &:has(input:read-only) {
-    border-color: ${(props) => parseColor(props.$readOnlyBorderColor)};
-    color: ${(props) => parseColor(props.$readOnlyColor)};
-  }
+  ${(props) =>
+    props.$readOnly &&
+    css`
+      border-color: ${parseColor(props.$readOnlyBorderColor)};
+      color: ${parseColor(props.$readOnlyColor)};
+    `}
 
-  &:has(input:disabled) {
-    background: ${(props) => parseColor(props.$disabledBackgroundColor)};
-    color: ${(props) => parseColor(props.$disabledColor)};
-  }
+  ${(props) =>
+    props.$disabled &&
+    css`
+      background: ${parseColor(props.$disabledBackgroundColor)};
+      color: ${parseColor(props.$disabledColor)};
+    `}
 `;
 
 /**
@@ -181,6 +187,8 @@ export const OakTextInput = ({
       $position="relative"
       $gap="space-between-s"
       $ph="inner-padding-l"
+      $disabled={!!props.disabled}
+      $readOnly={!!props.readOnly}
       onClick={(event) => {
         event.currentTarget.querySelector("input")?.focus();
       }}

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -1,0 +1,127 @@
+import React, { ChangeEventHandler } from "react";
+import styled from "styled-components";
+
+import { parseColor } from "@/styles/helpers/parseColor";
+import {
+  InternalTextInput,
+  InternalTextInputProps,
+} from "@/components/base/InternalTextInput";
+import { OakFlex } from "@/components/base";
+import { OakCombinedColorToken, OakDropShadowToken } from "@/styles";
+import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
+
+type StyledTextInputWrapperProps = {
+  $color: OakCombinedColorToken;
+  $hoverBackground: OakCombinedColorToken;
+  $background: OakCombinedColorToken;
+  $borderColor: OakCombinedColorToken;
+  $focusRingDropShadows: OakDropShadowToken[];
+  $disabledBackgroundColor: OakCombinedColorToken;
+  $readOnlyBorderColor: OakCombinedColorToken;
+  $disabledColor: OakCombinedColorToken;
+  $readOnlyColor: OakCombinedColorToken;
+};
+
+export type OakTextInputProps = Pick<
+  InternalTextInputProps,
+  "$width" | "$maxWidth" | "onInitialFocus"
+> &
+  Partial<StyledTextInputWrapperProps> & {
+    id?: string;
+    type?: "text" | "password" | "number" | "email" | "tel";
+    /**
+     * Disables input updating the appearance accordingly.
+     */
+    disabled?: boolean;
+    /**
+     * Marks the input as read-only. Preventing the user from changing the value.
+     */
+    readOnly?: boolean;
+    /**
+     * Sets the value. Use this in controlled components;
+     */
+    value?: string;
+    /**
+     * Sets the initial value. Use this for an uncontrolled component;
+     */
+    defaultValue?: string;
+    /**
+     * Used to target the input element in tests.
+     */
+    "data-testid"?: string;
+    placeholder?: string;
+    onChange?: ChangeEventHandler<HTMLInputElement>;
+  };
+
+const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
+  &:focus-within:not(:has(:disabled, :read-only)) {
+    box-shadow: ${(props) =>
+      props.$focusRingDropShadows
+        .map((dropShadow) => parseDropShadow(dropShadow))
+        .join(",")};
+  }
+
+  background: ${(props) => parseColor(props.$background)};
+
+  @media (hover: hover) {
+    &:hover:not(:focus-within, :has(:read-only)) {
+      background: ${(props) => parseColor(props.$hoverBackground)};
+    }
+  }
+
+  &:has(:read-only) {
+    border-color: ${(props) => parseColor(props.$readOnlyBorderColor)};
+    color: ${(props) => parseColor(props.$readOnlyColor)};
+  }
+
+  &:has(:disabled) {
+    background: ${(props) => parseColor(props.$disabledBackgroundColor)};
+    color: ${(props) => parseColor(props.$disabledColor)};
+  }
+`;
+
+/**
+ * Default input which can be extended to create specialised inputs.
+ */
+export const OakTextInput = ({
+  type = "text",
+  $borderColor = "border-primary",
+  $readOnlyBorderColor = "border-neutral",
+  $focusRingDropShadows = [
+    "drop-shadow-centered-yellow",
+    "drop-shadow-centered-grey",
+  ],
+  $background = "bg-primary",
+  $hoverBackground = "bg-neutral",
+  $disabledBackgroundColor = "bg-neutral",
+  $color = "text-primary",
+  $disabledColor = "text-disabled",
+  $readOnlyColor = "text-subdued",
+  ...props
+}: OakTextInputProps) => {
+  return (
+    <StyledTextInputWrapper
+      $width="fit-content"
+      $height="fit-content"
+      $borderStyle="solid"
+      $borderRadius="border-radius-s"
+      $ba="border-solid-m"
+      $borderColor={$borderColor}
+      $focusRingDropShadows={$focusRingDropShadows}
+      $background={$background}
+      $hoverBackground={$hoverBackground}
+      $disabledBackgroundColor={$disabledBackgroundColor}
+      $readOnlyBorderColor={$readOnlyBorderColor}
+      $disabledColor={$disabledColor}
+      $readOnlyColor={$readOnlyColor}
+      $color={$color}
+    >
+      <InternalTextInput
+        type={type}
+        {...props}
+        $pa="inner-padding-l"
+        $height="all-spacing-12"
+      />
+    </StyledTextInputWrapper>
+  );
+};

--- a/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`OakTextInput matches snapshot 1`] = `
 [
   <div
-    className="sc-gEvEer sc-eqUAAy sc-cwHptR jLJXtS fLZnXM jWXwGR"
+    className="sc-gEvEer sc-eqUAAy sc-cwHptR gOIKET kUreFU hbQnUv"
+    onClick={[Function]}
   >
     <input
-      className="sc-aXZVg cWXowl"
+      className="sc-aXZVg llBHGf"
       defaultValue="A nice text value"
       onFocus={[Function]}
       type="text"

--- a/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakTextInput matches snapshot 1`] = `
+[
+  <div
+    className="sc-gEvEer sc-eqUAAy sc-cwHptR jLJXtS fLZnXM jWXwGR"
+  >
+    <input
+      className="sc-aXZVg cWXowl"
+      defaultValue="A nice text value"
+      onFocus={[Function]}
+      type="text"
+    />
+  </div>,
+  ",",
+]
+`;

--- a/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakTextInput matches snapshot 1`] = `
 [
   <div
-    className="sc-gEvEer sc-eqUAAy sc-cwHptR eJgbvX kUreFU euoYjd"
+    className="sc-gEvEer sc-eqUAAy sc-cwHptR eJgbvX kUreFU cxqUUM"
     onClick={[Function]}
   >
     <input

--- a/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakTextInput matches snapshot 1`] = `
 [
   <div
-    className="sc-gEvEer sc-eqUAAy sc-cwHptR gOIKET kUreFU hbQnUv"
+    className="sc-gEvEer sc-eqUAAy sc-cwHptR eJgbvX kUreFU euoYjd"
     onClick={[Function]}
   >
     <input

--- a/src/components/ui/OakTextInput/index.ts
+++ b/src/components/ui/OakTextInput/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakTextInput";

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -5,3 +5,4 @@ export * from "./OakSecondaryButton";
 export * from "./OakRadioButton";
 export * from "./OakRadioGroup";
 export * from "./OakCheckBox";
+export * from "./OakTextInput";


### PR DESCRIPTION
Adds `OakTextInput` which will be used initially to enable free text input for quizzes 

## TODO
- [ ] Update the corresponding search, tick and cross icons 

## Links

Figma 👉🏼  https://www.figma.com/file/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?type=design&node-id=3854-11120&mode=dev

To review in Storybook 👉🏼 https://deploy-preview-47--lively-meringue-8ebd43.netlify.app/?path=/docs/components-ui-oaktextinput--docs

## A/C

- [x] Focus state
- [x] Disabled state
- [x] Read only state
- [x] Valid
- [x] Invalid
- [x] Start and end enhancer icons