### PR TITLE
chore: add warning and update search icons for `OakIcon`

### DIFF
--- a/src/components/base/OakIcon/OakIcon.tsx
+++ b/src/components/base/OakIcon/OakIcon.tsx
@@ -49,6 +49,7 @@ export const oakIconNames = [
   "instagram",
   "dot",
   "dot-png",
+  "warning",
 ] as const;
 
 export type OakIconName = (typeof oakIconNames)[number];

--- a/src/components/ui/OakTextInput/OakTextInput.stories.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.stories.tsx
@@ -89,7 +89,7 @@ export const InvalidWithIcon: Story = {
     <OakTextInput
       validity="invalid"
       value="A fine text value"
-      iconName="cross"
+      iconName="warning"
     />
   ),
 };
@@ -111,7 +111,7 @@ export const ReadOnlyInvalidTrailingIcon: Story = {
       {...args}
       validity="invalid"
       value="A fine text value"
-      iconName="cross"
+      iconName="warning"
       isTrailingIcon
       readOnly
     />

--- a/src/components/ui/OakTextInput/OakTextInput.stories.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.stories.tsx
@@ -46,7 +46,12 @@ export const WithIcon: Story = {
 
 export const WithTrailingIcon: Story = {
   render: (args) => (
-    <OakTextInput {...args} value="A fine text value" iconName="search" />
+    <OakTextInput
+      {...args}
+      value="A fine text value"
+      iconName="search"
+      isTrailingIcon
+    />
   ),
 };
 

--- a/src/image-map.json
+++ b/src/image-map.json
@@ -31,7 +31,7 @@
     "equipment-required": "v1699953925/icons/pw22bdhj2vrzfv2ogi4e.svg",
     "chevron-left": "v1699953962/icons/xpp10hijwzhyeqt6ylqf.svg",
     "download": "v1699953991/icons/dk0f6a6hdpzxftjosngn.svg",
-    "search": "v1699954021/icons/j37bbtoldfzu7tsgnowr.svg",
+    "search": "v1704901279/icons/canbi3fuz5fanzom2hvi.svg",
     "chevron-up": "v1699954058/icons/pay71thmhhylj7z28sj1.svg",
     "go": "v1699954090/icons/vdzptyvmitylra8x4usy.svg",
     "copyright": "v1699954118/icons/boiod3rflocgsnfokyo8.svg",
@@ -43,6 +43,7 @@
     "tick": "v1699954310/icons/efd3esaor6zqk7seh6kt.svg",
     "instagram": "v1699954343/icons/ayfeljric0kkimdymvva.svg",
     "dot": "v1699954371/icons/knykdclphkm8lgff4u2g.svg",
-    "dot-png": "v1699954394/icons/qecbh291nzwmhcvqayqd.png"
+    "dot-png": "v1699954394/icons/qecbh291nzwmhcvqayqd.png",
+    "warning": "v1704901279/icons/zzszodmk7fvxm9xzzg9s.svg"
   }
 }


### PR DESCRIPTION
also updates the example for `OakTextInput` to use the new icons

https://deploy-preview-57--lively-meringue-8ebd43.netlify.app/?path=/docs/components-ui-oaktextinput--docs#with-icon

https://deploy-preview-57--lively-meringue-8ebd43.netlify.app/?path=/docs/components-ui-oaktextinput--docs#read-only-invalid-trailing-icon

<img width="494" alt="Screenshot 2024-01-10 at 15 50 23" src="https://github.com/oaknational/oak-components/assets/122096/b65f7feb-54af-4f46-9aad-0e9c3ee8e85c">
<img width="463" alt="Screenshot 2024-01-10 at 15 50 17" src="https://github.com/oaknational/oak-components/assets/122096/adb56ed2-a38d-4faf-b1b2-9051e93c4d5b">
