### PR TITLE
feat(PUPIL-214) `OakQuizInput` component

### DIFF
--- a/src/components/base/InternalTextInput/InternalTextInput.tsx
+++ b/src/components/base/InternalTextInput/InternalTextInput.tsx
@@ -52,6 +52,10 @@ const StyledInput = styled.input`
     appearance: none;
   }
 
+  :disabled {
+    cursor: not-allowed;
+  }
+
   ${spacingStyle}
   ${sizeStyle}
 `;

--- a/src/components/base/InternalTextInput/__snapshots__/InternalTextInput.test.tsx.snap
+++ b/src/components/base/InternalTextInput/__snapshots__/InternalTextInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InternalTextInput matches snapshot 1`] = `
 <input
-  className="sc-aXZVg gKrgSR"
+  className="sc-aXZVg bTMTZW"
   onFocus={[Function]}
 />
 `;

--- a/src/components/integrated/OakQuizTextInput/OakQuizTextInput.stories.tsx
+++ b/src/components/integrated/OakQuizTextInput/OakQuizTextInput.stories.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakQuizTextInput } from "./OakQuizTextInput";
+
+import { sizeArgTypes } from "@/storybook-helpers/sizeStyleHelpers";
+
+const meta: Meta<typeof OakQuizTextInput> = {
+  component: OakQuizTextInput,
+  tags: ["autodocs"],
+  title: "components/integrated/OakQuizTextInput",
+  argTypes: {
+    width: sizeArgTypes["$width"],
+  },
+  parameters: {
+    controls: {
+      include: ["feedback", "width", "disabled"],
+    },
+  },
+  args: {
+    placeholder: "Placeholder text",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof OakQuizTextInput>;
+
+export const Default: Story = {
+  render: (args) => <OakQuizTextInput {...args} />,
+};
+
+export const WithCorrectFeedback: Story = {
+  render: () => (
+    <OakQuizTextInput value="A correct answer" feedback="correct" />
+  ),
+};
+
+export const WithIncorrectFeedback: Story = {
+  render: () => (
+    <OakQuizTextInput value="An incorrect answer" feedback="incorrect" />
+  ),
+};

--- a/src/components/integrated/OakQuizTextInput/OakQuizTextInput.test.tsx
+++ b/src/components/integrated/OakQuizTextInput/OakQuizTextInput.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+import { ThemeProvider } from "styled-components";
+
+import { OakQuizTextInput } from "./OakQuizTextInput";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { oakDefaultTheme } from "@/styles";
+
+describe("OakQuizTextInput", () => {
+  it("renders", () => {
+    const { getByTestId } = renderWithTheme(
+      <OakQuizTextInput
+        defaultValue="An answer to a question"
+        data-testid="quiz-input"
+      />,
+    );
+
+    expect(getByTestId("quiz-input")).toBeInTheDocument();
+  });
+
+  it("matches snapshot", () => {
+    const tree = create(
+      <ThemeProvider theme={oakDefaultTheme}>
+        <OakQuizTextInput defaultValue="An answer to a question" />,
+      </ThemeProvider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('sets the input to read-only when feedback is "correct"', () => {
+    const { getByRole, getByAltText } = renderWithTheme(
+      <OakQuizTextInput
+        defaultValue="An answer to a question"
+        feedback="correct"
+      />,
+    );
+
+    expect(getByRole("textbox")).toHaveAttribute("readonly");
+    expect(getByAltText("Correct")).toBeInTheDocument();
+  });
+
+  it('sets the input to read-only when feedback is "incorrect"', () => {
+    const { getByRole, getByAltText } = renderWithTheme(
+      <OakQuizTextInput
+        defaultValue="An answer to a question"
+        feedback="incorrect"
+      />,
+    );
+
+    expect(getByRole("textbox")).toHaveAttribute("readonly");
+    expect(getByAltText("Incorrect")).toBeInTheDocument();
+  });
+});

--- a/src/components/integrated/OakQuizTextInput/OakQuizTextInput.tsx
+++ b/src/components/integrated/OakQuizTextInput/OakQuizTextInput.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+import { OakTextInput, OakTextInputProps } from "@/components/ui";
+
+type OakQuizTextInputProps = Omit<
+  OakTextInputProps,
+  "validity" | "iconName" | "iconAlt" | "isTrailingIcon"
+> & {
+  /**
+   * Alters the appearance of the input to indicate whether or not a correct answer was given.
+   * Also sets the input to read-only.
+   */
+  feedback?: "correct" | "incorrect" | null;
+};
+
+export const OakQuizTextInput = ({
+  feedback,
+  readOnly,
+  ...props
+}: OakQuizTextInputProps) => {
+  let validity: OakTextInputProps["validity"];
+  let iconName: OakTextInputProps["iconName"];
+  let iconAlt: OakTextInputProps["iconAlt"] = undefined;
+
+  switch (feedback) {
+    case "correct":
+      validity = "valid";
+      iconName = "tick";
+      iconAlt = "Correct";
+      break;
+    case "incorrect":
+      validity = "invalid";
+      iconName = "cross";
+      iconAlt = "Incorrect";
+      break;
+  }
+
+  return (
+    <OakTextInput
+      {...props}
+      validity={validity}
+      iconName={iconName}
+      iconAlt={iconAlt}
+      readOnly={readOnly || !!feedback}
+      isTrailingIcon
+    />
+  );
+};

--- a/src/components/integrated/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
+++ b/src/components/integrated/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakQuizTextInput matches snapshot 1`] = `
+[
+  <div
+    className="sc-aXZVg sc-gEvEer sc-jsJBEP cTDiqX ftzkJO dAGEQO"
+    onClick={[Function]}
+  >
+    <input
+      className="sc-bXCLTC gAiXpM"
+      defaultValue="An answer to a question"
+      onFocus={[Function]}
+      readOnly={false}
+      type="text"
+    />
+  </div>,
+  ",",
+]
+`;

