### PR TITLE
Feat(PUPIL-208): `OakQuizRadioButton`

### DIFF
--- a/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.stories.tsx
+++ b/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.stories.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakQuizRadioButton } from "./OakQuizRadioButton";
+
+import { OakRadioGroup } from "@/components/ui";
+import { OakImage } from "@/components/base";
+
+const meta: Meta<typeof OakQuizRadioButton> = {
+  component: OakQuizRadioButton,
+  tags: ["autodocs"],
+  title: "components/integrated/OakQuizRadioButton",
+  args: {
+    label: "Radio option",
+    value: "Option 1",
+  },
+  parameters: {
+    controls: {
+      include: ["feedback", "disabled"],
+    },
+    backgrounds: {
+      default: "light",
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof OakQuizRadioButton>;
+
+export const Default: Story = {
+  render: (args) => (
+    <OakRadioGroup name="radio-group-1" $flexDirection="column">
+      <OakQuizRadioButton {...args} />
+    </OakRadioGroup>
+  ),
+};
+
+export const Selected: Story = {
+  render: (args) => (
+    <OakRadioGroup
+      name="radio-group-2"
+      value="Option 1"
+      $flexDirection="column"
+    >
+      <OakQuizRadioButton {...args} />
+    </OakRadioGroup>
+  ),
+};
+
+export const SelectedCorrect: Story = {
+  render: (args) => (
+    <OakRadioGroup
+      name="radio-group-3"
+      value="Option 1"
+      $flexDirection="column"
+    >
+      <OakQuizRadioButton {...args} feedback="correct" />
+    </OakRadioGroup>
+  ),
+};
+
+export const SelectedIncorrect: Story = {
+  render: (args) => (
+    <OakRadioGroup
+      name="radio-group-4"
+      value="Option 1"
+      $flexDirection="column"
+    >
+      <OakQuizRadioButton {...args} feedback="incorrect" />
+    </OakRadioGroup>
+  ),
+};
+
+export const Correct: Story = {
+  render: (args) => (
+    <OakRadioGroup name="radio-group-5" $flexDirection="column">
+      <OakQuizRadioButton {...args} feedback="correct" />
+    </OakRadioGroup>
+  ),
+};
+
+export const Incorrect: Story = {
+  render: (args) => (
+    <OakRadioGroup name="radio-group-6" $flexDirection="column">
+      <OakQuizRadioButton {...args} feedback="incorrect" />
+    </OakRadioGroup>
+  ),
+};
+
+export const Disabled: Story = {
+  render: (args) => (
+    <OakRadioGroup name="radio-group-7" $flexDirection="column">
+      <OakQuizRadioButton {...args} disabled />
+    </OakRadioGroup>
+  ),
+};
+
+export const SelectedDisabled: Story = {
+  render: (args) => (
+    <OakRadioGroup
+      name="radio-group-8"
+      value="Option 1"
+      $flexDirection="column"
+    >
+      <OakQuizRadioButton {...args} disabled />
+    </OakRadioGroup>
+  ),
+};
+
+export const WithImage: Story = {
+  render: (args) => (
+    <OakRadioGroup name="radio-group-9" $flexDirection="column">
+      <OakQuizRadioButton
+        {...args}
+        image={
+          <OakImage
+            alt="Some trees"
+            src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1698336490/sample.jpg`}
+            width={864}
+            height={576}
+            $minWidth={"all-spacing-19"}
+          />
+        }
+      />{" "}
+    </OakRadioGroup>
+  ),
+};

--- a/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.stories.tsx
+++ b/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof OakQuizRadioButton> = {
   tags: ["autodocs"],
   title: "components/integrated/OakQuizRadioButton",
   args: {
-    label: "Radio option",
+    label: "Option label",
     value: "Option 1",
   },
   parameters: {
@@ -37,91 +37,134 @@ export const Default: Story = {
 
 export const Selected: Story = {
   render: (args) => (
-    <OakRadioGroup
-      name="radio-group-2"
-      value="Option 1"
-      $flexDirection="column"
-    >
-      <OakQuizRadioButton {...args} />
-    </OakRadioGroup>
+    <>
+      <OakRadioGroup
+        name="radio-group-2"
+        value="Option 1"
+        $flexDirection="column"
+      >
+        <OakQuizRadioButton {...args} />
+      </OakRadioGroup>
+      <OakRadioGroup
+        name="radio-group-3"
+        value="Option 1"
+        $flexDirection="column"
+      >
+        <OakQuizRadioButton {...args} disabled label="Disabled" />
+      </OakRadioGroup>
+    </>
   ),
 };
 
-export const SelectedCorrect: Story = {
+export const NotSelected: Story = {
   render: (args) => (
-    <OakRadioGroup
-      name="radio-group-3"
-      value="Option 1"
-      $flexDirection="column"
-    >
-      <OakQuizRadioButton {...args} feedback="correct" />
-    </OakRadioGroup>
+    <>
+      <OakRadioGroup name="radio-group-4" value="" $flexDirection="column">
+        <OakQuizRadioButton {...args} />
+      </OakRadioGroup>
+      <OakRadioGroup name="radio-group-5" value="" $flexDirection="column">
+        <OakQuizRadioButton {...args} disabled label="Disabled" />
+      </OakRadioGroup>
+    </>
   ),
 };
 
-export const SelectedIncorrect: Story = {
+export const WithFeedback: Story = {
   render: (args) => (
-    <OakRadioGroup
-      name="radio-group-4"
-      value="Option 1"
-      $flexDirection="column"
-    >
-      <OakQuizRadioButton {...args} feedback="incorrect" />
-    </OakRadioGroup>
-  ),
-};
-
-export const Correct: Story = {
-  render: (args) => (
-    <OakRadioGroup name="radio-group-5" $flexDirection="column">
-      <OakQuizRadioButton {...args} feedback="correct" />
-    </OakRadioGroup>
-  ),
-};
-
-export const Incorrect: Story = {
-  render: (args) => (
-    <OakRadioGroup name="radio-group-6" $flexDirection="column">
-      <OakQuizRadioButton {...args} feedback="incorrect" />
-    </OakRadioGroup>
-  ),
-};
-
-export const Disabled: Story = {
-  render: (args) => (
-    <OakRadioGroup name="radio-group-7" $flexDirection="column">
-      <OakQuizRadioButton {...args} disabled />
-    </OakRadioGroup>
-  ),
-};
-
-export const SelectedDisabled: Story = {
-  render: (args) => (
-    <OakRadioGroup
-      name="radio-group-8"
-      value="Option 1"
-      $flexDirection="column"
-    >
-      <OakQuizRadioButton {...args} disabled />
-    </OakRadioGroup>
+    <>
+      <OakRadioGroup
+        name="radio-group-6"
+        value="Option 1"
+        $flexDirection="column"
+      >
+        <OakQuizRadioButton
+          {...args}
+          feedback="correct"
+          label="Correctly selected"
+        />
+      </OakRadioGroup>
+      <OakRadioGroup
+        name="radio-group-7"
+        value="Option 1"
+        $flexDirection="column"
+      >
+        <OakQuizRadioButton
+          {...args}
+          feedback="incorrect"
+          label="Incorrectly selected"
+        />
+      </OakRadioGroup>
+      <OakRadioGroup name="radio-group-8" value="" $flexDirection="column">
+        <OakQuizRadioButton
+          {...args}
+          feedback="correct"
+          label="Correctly not selected"
+        />
+      </OakRadioGroup>
+      <OakRadioGroup name="radio-group-9" value="" $flexDirection="column">
+        <OakQuizRadioButton
+          {...args}
+          feedback="incorrect"
+          label="Incorrectly not selected"
+        />
+      </OakRadioGroup>
+    </>
   ),
 };
 
 export const WithImage: Story = {
   render: (args) => (
-    <OakRadioGroup name="radio-group-9" $flexDirection="column">
-      <OakQuizRadioButton
-        {...args}
-        image={
-          <OakImage
-            alt="Some trees"
-            src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1698336490/sample.jpg`}
-            width={864}
-            height={576}
-            $minWidth={"all-spacing-19"}
-          />
-        }
-      />{" "}
-    </OakRadioGroup>
+    <>
+      <OakRadioGroup name="radio-group-10" $flexDirection="column">
+        <OakQuizRadioButton
+          {...args}
+          image={
+            <OakImage
+              alt="Some trees"
+              src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1698336490/sample.jpg`}
+              width={864}
+              height={576}
+              $minWidth="all-spacing-19"
+            />
+          }
+        />
+      </OakRadioGroup>
+      <OakRadioGroup name="radio-group-11" $flexDirection="column">
+        <OakQuizRadioButton
+          {...args}
+          feedback="correct"
+          label="Image with feedback"
+          image={
+            <OakImage
+              alt="Some trees"
+              src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1698336490/sample.jpg`}
+              width={864}
+              height={576}
+              $minWidth="all-spacing-19"
+            />
+          }
+        />
+      </OakRadioGroup>
+      <OakRadioGroup
+        name="radio-group-12"
+        value="Option 1"
+        $flexDirection="column"
+      >
+        <OakQuizRadioButton
+          {...args}
+          feedback="correct"
+          label="Selected image with feedback"
+          image={
+            <OakImage
+              alt="Some trees"
+              src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1698336490/sample.jpg`}
+              width={864}
+              height={576}
+              $minWidth="all-spacing-19"
+            />
+          }
+        />
+      </OakRadioGroup>
+    </>
   ),
 };

--- a/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.test.tsx
+++ b/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.test.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { create } from "react-test-renderer";
+
+import { OakQuizRadioButton } from "./OakQuizRadioButton";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { OakRadioGroup } from "@/components/ui";
+import { OakImage, OakThemeProvider } from "@/components/base";
+import { oakDefaultTheme } from "@/styles";
+
+describe("OakQuizRadioButton", () => {
+  it("renders a radio button", () => {
+    const { getByRole } = renderWithTheme(
+      <OakRadioGroup name="quiz-radio-group">
+        <OakQuizRadioButton
+          id="checkbox-1"
+          value="Option 1"
+          label="Radio option"
+        />
+      </OakRadioGroup>,
+    );
+
+    expect(getByRole("radio")).toBeInTheDocument();
+  });
+
+  it("matches snapshot", () => {
+    const tree = create(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakQuizRadioButton
+          id="checkbox-1"
+          value="Option 1"
+          label="Radio option"
+        />
+      </OakThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("gives the radio focus on click", async () => {
+    const { getByTestId, getByRole } = renderWithTheme(
+      <OakRadioGroup name="quiz-radio-group">
+        <OakQuizRadioButton
+          id="checkbox-1"
+          value="Option 1"
+          label="Radio option"
+          data-testid="quiz-radio"
+        />
+      </OakRadioGroup>,
+    );
+    await userEvent.click(getByTestId("quiz-radio"));
+
+    expect(getByRole("radio")).toHaveFocus();
+  });
+
+  it("can render an image as part of the label", async () => {
+    const { getByRole } = renderWithTheme(
+      <OakRadioGroup name="quiz-radio-group">
+        <OakQuizRadioButton
+          id="checkbox-1"
+          value="Option 1"
+          label="Radio option"
+          data-testid="quiz-radio"
+          image={
+            <OakImage src="https://via.placeholder.com/150" alt="Placeholder" />
+          }
+        />
+      </OakRadioGroup>,
+    );
+
+    expect(getByRole("img")).toBeInTheDocument();
+  });
+});

--- a/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.tsx
+++ b/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.tsx
@@ -130,11 +130,13 @@ export const OakQuizRadioButton = (props: OakQuizRadioButtonProps) => {
         {...rest}
       />
       {showFeedback && (
-        <OakIcon
-          iconName={isCorrect ? "tick" : "cross"}
-          $colorFilter={isCorrect ? "icon-success" : "icon-error"}
-          alt={isCorrect ? "Correct" : "Incorrect"}
-        />
+        <OakFlex $alignSelf="flex-end">
+          <OakIcon
+            iconName={isCorrect ? "tick" : "cross"}
+            $colorFilter={isCorrect ? "icon-success" : "icon-error"}
+            alt={isCorrect ? "Correct" : "Incorrect"}
+          />
+        </OakFlex>
       )}
     </StyledOakFlex>
   );

--- a/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.tsx
+++ b/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.tsx
@@ -46,6 +46,7 @@ const StyledOakFlex = styled(OakFlex)<StyledOakFlexProps>`
     css`
       &:hover {
         background-color: ${parseColor("bg-decorative1-subdued")};
+        text-decoration: underline;
       }
     `}
 

--- a/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.tsx
+++ b/src/components/integrated/OakQuizRadioButton/OakQuizRadioButton.tsx
@@ -1,0 +1,141 @@
+import React, { MouseEventHandler, useContext } from "react";
+import styled, { css } from "styled-components";
+
+import { OakBox, OakFlex, OakIcon } from "@/components/base";
+import {
+  OakRadioButton,
+  OakRadioButtonProps,
+} from "@/components/ui/OakRadioButton/OakRadioButton";
+import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
+import { parseBorder } from "@/styles/helpers/parseBorder";
+import { parseColor } from "@/styles/helpers/parseColor";
+import { parseBorderRadius } from "@/styles/helpers/parseBorderRadius";
+import { RadioContext } from "@/components/ui/OakRadioGroup/OakRadioGroup";
+import { OakUiRoleToken } from "@/styles";
+
+export type OakQuizRadioButtonProps = OakRadioButtonProps & {
+  feedback?: "correct" | "incorrect" | null;
+  image?: JSX.Element;
+};
+
+type StyledOakFlexProps = {
+  $disabled: boolean;
+  $checked: boolean;
+  $outlineColor?: OakUiRoleToken;
+};
+
+const StyledOakFlex = styled(OakFlex)<StyledOakFlexProps>`
+  ${(props) =>
+    !!props.$outlineColor &&
+    css`
+      outline: ${parseBorder("border-solid-xl")}
+        ${parseColor(props.$outlineColor)};
+    `}
+
+  &:hover {
+    cursor: ${(props) => (props.$disabled ? "default" : "pointer")};
+  }
+
+  &:focus-within {
+    box-shadow: ${parseDropShadow("drop-shadow-centered-yellow")},
+      ${parseDropShadow("drop-shadow-centered-grey")};
+  }
+
+  ${(props) =>
+    !props.$disabled &&
+    css`
+      &:hover {
+        background-color: ${parseColor("bg-decorative1-subdued")};
+      }
+    `}
+
+  ${(props) =>
+    !props.$disabled &&
+    !props.$checked &&
+    css`
+      &:hover:not(:focus-within)::after {
+        pointer-events: none;
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: ${parseBorderRadius("border-radius-m2")};
+        border-bottom: ${parseBorder("border-solid-l")} ${parseColor("grey60")};
+      }
+    `}
+`;
+
+export const OakQuizRadioButton = (props: OakQuizRadioButtonProps) => {
+  const { value, feedback, image, disabled, label, ...rest } = props;
+  const showFeedback = !!feedback;
+  const isCorrect = feedback === "correct";
+  // Give the input focus when the entire component is clicked
+  const handleOnClick: MouseEventHandler<HTMLElement> = (event) => {
+    event.currentTarget.querySelector("input")?.click();
+  };
+  const checked = useContext(RadioContext).currentValue === value;
+  let outlineColor: OakUiRoleToken | undefined;
+  let backgroundColor: OakUiRoleToken = "bg-primary";
+  switch (true) {
+    case disabled && !showFeedback:
+      backgroundColor = "bg-neutral-stronger";
+      break;
+    case feedback === "correct" && checked:
+      outlineColor = "border-success";
+      backgroundColor = "bg-correct";
+      break;
+    case feedback === "incorrect" && checked:
+      outlineColor = "border-error";
+      backgroundColor = "bg-incorrect";
+      break;
+    case checked && !disabled:
+      outlineColor = "border-primary";
+      break;
+  }
+
+  return (
+    <StyledOakFlex
+      $pa="inner-padding-l"
+      $borderRadius="border-radius-m2"
+      $justifyContent="space-between"
+      $position="relative"
+      $alignContent="center"
+      onClick={handleOnClick}
+      $disabled={disabled || showFeedback}
+      $checked={checked}
+      $outlineColor={outlineColor}
+      $background={backgroundColor}
+    >
+      <OakRadioButton
+        value={value}
+        disabled={disabled || showFeedback}
+        $labelGap="space-between-s"
+        disableFocusRing
+        radioInnerSize="all-spacing-6"
+        radioOuterSize="all-spacing-7"
+        checkedRadioBorderWidth="border-solid-l"
+        label={
+          image ? (
+            <OakFlex
+              $flexDirection="column"
+              $minWidth="all-spacing-20"
+              $gap="space-between-s"
+            >
+              <OakBox>{image}</OakBox>
+              {label}
+            </OakFlex>
+          ) : (
+            label
+          )
+        }
+        {...rest}
+      />
+      {showFeedback && (
+        <OakIcon
+          iconName={isCorrect ? "tick" : "cross"}
+          $colorFilter={isCorrect ? "icon-success" : "icon-error"}
+          alt={isCorrect ? "Correct" : "Incorrect"}
+        />
+      )}
+    </StyledOakFlex>
+  );
+};

--- a/src/components/integrated/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
+++ b/src/components/integrated/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakQuizRadioButton matches snapshot 1`] = `
 <div
-  className="sc-aXZVg sc-gEvEer sc-dLMFU iuOtXm jLIaXR ieHJUe"
+  className="sc-aXZVg sc-gEvEer sc-dLMFU iuOtXm jLIaXR dulAEB"
   onClick={[Function]}
 >
   <div

--- a/src/components/integrated/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
+++ b/src/components/integrated/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakQuizRadioButton matches snapshot 1`] = `
+[
+  <div
+    className="sc-aXZVg sc-gEvEer sc-dLMFU iuOtXm jLIaXR ieHJUe"
+    onClick={[Function]}
+  >
+    <div
+      className="sc-aXZVg goWQoj"
+    >
+      <label
+        className="sc-dAlyuH sc-jlZhew fNvgLA epcIrp"
+        htmlFor="checkbox-1"
+      >
+        <input
+          checked={false}
+          className="sc-cwHptR frvrbm"
+          id="checkbox-1"
+          name="default"
+          type="radio"
+          value="Option 1"
+        />
+        <div
+          className="sc-aXZVg sc-gEvEer sc-jEACwC eiBoAG eIypJK iXjILk"
+        />
+        Radio option
+      </label>
+    </div>
+  </div>,
+  ",",
+]
+`;

--- a/src/components/integrated/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
+++ b/src/components/integrated/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
@@ -1,33 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakQuizRadioButton matches snapshot 1`] = `
-[
+<div
+  className="sc-aXZVg sc-gEvEer sc-dLMFU iuOtXm jLIaXR ieHJUe"
+  onClick={[Function]}
+>
   <div
-    className="sc-aXZVg sc-gEvEer sc-dLMFU iuOtXm jLIaXR ieHJUe"
-    onClick={[Function]}
+    className="sc-aXZVg goWQoj"
   >
-    <div
-      className="sc-aXZVg goWQoj"
+    <label
+      className="sc-dAlyuH sc-jlZhew fNvgLA epcIrp"
+      htmlFor="checkbox-1"
     >
-      <label
-        className="sc-dAlyuH sc-jlZhew fNvgLA epcIrp"
-        htmlFor="checkbox-1"
-      >
-        <input
-          checked={false}
-          className="sc-cwHptR frvrbm"
-          id="checkbox-1"
-          name="default"
-          type="radio"
-          value="Option 1"
-        />
-        <div
-          className="sc-aXZVg sc-gEvEer sc-jEACwC eiBoAG eIypJK iXjILk"
-        />
-        Radio option
-      </label>
-    </div>
-  </div>,
-  ",",
-]
+      <input
+        checked={false}
+        className="sc-cwHptR frvrbm"
+        id="checkbox-1"
+        name="default"
+        type="radio"
+        value="Option 1"
+      />
+      <div
+        className="sc-aXZVg sc-gEvEer sc-jEACwC eiBoAG eIypJK iXjILk"
+      />
+      Radio option
+    </label>
+  </div>
+</div>
 `;

--- a/src/components/integrated/OakQuizRadioButton/index.ts
+++ b/src/components/integrated/OakQuizRadioButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakQuizRadioButton";

--- a/src/components/ui/OakRadioButton/OakRadioButton.tsx
+++ b/src/components/ui/OakRadioButton/OakRadioButton.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext } from "react";
+import React, { ReactNode, forwardRef, useContext } from "react";
 import styled, { css } from "styled-components";
 
 import { RadioContext } from "@/components/ui/OakRadioGroup/OakRadioGroup";
@@ -15,6 +15,7 @@ import {
   OakLabel,
   OakLabelProps,
 } from "@/components/base";
+import { OakAllSpacingToken, OakBorderWidthToken } from "@/styles";
 
 type RadioButtonLabelProps = {
   $labelAlignItems?: FlexStyleProps["$alignItems"];
@@ -48,10 +49,13 @@ const HiddenRadioButtonInput = styled.input.attrs({
 
 type VisibleRadioButtonInputProps = OakFlexProps & {
   $disableFocusRing: boolean;
+  $radioInnerSize: OakAllSpacingToken;
   disabled?: boolean;
 };
 
 const VisibleRadioButtonInput = styled(OakFlex)<VisibleRadioButtonInputProps>`
+  border-radius: 50%;
+
   ${(props) =>
     !props.$disableFocusRing &&
     css`
@@ -69,10 +73,9 @@ const VisibleRadioButtonInput = styled(OakFlex)<VisibleRadioButtonInputProps>`
 
   ${HiddenRadioButtonInput}:checked ~ &::after {
     content: "";
-    height: ${parseSpacing("all-spacing-4")};
-    width: ${parseSpacing("all-spacing-4")};
+    height: ${(props) => parseSpacing(props.$radioInnerSize)};
+    width: ${(props) => parseSpacing(props.$radioInnerSize)};
     background: ${parseColor("black")};
-    lay: block;
     position: absolute;
     border-radius: 50%;
     border: ${parseBorder("border-solid-m")} ${parseColor("white")};
@@ -83,10 +86,9 @@ const VisibleRadioButtonInput = styled(OakFlex)<VisibleRadioButtonInputProps>`
 const DisabledVisibleRadioButtonInput = styled(VisibleRadioButtonInput)`
   ${HiddenRadioButtonInput}:checked ~ &::after {
     content: "";
-    height: ${parseSpacing("all-spacing-4")};
-    width: ${parseSpacing("all-spacing-4")};
+    height: ${(props) => parseSpacing(props.$radioInnerSize)};
+    width: ${(props) => parseSpacing(props.$radioInnerSize)};
     background: ${parseColor("bg-btn-primary-disabled")};
-    lay: block;
     position: absolute;
     border-radius: 50%;
     border: ${parseBorder("border-solid-m")} ${parseColor("white")};
@@ -95,7 +97,7 @@ const DisabledVisibleRadioButtonInput = styled(VisibleRadioButtonInput)`
 
 export type OakRadioButtonProps = {
   id: string;
-  label: string;
+  label: ReactNode;
   value: string;
   tabIndex?: number;
   "data-testid"?: string;
@@ -105,6 +107,22 @@ export type OakRadioButtonProps = {
    * by other means, such as a border or background color change.
    */
   disableFocusRing?: boolean;
+  /**
+   * Allows the size of the radio button to be customized.
+   */
+  radioOuterSize?: OakAllSpacingToken;
+  /**
+   * Allows the size of the inner "checked" circle of the radio button to be customized.
+   */
+  radioInnerSize?: OakAllSpacingToken;
+  /**
+   * Allows the width of the radio button border to be customized.
+   */
+  radioBorderWidth?: OakBorderWidthToken;
+  /**
+   * Allows the width of the radio button border to be customized when the radio button is checked.
+   */
+  checkedRadioBorderWidth?: OakBorderWidthToken;
 } & OakBoxProps &
   RadioButtonLabelProps;
 
@@ -122,11 +140,18 @@ export const OakRadioButton = forwardRef<HTMLInputElement, OakRadioButtonProps>(
       $labelAlignItems = "center",
       $font = "body-1",
       "data-testid": dataTestId,
-      disableFocusRing,
+      disableFocusRing = false,
+      radioInnerSize = "all-spacing-4",
+      radioOuterSize = "all-spacing-6",
+      radioBorderWidth = "border-solid-m",
+      checkedRadioBorderWidth = "border-solid-m",
       ...rest
     } = props;
-
+    const checked = value === currentValue;
     const anyDisabled = disabled || radioContext.disabled;
+    const finalRadioBorderWidth = checked
+      ? checkedRadioBorderWidth
+      : radioBorderWidth;
 
     return (
       <OakBox {...rest}>
@@ -150,10 +175,9 @@ export const OakRadioButton = forwardRef<HTMLInputElement, OakRadioButtonProps>(
           />
           {!anyDisabled ? (
             <VisibleRadioButtonInput
-              $height={"all-spacing-6"}
-              $width={"all-spacing-6"}
-              $borderRadius={"border-radius-l"}
-              $ba={"border-solid-m"}
+              $height={radioOuterSize}
+              $width={radioOuterSize}
+              $ba={finalRadioBorderWidth}
               $borderColor={"black"}
               $flexGrow={0}
               $flexShrink={0}
@@ -161,13 +185,13 @@ export const OakRadioButton = forwardRef<HTMLInputElement, OakRadioButtonProps>(
               $justifyContent={"center"}
               $background={"white"}
               $disableFocusRing={!!disableFocusRing}
+              $radioInnerSize={radioInnerSize}
             />
           ) : (
             <DisabledVisibleRadioButtonInput
-              $height={"all-spacing-6"}
-              $width={"all-spacing-6"}
-              $borderRadius={"border-radius-l"}
-              $ba={"border-solid-m"}
+              $height={radioOuterSize}
+              $width={radioOuterSize}
+              $ba={finalRadioBorderWidth}
               $borderColor={"bg-btn-primary-disabled"}
               $flexGrow={0}
               $flexShrink={0}
@@ -175,6 +199,7 @@ export const OakRadioButton = forwardRef<HTMLInputElement, OakRadioButtonProps>(
               $justifyContent={"center"}
               $background={"white"}
               $disableFocusRing={!!disableFocusRing}
+              $radioInnerSize={radioInnerSize}
             />
           )}
           {label}

--- a/src/components/ui/OakRadioButton/OakRadioButton.tsx
+++ b/src/components/ui/OakRadioButton/OakRadioButton.tsx
@@ -47,22 +47,25 @@ const HiddenRadioButtonInput = styled.input.attrs({
 `;
 
 type VisibleRadioButtonInputProps = OakFlexProps & {
+  $disableFocusRing: boolean;
   disabled?: boolean;
 };
 
 const VisibleRadioButtonInput = styled(OakFlex)<VisibleRadioButtonInputProps>`
-
-  ${HiddenRadioButtonInput}:focus-visible ~ &::before {
-    content: "";
-    height: ${parseSpacing("all-spacing-7")};
-    width: ${parseSpacing("all-spacing-7")};
-    background: "transparent"
-    display: block;
-    position: absolute;
-    border-radius: 50%;
-    border: ${parseBorder("border-solid-m")} ${parseColor("grey60")};
-    box-shadow: ${`inset 0 0 0 0.13rem ${parseColor("lemon")}`};
-  }
+  ${(props) =>
+    !props.$disableFocusRing &&
+    css`
+      ${HiddenRadioButtonInput}:focus-visible ~ &::before {
+        content: "";
+        height: ${parseSpacing("all-spacing-7")};
+        width: ${parseSpacing("all-spacing-7")};
+        background: "transparent"
+        display: block;
+        position: absolute;
+        border-radius: 50%;
+        border: ${parseBorder("border-solid-m")} ${parseColor("grey60")};
+        box-shadow: ${`inset 0 0 0 0.13rem ${parseColor("lemon")}`};
+      }`}
 
   ${HiddenRadioButtonInput}:checked ~ &::after {
     content: "";
@@ -74,7 +77,6 @@ const VisibleRadioButtonInput = styled(OakFlex)<VisibleRadioButtonInputProps>`
     border-radius: 50%;
     border: ${parseBorder("border-solid-m")} ${parseColor("white")};
   }
-      
 `;
 
 // This is a hack to force React to rerender when the disabled prop is changed. Otherwise the pseudo element is not updated.
@@ -91,13 +93,18 @@ const DisabledVisibleRadioButtonInput = styled(VisibleRadioButtonInput)`
   }
 `;
 
-type OakRadioButtonProps = {
+export type OakRadioButtonProps = {
   id: string;
   label: string;
   value: string;
   tabIndex?: number;
   "data-testid"?: string;
   disabled?: boolean;
+  /**
+   * Allows the focus ring to be disabled. This is useful when focus is indicated
+   * by other means, such as a border or background color change.
+   */
+  disableFocusRing?: boolean;
 } & OakBoxProps &
   RadioButtonLabelProps;
 
@@ -115,6 +122,7 @@ export const OakRadioButton = forwardRef<HTMLInputElement, OakRadioButtonProps>(
       $labelAlignItems = "center",
       $font = "body-1",
       "data-testid": dataTestId,
+      disableFocusRing,
       ...rest
     } = props;
 
@@ -152,6 +160,7 @@ export const OakRadioButton = forwardRef<HTMLInputElement, OakRadioButtonProps>(
               $alignItems={"center"}
               $justifyContent={"center"}
               $background={"white"}
+              $disableFocusRing={!!disableFocusRing}
             />
           ) : (
             <DisabledVisibleRadioButtonInput
@@ -165,6 +174,7 @@ export const OakRadioButton = forwardRef<HTMLInputElement, OakRadioButtonProps>(
               $alignItems={"center"}
               $justifyContent={"center"}
               $background={"white"}
+              $disableFocusRing={!!disableFocusRing}
             />
           )}
           {label}

--- a/src/components/ui/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
+++ b/src/components/ui/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="1"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC RIWSy eIypJK estjvb"
       />
       Option 1
     </label>
@@ -48,7 +48,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="2"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC RIWSy eIypJK estjvb"
       />
       Option 2
     </label>
@@ -70,7 +70,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="3"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC RIWSy eIypJK estjvb"
       />
       Option 3
     </label>

--- a/src/components/ui/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
+++ b/src/components/ui/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="1"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK cQwtet"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
       />
       Option 1
     </label>
@@ -48,7 +48,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="2"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK cQwtet"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
       />
       Option 2
     </label>
@@ -70,7 +70,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="3"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK cQwtet"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
       />
       Option 3
     </label>

--- a/src/components/ui/OakRadioGroup/OakRadioGroup.test.tsx
+++ b/src/components/ui/OakRadioGroup/OakRadioGroup.test.tsx
@@ -246,4 +246,31 @@ describe("RadioGroup", () => {
   });
 
   it.todo("disables all radios when disabled prop is passed to RadioGroup");
+
+  it("allows the initial value to be set with defaultValue", () => {
+    const { getByLabelText } = renderWithTheme(
+      <OakRadioGroup name="test" defaultValue="2">
+        <OakRadioButton id="radio-1" value="1" label="Option 1" />
+        <OakRadioButton id="radio-2" value="2" label="Option 2" />
+      </OakRadioGroup>,
+    );
+
+    expect(getByLabelText("Option 2")).toBeChecked();
+  });
+
+  it("value can be controlled by passing a `value` prop", async () => {
+    const { getByLabelText } = renderWithTheme(
+      <OakRadioGroup name="test" value="1">
+        <OakRadioButton id="radio-1" value="1" label="Option 1" />
+        <OakRadioButton id="radio-2" value="2" label="Option 2" />
+      </OakRadioGroup>,
+    );
+
+    const option2 = getByLabelText("Option 2");
+
+    await userEvent.click(option2);
+
+    // The `value` prop should prevent the value from changing
+    expect(getByLabelText("Option 1")).toBeChecked();
+  });
 });

--- a/src/components/ui/OakRadioGroup/OakRadioGroup.tsx
+++ b/src/components/ui/OakRadioGroup/OakRadioGroup.tsx
@@ -23,6 +23,16 @@ export type OakRadioGroupProps = {
   disabled?: boolean;
   children: React.ReactNode;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  /**
+   * Sets the value of the radio group
+   * for use as a controlled component
+   */
+  value?: string;
+  /**
+   * Sets the initial value of the radio group
+   * for use as an uncontrolled component
+   */
+  defaultValue?: string;
 } & Pick<TypographyStyleProps, "$font"> &
   ColorStyleProps &
   Pick<FlexStyleProps, "$flexDirection" | "$alignItems" | "$gap">;
@@ -36,13 +46,17 @@ export const OakRadioGroup = (props: OakRadioGroupProps) => {
     $font = "body-1-bold",
     $gap = "space-between-s",
     disabled,
+    value,
+    defaultValue = "",
     ...rest
   } = props;
 
-  const [value, setValue] = useState("");
+  const [currentValue, setValue] = useState(defaultValue);
 
   const handleValueUpdated = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(event.target.value);
+    if (value === undefined) {
+      setValue(event.target.value);
+    }
     if (onChange) {
       onChange(event);
     }
@@ -53,7 +67,7 @@ export const OakRadioGroup = (props: OakRadioGroupProps) => {
       <OakLabel $font={$font}>{label}</OakLabel>
       <RadioContext.Provider
         value={{
-          currentValue: value,
+          currentValue: value ?? currentValue,
           name,
           disabled: disabled,
           onValueUpdated: handleValueUpdated,

--- a/src/components/ui/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
+++ b/src/components/ui/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="1"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC RIWSy eIypJK estjvb"
       />
       Option 1
     </label>
@@ -48,7 +48,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="2"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC RIWSy eIypJK estjvb"
       />
       Option 2
     </label>
@@ -70,7 +70,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="3"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC RIWSy eIypJK estjvb"
       />
       Option 3
     </label>

--- a/src/components/ui/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
+++ b/src/components/ui/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="1"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK cQwtet"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
       />
       Option 1
     </label>
@@ -48,7 +48,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="2"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK cQwtet"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
       />
       Option 2
     </label>
@@ -70,7 +70,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="3"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK cQwtet"
+        className="sc-aXZVg sc-gEvEer sc-jEACwC bEbznh eIypJK fKnjkd"
       />
       Option 3
     </label>


### PR DESCRIPTION
Builds on `OakRadioButton` adding feedback and UI states as per the Figma design 👇🏼 

https://www.figma.com/file/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?type=design&node-id=3473-12269&mode=dev 

Storybook 👇🏼 
https://deploy-preview-56--lively-meringue-8ebd43.netlify.app/?path=/docs/components-integrated-oakquizradiobutton--docs

![deploy-preview-56--lively-meringue-8ebd43 netlify app__path=_docs_components-integrated-oakquizradiobutton--docs (1)](https://github.com/oaknational/oak-components/assets/122096/cd2261d6-3fa2-4e45-aa1f-34f256d46bfa)

