### PR TITLE
feat(PUPIL-230): allow buttons to stretch to full width

### DIFF
--- a/src/components/integrated/OakQuizBottomNav/OakQuizBottomNav.stories.tsx
+++ b/src/components/integrated/OakQuizBottomNav/OakQuizBottomNav.stories.tsx
@@ -50,7 +50,11 @@ export const Default: Story = {
 export const WithButton: Story = {
   render: (args) => (
     <OakQuizBottomNav {...args}>
-      <OakPrimaryButton iconName="arrow-right" isTrailingIcon>
+      <OakPrimaryButton
+        iconName="arrow-right"
+        isTrailingIcon
+        width={["100%", "auto"]}
+      >
         Continue
       </OakPrimaryButton>
     </OakQuizBottomNav>
@@ -60,7 +64,11 @@ export const WithButton: Story = {
 export const WithHintAndButton: Story = {
   render: (args) => (
     <OakQuizBottomNav {...args}>
-      <OakPrimaryButton iconName="arrow-right" isTrailingIcon>
+      <OakPrimaryButton
+        iconName="arrow-right"
+        isTrailingIcon
+        width={["100%", "auto"]}
+      >
         Continue
       </OakPrimaryButton>
     </OakQuizBottomNav>
@@ -74,17 +82,29 @@ export const WithFeedbackAndButton: Story = {
   render: (args) => (
     <>
       <OakQuizBottomNav {...args} feedback="correct">
-        <OakPrimaryButton iconName="arrow-right" isTrailingIcon>
+        <OakPrimaryButton
+          iconName="arrow-right"
+          isTrailingIcon
+          width={["100%", "auto"]}
+        >
           Continue
         </OakPrimaryButton>
       </OakQuizBottomNav>
       <OakQuizBottomNav {...args} feedback="incorrect">
-        <OakPrimaryButton iconName="arrow-right" isTrailingIcon>
+        <OakPrimaryButton
+          iconName="arrow-right"
+          isTrailingIcon
+          width={["100%", "auto"]}
+        >
           Continue
         </OakPrimaryButton>
       </OakQuizBottomNav>
       <OakQuizBottomNav {...args} feedback="partially-correct">
-        <OakPrimaryButton iconName="arrow-right" isTrailingIcon>
+        <OakPrimaryButton
+          iconName="arrow-right"
+          isTrailingIcon
+          width={["100%", "auto"]}
+        >
           Continue
         </OakPrimaryButton>
       </OakQuizBottomNav>

--- a/src/components/integrated/OakQuizBottomNav/OakQuizBottomNav.tsx
+++ b/src/components/integrated/OakQuizBottomNav/OakQuizBottomNav.tsx
@@ -63,6 +63,7 @@ export const OakQuizBottomNav = ({
         $height="fit-content"
         $alignSelf="flex-end"
         $justifyContent={["initial", "flex-end"]}
+        $width={["100%", "auto"]}
       >
         {children}
       </OakFlex>

--- a/src/components/integrated/OakQuizBottomNav/__snapshots__/OakQuizBottomNav.test.tsx.snap
+++ b/src/components/integrated/OakQuizBottomNav/__snapshots__/OakQuizBottomNav.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`OakQuizBottomNav matches snapshot 1`] = `
       </button>
     </div>
     <div
-      className="sc-aXZVg sc-gEvEer haniGH kPptmY"
+      className="sc-aXZVg sc-gEvEer bkGhTK kPptmY"
     />
   </div>,
   <div
@@ -116,7 +116,7 @@ exports[`OakQuizBottomNav matches snapshot 1`] = `
       </p>
     </div>
     <div
-      className="sc-aXZVg sc-gEvEer haniGH kPptmY"
+      className="sc-aXZVg sc-gEvEer bkGhTK kPptmY"
     />
   </div>,
   <div
@@ -173,7 +173,7 @@ exports[`OakQuizBottomNav matches snapshot 1`] = `
       </p>
     </div>
     <div
-      className="sc-aXZVg sc-gEvEer haniGH kPptmY"
+      className="sc-aXZVg sc-gEvEer bkGhTK kPptmY"
     />
   </div>,
   <div
@@ -230,7 +230,7 @@ exports[`OakQuizBottomNav matches snapshot 1`] = `
       </p>
     </div>
     <div
-      className="sc-aXZVg sc-gEvEer haniGH kPptmY"
+      className="sc-aXZVg sc-gEvEer bkGhTK kPptmY"
     />
   </div>,
 ]

--- a/src/components/ui/InternalRectButton/InternalRectButton.stories.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.stories.tsx
@@ -7,6 +7,7 @@ import { oakIconNames } from "@/components/base/OakIcon";
 import { OakFlex } from "@/components/base";
 import { borderArgTypes } from "@/storybook-helpers/borderStyleHelpers";
 import { colorArgTypes } from "@/storybook-helpers/colorStyleHelpers";
+import { sizeArgTypes } from "@/storybook-helpers/sizeStyleHelpers";
 
 const controlIconNames = [null, [...oakIconNames].sort()].flat();
 
@@ -50,6 +51,7 @@ const meta: Meta<typeof InternalRectButton> = {
     disabledBackground: colorArgTypes.$color,
     disabledBorderColor: colorArgTypes.$color,
     disabledTextColor: colorArgTypes.$color,
+    width: sizeArgTypes["$width"],
   },
   parameters: {
     controls: {
@@ -66,6 +68,7 @@ const meta: Meta<typeof InternalRectButton> = {
         "disabledBackground",
         "disabledBorderColor",
         "disabledTextColor",
+        "width",
         "type",
       ],
     },

--- a/src/components/ui/InternalRectButton/InternalRectButton.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.tsx
@@ -39,6 +39,8 @@ export type InternalRectButtonProps = Omit<
   disabledBackground: OakCombinedColorToken;
   disabledBorderColor: OakCombinedColorToken;
   disabledTextColor: OakCombinedColorToken;
+  width?: SizeStyleProps["$width"];
+  maxWidth?: SizeStyleProps["$maxWidth"];
 } & PositionStyleProps;
 
 const StyledInternalButton = styled(InternalButton)<
@@ -88,8 +90,16 @@ const StyledButtonWrapper = styled(OakBox)`
 `;
 
 export const InternalRectButton = (props: InternalRectButtonProps) => {
-  const { children, iconName, isTrailingIcon, isLoading, disabled, ...rest } =
-    props;
+  const {
+    children,
+    iconName,
+    isTrailingIcon,
+    isLoading,
+    disabled,
+    width,
+    maxWidth,
+    ...rest
+  } = props;
 
   const icon = (
     <>
@@ -115,7 +125,12 @@ export const InternalRectButton = (props: InternalRectButtonProps) => {
   const iconLogic = <>{isLoading && !disabled ? loader : icon}</>;
 
   return (
-    <StyledButtonWrapper className="button-wrapper" $position={"relative"}>
+    <StyledButtonWrapper
+      className="button-wrapper"
+      $position={"relative"}
+      $width={width}
+      $maxWidth={maxWidth}
+    >
       <OakBox
         className="grey-shadow"
         $position={"absolute"}
@@ -151,6 +166,7 @@ export const InternalRectButton = (props: InternalRectButtonProps) => {
           $flexDirection={"row"}
           $alignItems={"center"}
           $gap="space-between-ssx"
+          $justifyContent="center"
         >
           {!isTrailingIcon && iconLogic}
           <OakSpan $font={"body-1-bold"}>{children}</OakSpan>

--- a/src/components/ui/InternalRectButton/__snapshots__/InternalRectButton.test.tsx.snap
+++ b/src/components/ui/InternalRectButton/__snapshots__/InternalRectButton.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`InternalRectButton matches snapshot 1`] = `
     type="button"
   >
     <div
-      className="sc-aXZVg sc-gEvEer dPEvkO OzInM"
+      className="sc-aXZVg sc-gEvEer dPEvkO joqyk"
     >
       <div
         className="sc-aXZVg cgcTZj"

--- a/src/components/ui/OakPrimaryButton/OakPrimaryButton.tsx
+++ b/src/components/ui/OakPrimaryButton/OakPrimaryButton.tsx
@@ -17,6 +17,8 @@ export type OakPrimaryButtonProps = Pick<
   | "iconName"
   | "isTrailingIcon"
   | "type"
+  | "width"
+  | "maxWidth"
 >;
 
 export const OakPrimaryButton = (props: OakPrimaryButtonProps) => {

--- a/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
     type="button"
   >
     <div
-      className="sc-aXZVg sc-gEvEer dPEvkO OzInM"
+      className="sc-aXZVg sc-gEvEer dPEvkO joqyk"
     >
       <div
         className="sc-aXZVg cgcTZj"

--- a/src/components/ui/OakSecondaryButton/OakSecondaryButton.tsx
+++ b/src/components/ui/OakSecondaryButton/OakSecondaryButton.tsx
@@ -17,6 +17,8 @@ export type OakSecondaryButtonProps = Pick<
   | "iconName"
   | "isTrailingIcon"
   | "type"
+  | "width"
+  | "maxWidth"
 >;
 
 export const OakSecondaryButton = (props: OakSecondaryButtonProps) => {

--- a/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
     type="button"
   >
     <div
-      className="sc-aXZVg sc-gEvEer dPEvkO OzInM"
+      className="sc-aXZVg sc-gEvEer dPEvkO joqyk"
     >
       <div
         className="sc-aXZVg cgcTZj"


### PR DESCRIPTION
* adds `width` and `maxWidth` props to `InternalRectButton`
* justifies the button content to the center
* sets the width of the example buttons to 100% in the bottom nav story

Storybook: https://deploy-preview-62--lively-meringue-8ebd43.netlify.app/?path=/docs/components-integrated-oakquizbottomnav--docs

**Mobile**
<img width="632" alt="Screenshot 2024-01-15 at 11 17 11" src="https://github.com/oaknational/oak-components/assets/122096/7daeb88d-b562-4b94-b7f8-e03c084cd465">

**Above**
<img width="1155" alt="Screenshot 2024-01-15 at 11 17 17" src="https://github.com/oaknational/oak-components/assets/122096/51a15a28-ce96-4d1c-9df8-5d6c4c66132e">
