### PR TITLE
feat(PUPIL-230): add `OakTertiaryButton`

### DIFF
--- a/src/components/integrated/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
+++ b/src/components/integrated/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`OakQuizTextInput matches snapshot 1`] = `
 [
   <div
-    className="sc-aXZVg sc-gEvEer sc-jsJBEP cTDiqX ftzkJO dAGEQO"
+    className="sc-aXZVg sc-gEvEer sc-eeDRCY cTDiqX ftzkJO chFYLu"
     onClick={[Function]}
   >
     <input
-      className="sc-bXCLTC gAiXpM"
+      className="sc-jsJBEP kpslra"
       defaultValue="An answer to a question"
       onFocus={[Function]}
       readOnly={false}

--- a/src/components/ui/OakTertiaryButton/OakTertiaryButton.stories.tsx
+++ b/src/components/ui/OakTertiaryButton/OakTertiaryButton.stories.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakTertiaryButton } from "./OakTertiaryButton";
+
+import { OakFlex } from "@/components/base";
+
+const meta: Meta<typeof OakTertiaryButton> = {
+  component: OakTertiaryButton,
+  tags: ["autodocs"],
+  title: "components/ui/OakTertiaryButton",
+  argTypes: {},
+  parameters: {
+    controls: {
+      include: ["iconName", "isTrailingIcon"],
+    },
+  },
+  decorators: [(Story) => <OakFlex $gap="space-between-m">{Story()}</OakFlex>],
+};
+export default meta;
+
+type Story = StoryObj<typeof OakTertiaryButton>;
+
+export const Default: Story = {
+  render: (args) => (
+    <>
+      <OakTertiaryButton {...args}>Tertiary Button</OakTertiaryButton>
+      <OakTertiaryButton {...args} disabled>
+        Disabled Button
+      </OakTertiaryButton>
+    </>
+  ),
+};
+
+export const WithIcon: Story = {
+  render: (args) => (
+    <>
+      <OakTertiaryButton {...args}>Leading icon</OakTertiaryButton>
+      <OakTertiaryButton {...args} isTrailingIcon>
+        Trailing icon
+      </OakTertiaryButton>
+    </>
+  ),
+  args: {
+    iconName: "arrow-right",
+  },
+};

--- a/src/components/ui/OakTertiaryButton/OakTertiaryButton.test.tsx
+++ b/src/components/ui/OakTertiaryButton/OakTertiaryButton.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+import { ThemeProvider } from "styled-components";
+
+import { OakTertiaryButton } from "./OakTertiaryButton";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { oakDefaultTheme } from "@/styles";
+
+describe("OakTertiaryButton", () => {
+  it("renders", () => {
+    const { getByRole } = renderWithTheme(
+      <OakTertiaryButton>Click</OakTertiaryButton>,
+    );
+
+    expect(getByRole("button")).toBeInTheDocument();
+  });
+
+  it("matches snapshot", () => {
+    const tree = create(
+      <ThemeProvider theme={oakDefaultTheme}>
+        <OakTertiaryButton>Click Me</OakTertiaryButton>
+      </ThemeProvider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/ui/OakTertiaryButton/OakTertiaryButton.tsx
+++ b/src/components/ui/OakTertiaryButton/OakTertiaryButton.tsx
@@ -1,0 +1,98 @@
+import React, { ReactNode } from "react";
+import { ImageProps } from "next/image";
+import styled from "styled-components";
+
+import { OakRoundIcon, OakRoundIconProps } from "../OakRoundIcon";
+
+import { OakFlex, OakIconName, OakSpan } from "@/components/base";
+import {
+  InternalButton,
+  InternalButtonProps,
+} from "@/components/base/InternalButton";
+import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
+
+type BaseTertiaryButtonProps = InternalButtonProps & {
+  iconBackground?: OakRoundIconProps["$background"];
+  iconColorFilter?: OakRoundIconProps["$colorFilter"];
+  isTrailingIcon?: boolean;
+};
+
+type TertiaryButtonProps = BaseTertiaryButtonProps & {
+  iconName?: undefined;
+  iconSrc?: undefined;
+};
+
+type TertiaryButtonWithIconNameProps = BaseTertiaryButtonProps & {
+  iconName: OakIconName;
+  iconSrc?: undefined;
+};
+
+type TertiaryButtonWithIconSrcProps = BaseTertiaryButtonProps & {
+  iconSrc: ImageProps["src"];
+  iconName?: undefined;
+};
+
+export type OakTertiaryButtonProps =
+  | TertiaryButtonProps
+  | TertiaryButtonWithIconNameProps
+  | TertiaryButtonWithIconSrcProps;
+
+const StyledInternalButton = styled(InternalButton)`
+  &:focus-visible {
+    box-shadow: ${parseDropShadow("drop-shadow-centered-yellow")},
+      ${parseDropShadow("drop-shadow-centered-grey")};
+  }
+`;
+
+/**
+ * A subtle button with no border and an optional rounded icon.
+ * Supports either an icon name or an image src
+ */
+export const OakTertiaryButton = ({
+  iconBackground,
+  iconColorFilter,
+  isTrailingIcon,
+  iconName,
+  iconSrc,
+  children,
+  disabled,
+  ...props
+}: OakTertiaryButtonProps) => {
+  const iconProps = {
+    alt: "",
+    $background: iconBackground,
+    $colorFilter: iconColorFilter,
+  };
+
+  let icon: ReactNode = null;
+  if (iconName) {
+    icon = <OakRoundIcon iconName={iconName} {...iconProps} />;
+  }
+  if (iconSrc) {
+    icon = <OakRoundIcon src={iconSrc} {...iconProps} />;
+  }
+
+  return (
+    <StyledInternalButton
+      {...props}
+      disabled={disabled}
+      $borderRadius="border-radius-s"
+    >
+      <OakFlex
+        $flexDirection="row"
+        $alignItems="center"
+        $gap="space-between-ssx"
+        $height="all-spacing-9"
+      >
+        {!isTrailingIcon && icon}
+        <OakSpan
+          $font="heading-7"
+          $color={disabled ? "text-disabled" : "text-primary"}
+        >
+          {children}
+        </OakSpan>
+        {isTrailingIcon && icon}
+      </OakFlex>
+    </StyledInternalButton>
+  );
+};

--- a/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakTertiaryButton matches snapshot 1`] = `
+<button
+  className="sc-jlZhew sc-cwHptR cxpleo hkrMvC"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  type="button"
+>
+  <div
+    className="sc-aXZVg sc-gEvEer idRvCw OzInM"
+  >
+    <span
+      className="sc-eqUAAy bIYHoz"
+    >
+      Click Me
+    </span>
+  </div>
+</button>
+`;

--- a/src/components/ui/OakTertiaryButton/index.ts
+++ b/src/components/ui/OakTertiaryButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakTertiaryButton";

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -2,6 +2,7 @@ export * from "./OakFieldError";
 export * from "./OakLoadingSpinner";
 export * from "./OakPrimaryButton";
 export * from "./OakSecondaryButton";
+export * from "./OakTertiaryButton";
 export * from "./OakRadioButton";
 export * from "./OakRadioGroup";
 export * from "./OakCheckBox";


### PR DESCRIPTION
a subtle button variant with no border and an optional rounded icon.

This will initially be used for the hint button in the quiz bottom nav.

<img width="394" alt="Screenshot 2024-01-11 at 15 15 22" src="https://github.com/oaknational/oak-components/assets/122096/f99367dc-d9e6-481e-957a-b71bf0cf71be">

![localhost_6006__path=_docs_components-ui-oaktertiarybutton--docs](https://github.com/oaknational/oak-components/assets/122096/447d7b7d-9441-47fe-b642-4c2524525142)