--- a/src/components/integrated/OakQuizTextInput/index.ts
+++ b/src/components/integrated/OakQuizTextInput/index.ts
@@ -1,2 +1,1 @@
-export * from "./OakQuizCheckBox";
 export * from "./OakQuizTextInput";

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -26,8 +26,6 @@ type StyledTextInputWrapperProps = {
 };
 
 export type OakTextInputProps = {
-  id?: string;
-  type?: "text" | "password" | "number" | "email" | "tel";
   /**
    * Disables user input and updates the appearance accordingly.
    */
@@ -79,7 +77,8 @@ export type OakTextInputProps = {
   readOnlyColor?: OakCombinedColorToken;
   width?: SizeStyleProps["$width"];
   maxWidth?: SizeStyleProps["$maxWidth"];
-} & Pick<InternalTextInputProps, "onInitialFocus" | "placeholder">;
+  iconAlt?: string;
+} & InternalTextInputProps;
 
 const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
   &:hover {
@@ -95,11 +94,15 @@ const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
 
   background: ${(props) => parseColor(props.$background)};
 
-  @media (hover: hover) {
-    &:hover:not(:focus-within) {
-      background: ${(props) => parseColor(props.$hoverBackground)};
-    }
-  }
+  ${(props) =>
+    !props.$readOnly &&
+    css`
+      @media (hover: hover) {
+        &:hover:not(:focus-within) {
+          background: ${parseColor(props.$hoverBackground)};
+        }
+      }
+    `}
 
   ${(props) =>
     props.$readOnly &&
@@ -143,6 +146,7 @@ export const OakTextInput = ({
   validIconColor = "icon-success",
   invalidIconColor = "border-error",
   iconName,
+  iconAlt,
   isTrailingIcon = false,
   width,
   maxWidth,
@@ -201,6 +205,7 @@ export const OakTextInput = ({
           iconName={iconName}
           $colorFilter={finalIconColor}
           $pointerEvents="none"
+          alt={iconAlt}
         />
       )}
       <InternalTextInput
@@ -216,6 +221,7 @@ export const OakTextInput = ({
           iconName={iconName}
           $colorFilter={finalIconColor}
           $pointerEvents="none"
+          alt={iconAlt}
         />
       )}
     </StyledTextInputWrapper>

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -113,6 +113,9 @@ const StyledTextInputWrapper = styled(OakFlex)<StyledTextInputWrapperProps>`
     css`
       background: ${parseColor(props.$disabledBackgroundColor)};
       color: ${parseColor(props.$disabledColor)};
+      &:hover {
+        cursor: not-allowed;
+      }
     `}
 `;
 

--- a/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`OakTextInput matches snapshot 1`] = `
 [
   <div
-    className="sc-gEvEer sc-eqUAAy sc-cwHptR eJgbvX kUreFU cxqUUM"
+    className="sc-gEvEer sc-eqUAAy sc-cwHptR eJgbvX kUreFU bmxVLQ"
     onClick={[Function]}
   >
     <input
-      className="sc-aXZVg llBHGf"
+      className="sc-aXZVg htVdEQ"
       defaultValue="A nice text value"
       onFocus={[Function]}
       type="text"


### PR DESCRIPTION
* Adds the `not-allowed` cursor to inputs when disabled
* Adds an `iconAlt` prop to `OakTextInput` so that we can deliver some context to AT with the icon
* Adds `OakQuizTextInput` which is a specialised form of `OakTextInput` configured with feedback states for quiizzes.

## TODO
- [ ] Add 👇🏼 new icons when I have access


![search](https://github.com/oaknational/oak-components/assets/122096/a65c11c8-9d90-4f7e-b9fc-4e82868cc3b6)
![warning](https://github.com/oaknational/oak-components/assets/122096/c87bccf2-107f-4224-bcb7-e2c7cbcda451)

Builds upon the base `OakTextInput` as in Figma here 👇🏼 
https://www.figma.com/file/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?type=design&node-id=3854-11120&mode=dev

Can be found in Storybook here 👇🏼 
https://deploy-preview-51--lively-meringue-8ebd43.netlify.app/?path=/docs/components-integrated-oakquiztextinput--docs