### PR TITLE
chore: add `jest-styled-components`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -70,7 +70,7 @@ const config = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ["<rootDir>/src/test-helpers/setupTests.ts"],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "husky": "^8.0.3",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-styled-components": "^7.2.0",
         "prettier": "^3.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -18707,6 +18708,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/jest-styled-components": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-7.2.0.tgz",
+      "integrity": "sha512-gwyyveNjvuRA0pyhbQoydXZllLZESs2VuL5fXCabzh0buHPAOUfANtW7n5YMPmdC0sH3VB7h2eUGZ23+tjvaBA==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 5"
+      }
     },
     "node_modules/jest-util": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-styled-components": "^7.2.0",
     "prettier": "^3.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/base/InternalButton/__snapshots__/InternalButton.test.tsx.snap
+++ b/src/components/base/InternalButton/__snapshots__/InternalButton.test.tsx.snap
@@ -1,8 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalButton matches snapshot 1`] = `
+.c0 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+}
+
+.c0:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
 <button
-  className="sc-aXZVg fCQWqS"
+  className="c0"
   onClick={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}

--- a/src/components/base/InternalCard/__snapshots__/InternalCard.test.tsx.snap
+++ b/src/components/base/InternalCard/__snapshots__/InternalCard.test.tsx.snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakBox matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  padding: 1.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
 <div
-  className="sc-aXZVg sc-gEvEer sc-eqUAAy hLAgDO cbUMXN"
+  className="c0 c1"
 />
 `;

--- a/src/components/base/InternalCheckBox/__snapshots__/InternalCheckBox.test.tsx.snap
+++ b/src/components/base/InternalCheckBox/__snapshots__/InternalCheckBox.test.tsx.snap
@@ -1,8 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalCheckBox matches snapshot 1`] = `
+.c0 {
+  -webkit-appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  margin: 0;
+  outline: none;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.125rem;
+}
+
+.c0:checked {
+  background: #222222;
+}
+
+.c0:disabled {
+  pointer-events: none;
+}
+
 <input
-  className="sc-aXZVg biWKGi"
+  className="c0"
   id="checkbox-1"
   name="checkbox-1"
   onMouseEnter={[Function]}

--- a/src/components/base/InternalCheckBoxLabel/__snapshots__/InternalCheckBoxLabel.test.tsx.snap
+++ b/src/components/base/InternalCheckBoxLabel/__snapshots__/InternalCheckBoxLabel.test.tsx.snap
@@ -1,8 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalCheckBoxLabel matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 <label
-  className="sc-dAlyuH sc-jlZhew iDHxRc jGsLfY"
+  className="c0 c1"
   data-testid="test-1"
   htmlFor="checkbox-1"
 >

--- a/src/components/base/InternalCheckBoxWrapper/__snapshots__/InternalCheckBoxWrapper.test.tsx.snap
+++ b/src/components/base/InternalCheckBoxWrapper/__snapshots__/InternalCheckBoxWrapper.test.tsx.snap
@@ -2,8 +2,34 @@
 
 exports[`InternalCheckBoxWrapper matches snapshot 1`] = `
 [
-  <div
-    className="sc-aXZVg cgcTZj"
+  .c0 {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  position: absolute;
+  top: 0rem;
+  left: 0rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  pointer-events: none;
+  opacity: 0;
+}
+
+input:checked + .c1 {
+  opacity: 1;
+}
+
+<div
+    className="c0"
   >
     <input
       data-testid="test-input"
@@ -12,7 +38,7 @@ exports[`InternalCheckBoxWrapper matches snapshot 1`] = `
       value="Option 1"
     />
     <div
-      className="sc-aXZVg sc-jlZhew biXGJa nsmqb"
+      className="c1 c2 c3"
     >
       <div
         data-testid="test-icon"

--- a/src/components/base/InternalTextInput/__snapshots__/InternalTextInput.test.tsx.snap
+++ b/src/components/base/InternalTextInput/__snapshots__/InternalTextInput.test.tsx.snap
@@ -1,8 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalTextInput matches snapshot 1`] = `
+.c0 {
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  appearance: none !important;
+  border: 0;
+  border-radius: 0;
+  border-color: transparent;
+  box-shadow: none;
+  font-family: inherit;
+  background: transparent;
+  outline: none;
+  color: inherit;
+}
+
+.c0::-webkit-search-decoration,
+.c0::-webkit-search-cancel-button,
+.c0::-webkit-search-results-button,
+.c0::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c0::-webkit-search-decoration,
+.c0::-webkit-search-cancel-button,
+.c0::-webkit-search-results-button,
+.c0::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c0::-webkit-search-decoration,
+.c0::-webkit-search-cancel-button,
+.c0::-webkit-search-results-button,
+.c0::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c0::-webkit-search-decoration,
+.c0::-webkit-search-cancel-button,
+.c0::-webkit-search-results-button,
+.c0::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c0:disabled {
+  cursor: not-allowed;
+}
+
+@media (max-width:750px) {
+  .c0 {
+    font-size: 16px;
+  }
+}
+
 <input
-  className="sc-aXZVg bTMTZW"
+  className="c0"
   onFocus={[Function]}
 />
 `;

--- a/src/components/base/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
+++ b/src/components/base/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
@@ -1,19 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalTooltip matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  position: absolute;
+  top: 0rem;
+  left: 0rem;
+  -webkit-transform: translateY(calc(-100% - 16px));
+  -ms-transform: translateY(calc(-100% - 16px));
+  transform: translateY(calc(-100% - 16px));
+  font-family: Lexend,sans-serif;
+  z-index: 300;
+}
+
+.c4 {
+  position: relative;
+  max-width: 22.5rem;
+  color: #ffffff;
+  background: #222222;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  pointer-events: none;
+}
+
+.c6 {
+  position: absolute;
+  bottom: -16px;
+  left: 0;
+  fill: #222222;
+}
+
+@media (min-width:750px) {
+  .c4 {
+    max-width: 40rem;
+  }
+}
+
 <div
-  className="sc-aXZVg sc-gEvEer iBTklz dnJeoC"
+  className="c0 c1"
 >
   <div
-    className="sc-aXZVg sc-gEvEer cBEgJK iQgtgu"
+    className="c2 c3"
     role="tooltip"
   >
     <div
-      className="sc-aXZVg sc-gEvEer sc-eqUAAy HjOnE dnJeoC hYnrwb"
+      className="c4 c1 c5"
     >
       Hello there
       <svg
-        className="sc-fqkvVR cOpSNb"
+        className="c6"
         height="16"
         width="16"
       >

--- a/src/components/base/OakAnchorTarget/__snapshots__/OakAnchorTarget.test.tsx.snap
+++ b/src/components/base/OakAnchorTarget/__snapshots__/OakAnchorTarget.test.tsx.snap
@@ -1,7 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakAnchorTarget matches snapshot 1`] = `
+.c0 {
+  position: absolute;
+  top: 0;
+}
+
 <span
-  className="sc-aXZVg hiakbw"
+  className="c0"
 />
 `;

--- a/src/components/base/OakAspectRatio/__snapshots__/OakAspectRatio.test.tsx.snap
+++ b/src/components/base/OakAspectRatio/__snapshots__/OakAspectRatio.test.tsx.snap
@@ -1,11 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakAspectRatio matches snapshot 1`] = `
+.c0 {
+  width: 100%;
+  height: 0;
+  position: relative;
+  padding-top: 56.25%;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  top: 0;
+}
+
 <div
-  className="sc-aXZVg csaaPj"
+  className="c0"
 >
   <div
-    className="sc-gEvEer fXDPyo"
+    className="c1"
   />
 </div>
 `;

--- a/src/components/base/OakBox/__snapshots__/OakBox.test.tsx.snap
+++ b/src/components/base/OakBox/__snapshots__/OakBox.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakBox matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
 <div
-  className="sc-aXZVg dPEvkO"
+  className="c0"
 />
 `;

--- a/src/components/base/OakFlex/__snapshots__/OakFlex.test.tsx.snap
+++ b/src/components/base/OakFlex/__snapshots__/OakFlex.test.tsx.snap
@@ -1,7 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakBox matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 <div
-  className="sc-aXZVg sc-gEvEer dPEvkO dnJeoC"
+  className="c0 c1"
 />
 `;

--- a/src/components/base/OakForm/__snapshots__/OakForm.test.tsx.snap
+++ b/src/components/base/OakForm/__snapshots__/OakForm.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakBox matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
 <form
-  className="sc-gEvEer kSdOXa"
+  className="c0"
 />
 `;

--- a/src/components/base/OakHeading/__snapshots__/OakHeading.test.tsx.snap
+++ b/src/components/base/OakHeading/__snapshots__/OakHeading.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Heading matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
 <h1
-  className="sc-aXZVg jFyBpA"
+  className="c0"
 />
 `;

--- a/src/components/base/OakIcon/__snapshots__/OakIcon.test.tsx.snap
+++ b/src/components/base/OakIcon/__snapshots__/OakIcon.test.tsx.snap
@@ -1,12 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakIcon matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  width: 2rem;
+  height: 2rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  object-fit: contain;
+}
+
 <div
-  className="sc-aXZVg gNRRHr"
+  className="c0"
 >
   <img
     alt="home"
-    className="sc-gEvEer hAbnnj"
+    className="c1"
     data-nimg="fill"
     decoding="async"
     loading="lazy"

--- a/src/components/base/OakImage/__snapshots__/OakImage.test.tsx.snap
+++ b/src/components/base/OakImage/__snapshots__/OakImage.test.tsx.snap
@@ -1,12 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakImage matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  width: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  object-fit: contain;
+}
+
 <div
-  className="sc-aXZVg jBAFHB"
+  className="c0"
 >
   <img
     alt="a test image"
-    className="sc-gEvEer hAbnnj"
+    className="c1"
     data-nimg="fill"
     decoding="async"
     loading="lazy"

--- a/src/components/base/OakLI/__snapshots__/OakLI.test.tsx.snap
+++ b/src/components/base/OakLI/__snapshots__/OakLI.test.tsx.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakLI matches snapshot 1`] = `
+.c0 {
+  display: revert;
+  font-family: Lexend,sans-serif;
+  font-family: Lexend,sans-serif;
+  display: revert;
+}
+
 <li
-  className="sc-gEvEer lbURhj"
+  className="c0"
 />
 `;

--- a/src/components/base/OakLabel/__snapshots__/OakLabel.test.tsx.snap
+++ b/src/components/base/OakLabel/__snapshots__/OakLabel.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakLabel matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
 <label
-  className="sc-aXZVg dtQMNf"
+  className="c0"
 />
 `;

--- a/src/components/base/OakMaxWidth/__snapshots__/OakMaxWidth.test.tsx.snap
+++ b/src/components/base/OakMaxWidth/__snapshots__/OakMaxWidth.test.tsx.snap
@@ -1,7 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakMaxWidth matches snapshot 1`] = `
+.c0 {
+  width: 100%;
+  max-width: 30rem;
+  padding-left: 0rem;
+  padding-right: 0rem;
+  margin-left: auto;
+  margin-right: auto;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+@media (min-width:750px) {
+  .c0 {
+    max-width: 80rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    padding-left: 0.75rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    padding-right: 0.75rem;
+  }
+}
+
 <div
-  className="sc-aXZVg sc-gEvEer sc-eqUAAy kQhzYP cbUMXN"
+  className="c0 c1"
 />
 `;

--- a/src/components/base/OakOL/__snapshots__/OakOL.test.tsx.snap
+++ b/src/components/base/OakOL/__snapshots__/OakOL.test.tsx.snap
@@ -1,7 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakOL matches snapshot 1`] = `
+.c0 {
+  counter-reset: item;
+  padding: 0;
+  font-family: Lexend,sans-serif;
+}
+
+.c0 li {
+  display: block;
+  counter-increment: item;
+  margin: 0;
+  padding: 0 0 0 16px;
+  text-indent: -16px;
+  list-style-type: none;
+  line-height: 32px;
+}
+
+.c0 li br {
+  content: "";
+  display: block;
+  margin-top: 8px;
+}
+
+.c0 li::before {
+  padding-right: 4px;
+  content: counter(item) ".";
+}
+
 <ol
-  className="sc-aXZVg hgUwxN"
+  className="c0"
 />
 `;

--- a/src/components/base/OakP/__snapshots__/OakP.test.tsx.snap
+++ b/src/components/base/OakP/__snapshots__/OakP.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`P matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
 <p
-  className="sc-aXZVg kqmuya"
+  className="c0"
 />
 `;

--- a/src/components/base/OakScreenReader/__snapshots__/OakScreenReader.test.tsx.snap
+++ b/src/components/base/OakScreenReader/__snapshots__/OakScreenReader.test.tsx.snap
@@ -1,7 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakScreenReader matches snapshot 1`] = `
+.c0 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
 <span
-  className="sc-aXZVg gDZdFS"
+  className="c0"
 />
 `;

--- a/src/components/base/OakSpan/__snapshots__/OakSpan.test.tsx.snap
+++ b/src/components/base/OakSpan/__snapshots__/OakSpan.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSpan matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
 <span
-  className="sc-aXZVg DmSIJ"
+  className="c0"
 />
 `;

--- a/src/components/base/OakTypography/__snapshots__/OakTypography.test.tsx.snap
+++ b/src/components/base/OakTypography/__snapshots__/OakTypography.test.tsx.snap
@@ -1,7 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTypography matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  font-family: Lexend,sans-serif;
+}
+
 <div
-  className="sc-aXZVg sc-gEvEer dPEvkO dSonKc"
+  className="c0 c1"
 />
 `;

--- a/src/components/base/OakUL/__snapshots__/OakUL.test.tsx.snap
+++ b/src/components/base/OakUL/__snapshots__/OakUL.test.tsx.snap
@@ -1,7 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakUL matches snapshot 1`] = `
+.c0 {
+  margin: 0;
+  font-family: Lexend,sans-serif;
+}
+
 <ul
-  className="sc-gEvEer ceYxIG"
+  className="c0"
 />
 `;

--- a/src/components/integrated/OakQuizBottomNav/__snapshots__/OakQuizBottomNav.test.tsx.snap
+++ b/src/components/integrated/OakQuizBottomNav/__snapshots__/OakQuizBottomNav.test.tsx.snap
@@ -2,31 +2,203 @@
 
 exports[`OakQuizBottomNav matches snapshot 1`] = `
 [
-  <div
-    className="sc-aXZVg sc-gEvEer sc-iHGNWf hctFYU iQpLSn clCXpd"
+  .c0 {
+  min-height: 3rem;
+  padding: 1rem;
+  background: #ffffff;
+  border-top: 0.25rem solid;
+  border-color: #ffffff;
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  position: relative;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c7 {
+  height: 3rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c9 {
+  width: 3rem;
+  height: 3rem;
+  padding: 0.25rem;
+  background: #ffe555;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c10 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c13 {
+  width: 100%;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: initial;
+  -webkit-justify-content: initial;
+  -ms-flex-pack: initial;
+  justify-content: initial;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c12 {
+  color: #222222;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c11 {
+  object-fit: contain;
+}
+
+.c5 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  border-radius: 0.25rem;
+}
+
+.c5:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c6:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c2 {
+  box-sizing: content-box;
+}
+
+@media (min-width:750px) {
+  .c0 {
+    background: #ebfbeb;
+  }
+}
+
+@media (min-width:750px) {
+  .c13 {
+    width: auto;
+  }
+}
+
+@media (min-width:750px) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media (min-width:750px) {
+  .c14 {
+    -webkit-box-pack: end;
+    -webkit-justify-content: flex-end;
+    -ms-flex-pack: end;
+    justify-content: flex-end;
+  }
+}
+
+<div
+    className="c0 c1 c2"
   >
     <div
-      className="sc-aXZVg sc-gEvEer iBTklz dnJeoC"
+      className="c3 c4"
     >
       <button
-        className="sc-jEACwC sc-eDPEul cxiCSm jIpyWh"
+        className="c5 c6"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         type="button"
       >
         <div
-          className="sc-aXZVg sc-gEvEer kEIIQV OzInM"
+          className="c7 c8"
         >
           <div
-            className="sc-aXZVg dNqVNp"
+            className="c9"
           >
             <div
-              className="sc-aXZVg jnxfJj"
+              className="c10"
             >
               <img
                 alt=""
-                className="sc-fqkvVR kHVsCf"
+                className="c11"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -51,7 +223,7 @@ exports[`OakQuizBottomNav matches snapshot 1`] = `
             </div>
           </div>
           <span
-            className="sc-eqUAAy bUYyl"
+            className="c12"
           >
             Need a hint?
           </span>
@@ -59,27 +231,164 @@ exports[`OakQuizBottomNav matches snapshot 1`] = `
       </button>
     </div>
     <div
-      className="sc-aXZVg sc-gEvEer bkGhTK kPptmY"
+      className="c13 c14"
     />
   </div>,
-  <div
-    className="sc-aXZVg sc-gEvEer sc-iHGNWf hctFYU iQpLSn clCXpd"
+  .c0 {
+  min-height: 3rem;
+  padding: 1rem;
+  background: #ffffff;
+  border-top: 0.25rem solid;
+  border-color: #ffffff;
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c10 {
+  width: 100%;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  font-family: Lexend,sans-serif;
+}
+
+.c5 {
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0rem;
+  background: #287c34;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: initial;
+  -webkit-justify-content: initial;
+  -ms-flex-pack: initial;
+  justify-content: initial;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.c8 {
+  color: #287c34;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c9 {
+  margin-top: 0.75rem;
+  font-family: Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c7 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  object-fit: contain;
+}
+
+.c2 {
+  box-sizing: content-box;
+}
+
+@media (min-width:750px) {
+  .c0 {
+    background: #ebfbeb;
+  }
+}
+
+@media (min-width:750px) {
+  .c10 {
+    width: auto;
+  }
+}
+
+@media (min-width:750px) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media (min-width:750px) {
+  .c11 {
+    -webkit-box-pack: end;
+    -webkit-justify-content: flex-end;
+    -ms-flex-pack: end;
+    justify-content: flex-end;
+  }
+}
+
+<div
+    className="c0 c1 c2"
   >
     <div
-      className="sc-aXZVg dPEvkO"
+      className="c3"
     >
       <div
-        className="sc-aXZVg sc-gEvEer dPEvkO lScBP"
+        className="c3 c4"
       >
         <div
-          className="sc-aXZVg gSLHXh"
+          className="c5"
         >
           <div
-            className="sc-aXZVg jnxfJj"
+            className="c6"
           >
             <img
               alt="tick"
-              className="sc-fqkvVR wpdFy"
+              className="c7"
               data-nimg="fill"
               decoding="async"
               loading="lazy"
@@ -104,39 +413,176 @@ exports[`OakQuizBottomNav matches snapshot 1`] = `
           </div>
         </div>
         <span
-          className="sc-eqUAAy fxSatT"
+          className="c8"
         >
           Correct
         </span>
       </div>
       <p
-        className="sc-eqUAAy csTXOv"
+        className="c9"
       >
         Well done!
       </p>
     </div>
     <div
-      className="sc-aXZVg sc-gEvEer bkGhTK kPptmY"
+      className="c10 c11"
     />
   </div>,
-  <div
-    className="sc-aXZVg sc-gEvEer sc-iHGNWf hctFYU iQpLSn clCXpd"
+  .c0 {
+  min-height: 3rem;
+  padding: 1rem;
+  background: #ffffff;
+  border-top: 0.25rem solid;
+  border-color: #ffffff;
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c10 {
+  width: 100%;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  font-family: Lexend,sans-serif;
+}
+
+.c5 {
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0rem;
+  background: #dd0035;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: initial;
+  -webkit-justify-content: initial;
+  -ms-flex-pack: initial;
+  justify-content: initial;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.c8 {
+  color: #dd0035;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c9 {
+  margin-top: 0.75rem;
+  font-family: Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c7 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  object-fit: contain;
+}
+
+.c2 {
+  box-sizing: content-box;
+}
+
+@media (min-width:750px) {
+  .c0 {
+    background: #ebfbeb;
+  }
+}
+
+@media (min-width:750px) {
+  .c10 {
+    width: auto;
+  }
+}
+
+@media (min-width:750px) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media (min-width:750px) {
+  .c11 {
+    -webkit-box-pack: end;
+    -webkit-justify-content: flex-end;
+    -ms-flex-pack: end;
+    justify-content: flex-end;
+  }
+}
+
+<div
+    className="c0 c1 c2"
   >
     <div
-      className="sc-aXZVg dPEvkO"
+      className="c3"
     >
       <div
-        className="sc-aXZVg sc-gEvEer dPEvkO lScBP"
+        className="c3 c4"
       >
         <div
-          className="sc-aXZVg hUutdO"
+          className="c5"
         >
           <div
-            className="sc-aXZVg jnxfJj"
+            className="c6"
           >
             <img
               alt="cross"
-              className="sc-fqkvVR wpdFy"
+              className="c7"
               data-nimg="fill"
               decoding="async"
               loading="lazy"
@@ -161,39 +607,176 @@ exports[`OakQuizBottomNav matches snapshot 1`] = `
           </div>
         </div>
         <span
-          className="sc-eqUAAy gOZZgo"
+          className="c8"
         >
           Incorrect
         </span>
       </div>
       <p
-        className="sc-eqUAAy kPsyPT"
+        className="c9"
       >
         Keep trying
       </p>
     </div>
     <div
-      className="sc-aXZVg sc-gEvEer bkGhTK kPptmY"
+      className="c10 c11"
     />
   </div>,
-  <div
-    className="sc-aXZVg sc-gEvEer sc-iHGNWf hctFYU iQpLSn clCXpd"
+  .c0 {
+  min-height: 3rem;
+  padding: 1rem;
+  background: #ffffff;
+  border-top: 0.25rem solid;
+  border-color: #ffffff;
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c10 {
+  width: 100%;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  font-family: Lexend,sans-serif;
+}
+
+.c5 {
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0rem;
+  background: #287c34;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: initial;
+  -webkit-justify-content: initial;
+  -ms-flex-pack: initial;
+  justify-content: initial;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.c8 {
+  color: #287c34;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c9 {
+  margin-top: 0.75rem;
+  font-family: Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c7 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  object-fit: contain;
+}
+
+.c2 {
+  box-sizing: content-box;
+}
+
+@media (min-width:750px) {
+  .c0 {
+    background: #ebfbeb;
+  }
+}
+
+@media (min-width:750px) {
+  .c10 {
+    width: auto;
+  }
+}
+
+@media (min-width:750px) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media (min-width:750px) {
+  .c11 {
+    -webkit-box-pack: end;
+    -webkit-justify-content: flex-end;
+    -ms-flex-pack: end;
+    justify-content: flex-end;
+  }
+}
+
+<div
+    className="c0 c1 c2"
   >
     <div
-      className="sc-aXZVg dPEvkO"
+      className="c3"
     >
       <div
-        className="sc-aXZVg sc-gEvEer dPEvkO lScBP"
+        className="c3 c4"
       >
         <div
-          className="sc-aXZVg gSLHXh"
+          className="c5"
         >
           <div
-            className="sc-aXZVg jnxfJj"
+            className="c6"
           >
             <img
               alt="tick"
-              className="sc-fqkvVR wpdFy"
+              className="c7"
               data-nimg="fill"
               decoding="async"
               loading="lazy"
@@ -218,19 +801,19 @@ exports[`OakQuizBottomNav matches snapshot 1`] = `
           </div>
         </div>
         <span
-          className="sc-eqUAAy fxSatT"
+          className="c8"
         >
           Correct
         </span>
       </div>
       <p
-        className="sc-eqUAAy csTXOv"
+        className="c9"
       >
         Nearly there
       </p>
     </div>
     <div
-      className="sc-aXZVg sc-gEvEer bkGhTK kPptmY"
+      className="c10 c11"
     />
   </div>,
 ]

--- a/src/components/integrated/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
+++ b/src/components/integrated/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
@@ -2,28 +2,266 @@
 
 exports[`OakQuizCheckBox matches snapshot 1`] = `
 [
-  <div
-    className="sc-aXZVg sc-gEvEer jBAFHB dnJeoC"
+  .c0 {
+  position: relative;
+  width: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  padding: 1.25rem;
+  background: #ffffff;
+  border-color: #222222;
+  border-radius: 0.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c2:hover {
+  cursor: pointer;
+}
+
+.c5 {
+  position: absolute;
+  top: 0rem;
+  left: 0rem;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c12 {
+  position: relative;
+  width: 2rem;
+  height: 2rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c16 {
+  position: absolute;
+  top: 0rem;
+  left: 0rem;
+  width: 2rem;
+  height: 2rem;
+  padding: 0.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c18 {
+  width: 100%;
+  height: 100%;
+  background: #222222;
+  font-family: Lexend,sans-serif;
+}
+
+.c19 {
+  width: 100%;
+  height: 100%;
+  border: 0.125rem solid;
+  border-color: #ffffff;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c8 {
+  font-family: Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+  color: #222222;
+}
+
+.c17 {
+  pointer-events: none;
+  opacity: 0;
+}
+
+input:checked + .c15 {
+  opacity: 1;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 1rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  cursor: pointer;
+}
+
+.c13 {
+  -webkit-appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  margin: 0;
+  outline: none;
+  border: 0.125rem solid;
+  border-color: #808080;
+  border-radius: 0.25rem;
+  width: 2rem;
+  height: 2rem;
+}
+
+.c13:disabled {
+  pointer-events: none;
+}
+
+.c14:checked:not(:disabled) {
+  border: 0.188rem solid;
+  border-color: #222222;
+}
+
+.c14:checked:disabled {
+  border: 0.188rem solid;
+  border-color: #808080;
+}
+
+.c11 {
+  pointer-events: none;
+}
+
+.c4:has(input:not(:disabled)) {
+  cursor: pointer;
+}
+
+.c4:has(input:disabled) {
+  pointer-events: none;
+  cursor: none;
+}
+
+.c6 {
+  pointer-events: none;
+}
+
+@media (hover:hover) {
+  .c10:hover {
+    -webkit-text-decoration: underline;
+    text-decoration: underline;
+  }
+}
+
+@media (hover:hover) {
+  .c14:hover:not(:disabled) {
+    background: #ffffff;
+  }
+}
+
+@media (hover:hover) {
+  .c4:hover:has(input:not(:disabled)) {
+    background-color: #dff9de;
+  }
+
+  .c4:hover input:not(:disabled) {
+    background: #ffffff;
+  }
+
+  .c4:hover:has(input:not(:disabled)) .c7 {
+    -webkit-text-decoration: underline;
+    text-decoration: underline;
+  }
+
+  .c4:hover:has( .c7 input:not(:focus-visible):not(:checked):not(:disabled) )::after {
+    content: "";
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    position: absolute;
+    border-bottom: 0.25rem solid;
+    border-radius: 0.5rem;
+  }
+
+  .c4 .yellow-shadow:has( + .c7 input:focus-visible ) {
+    box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
+  }
+
+  .c4 .grey-shadow:has( ~ .c7 input:focus-visible ) {
+    box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
+  }
+
+  .c4:has(input:checked:not(:disabled))::after {
+    content: "";
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    position: absolute;
+    border: 0.188rem solid;
+    border-radius: 0.5rem;
+  }
+
+  .c4:has(input:checked:disabled)::after {
+    content: "";
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    position: absolute;
+    border: 0.188rem solid;
+    border-radius: 0.5rem;
+    border-color: #808080;
+  }
+}
+
+<div
+    className="c0 c1"
   >
     <div
-      className="sc-aXZVg sc-gEvEer sc-ikkxIA cUJZzF ksSdnF fQHFKu"
+      className="c2 c3 c4"
       onClick={[Function]}
     >
       <div
-        className="sc-aXZVg sc-dAbbOL hzUdkx cyAgdo grey-shadow"
+        className="c5 c6 grey-shadow"
       />
       <div
-        className="sc-aXZVg sc-dAbbOL hzUdkx cyAgdo yellow-shadow"
+        className="c5 c6 yellow-shadow"
       />
       <label
-        className="sc-dAlyuH sc-cwHptR sc-jEACwC sc-gFqAkR gNoDGX fCdzRU ksabAH gerWxj"
+        className="c7 c8 c9 c10 c11"
         htmlFor="checkbox-1"
       >
         <div
-          className="sc-aXZVg gNRRHr"
+          className="c12"
         >
           <input
-            className="sc-cPiKLX sc-fPXMVe jugCJa gWbGHr"
+            className="c13 c14"
             disabled={false}
             id="checkbox-1"
             name="checkbox-1"
@@ -33,13 +271,13 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
             value="Option 1"
           />
           <div
-            className="sc-aXZVg sc-jlZhew hEtqXH nsmqb"
+            className="c15 c16 c17"
           >
             <div
-              className="sc-aXZVg foENXr"
+              className="c18"
             >
               <div
-                className="sc-aXZVg UZQif"
+                className="c19"
               />
             </div>
           </div>

--- a/src/components/integrated/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
+++ b/src/components/integrated/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
@@ -1,11 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakQuizCounter matches snapshot 1`] = `
+.c0 {
+  color: #808080;
+  font-family: Lexend,sans-serif;
+  font-weight: 400;
+  font-size: 2rem;
+  line-height: 2.5rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c1 {
+  color: #222222;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 2rem;
+  line-height: 2.5rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
 <span
-  className="sc-eqUAAy laHouJ"
+  className="c0"
 >
   <span
-    className="sc-eqUAAy cicTyP"
+    className="c1"
   >
     5
      

--- a/src/components/integrated/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
+++ b/src/components/integrated/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
@@ -2,21 +2,79 @@
 
 exports[`OakQuizFeedback matches snapshot 1`] = `
 [
-  <div
-    className="sc-aXZVg dPEvkO"
+  .c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0rem;
+  background: #287c34;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.c5 {
+  color: #287c34;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c6 {
+  margin-top: 0.75rem;
+  font-family: Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c4 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  object-fit: contain;
+}
+
+<div
+    className="c0"
   >
     <div
-      className="sc-aXZVg sc-gEvEer dPEvkO lScBP"
+      className="c0 c1"
     >
       <div
-        className="sc-aXZVg gSLHXh"
+        className="c2"
       >
         <div
-          className="sc-aXZVg jnxfJj"
+          className="c3"
         >
           <img
             alt="tick"
-            className="sc-dcJsrY eRtzRJ"
+            className="c4"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -41,32 +99,90 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
         </div>
       </div>
       <span
-        className="sc-eqUAAy fxSatT"
+        className="c5"
       >
         Correct
       </span>
     </div>
     <p
-      className="sc-eqUAAy csTXOv"
+      className="c6"
     >
       Well done!
     </p>
   </div>,
-  <div
-    className="sc-aXZVg dPEvkO"
+  .c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0rem;
+  background: #dd0035;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.c5 {
+  color: #dd0035;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c6 {
+  margin-top: 0.75rem;
+  font-family: Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c4 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  object-fit: contain;
+}
+
+<div
+    className="c0"
   >
     <div
-      className="sc-aXZVg sc-gEvEer dPEvkO lScBP"
+      className="c0 c1"
     >
       <div
-        className="sc-aXZVg hUutdO"
+        className="c2"
       >
         <div
-          className="sc-aXZVg jnxfJj"
+          className="c3"
         >
           <img
             alt="cross"
-            className="sc-dcJsrY eRtzRJ"
+            className="c4"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -91,32 +207,90 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
         </div>
       </div>
       <span
-        className="sc-eqUAAy gOZZgo"
+        className="c5"
       >
         Incorrect
       </span>
     </div>
     <p
-      className="sc-eqUAAy kPsyPT"
+      className="c6"
     >
       Keep trying
     </p>
   </div>,
-  <div
-    className="sc-aXZVg dPEvkO"
+  .c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0rem;
+  background: #287c34;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.c5 {
+  color: #287c34;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c6 {
+  margin-top: 0.75rem;
+  font-family: Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c4 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  object-fit: contain;
+}
+
+<div
+    className="c0"
   >
     <div
-      className="sc-aXZVg sc-gEvEer dPEvkO lScBP"
+      className="c0 c1"
     >
       <div
-        className="sc-aXZVg gSLHXh"
+        className="c2"
       >
         <div
-          className="sc-aXZVg jnxfJj"
+          className="c3"
         >
           <img
             alt="tick"
-            className="sc-dcJsrY eRtzRJ"
+            className="c4"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -141,13 +315,13 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
         </div>
       </div>
       <span
-        className="sc-eqUAAy fxSatT"
+        className="c5"
       >
         Correct
       </span>
     </div>
     <p
-      className="sc-eqUAAy csTXOv"
+      className="c6"
     >
       Nearly there
     </p>

--- a/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -2,28 +2,121 @@
 
 exports[`OakQuizHint matches snapshot 1`] = `
 [
-  <div
-    className="sc-aXZVg sc-gEvEer iBTklz dnJeoC"
+  .c0 {
+  position: relative;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c4 {
+  height: 3rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
+  width: 3rem;
+  height: 3rem;
+  padding: 0.25rem;
+  background: #ffe555;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c7 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.c9 {
+  color: #222222;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c8 {
+  object-fit: contain;
+}
+
+.c2 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  border-radius: 0.25rem;
+}
+
+.c2:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c3:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+<div
+    className="c0 c1"
   >
     <button
-      className="sc-jEACwC sc-eDPEul cxiCSm jIpyWh"
+      className="c2 c3"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       type="button"
     >
       <div
-        className="sc-aXZVg sc-gEvEer kEIIQV OzInM"
+        className="c4 c5"
       >
         <div
-          className="sc-aXZVg dNqVNp"
+          className="c6"
         >
           <div
-            className="sc-aXZVg jnxfJj"
+            className="c7"
           >
             <img
               alt=""
-              className="sc-fqkvVR kHVsCf"
+              className="c8"
               data-nimg="fill"
               decoding="async"
               loading="lazy"
@@ -48,7 +141,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
           </div>
         </div>
         <span
-          className="sc-eqUAAy bUYyl"
+          className="c9"
         >
           Need a hint?
         </span>

--- a/src/components/integrated/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
+++ b/src/components/integrated/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
@@ -1,27 +1,155 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakQuizRadioButton matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  padding: 1.25rem;
+  background: #ffffff;
+  border-radius: 0.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c0:hover {
+  cursor: pointer;
+}
+
+.c3 {
+  font-family: Lexend,sans-serif;
+}
+
+.c9 {
+  width: 2rem;
+  height: 2rem;
+  background: #ffffff;
+  border: 0.125rem solid;
+  border-color: #222222;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c4 {
+  font-family: Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c5 {
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 1rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.c11 {
+  border-radius: 50%;
+}
+
+.c6:checked ~ .c8::after {
+  content: "";
+  height: 1.5rem;
+  width: 1.5rem;
+  background: #222222;
+  position: absolute;
+  border-radius: 50%;
+  border: 0.125rem solid #ffffff;
+}
+
+.c2:hover {
+  cursor: pointer;
+}
+
+.c2:focus-within {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c2:hover {
+  background-color: #dff9de;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2:hover:not(:focus-within)::after {
+  pointer-events: none;
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 0.5rem;
+  border-bottom: 0.188rem solid #575757;
+}
+
 <div
-  className="sc-aXZVg sc-gEvEer sc-dLMFU bodKXD jLIaXR dulAEB"
+  className="c0 c1 c2"
   onClick={[Function]}
 >
   <div
-    className="sc-aXZVg dPEvkO"
+    className="c3"
   >
     <label
-      className="sc-dAlyuH sc-jlZhew fNvgLA epcIrp"
+      className="c4 c5"
       htmlFor="checkbox-1"
     >
       <input
         checked={false}
-        className="sc-cwHptR frvrbm"
+        className="c6 c7"
         id="checkbox-1"
         name="default"
         type="radio"
         value="Option 1"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC cSxuUX eIypJK iXjILk"
+        className="c8 c9 c10 c11"
       />
       Radio option
     </label>

--- a/src/components/integrated/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
+++ b/src/components/integrated/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
@@ -2,12 +2,116 @@
 
 exports[`OakQuizTextInput matches snapshot 1`] = `
 [
-  <div
-    className="sc-aXZVg sc-gEvEer sc-eeDRCY dyiMma ftzkJO chFYLu"
+  .c0 {
+  position: relative;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  color: #222222;
+  background: #ffffff;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c0:hover {
+  cursor: pointer;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+.c3 {
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  appearance: none !important;
+  border: 0;
+  border-radius: 0;
+  border-color: transparent;
+  box-shadow: none;
+  font-family: inherit;
+  background: transparent;
+  outline: none;
+  color: inherit;
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+  height: 4.5rem;
+}
+
+.c3::-webkit-input-placeholder {
+  color: #575757;
+}
+
+.c3::-moz-placeholder {
+  color: #575757;
+}
+
+.c3:-ms-input-placeholder {
+  color: #575757;
+}
+
+.c3::placeholder {
+  color: #575757;
+}
+
+.c3::-webkit-search-decoration,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button,
+.c3::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c3:disabled {
+  cursor: not-allowed;
+}
+
+.c2 {
+  background: #ffffff;
+}
+
+.c2:hover {
+  cursor: text;
+}
+
+.c2:focus-within {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+@media (max-width:750px) {
+  .c3 {
+    font-size: 16px;
+  }
+}
+
+@media (hover:hover) {
+  .c2:hover:not(:focus-within) {
+    background: #f2f2f2;
+  }
+}
+
+<div
+    className="c0 c1 c2"
     onClick={[Function]}
   >
     <input
-      className="sc-jsJBEP kpslra"
+      className="c3"
       defaultValue="An answer to a question"
       onFocus={[Function]}
       readOnly={false}

--- a/src/components/ui/InternalRectButton/__snapshots__/InternalRectButton.test.tsx.snap
+++ b/src/components/ui/InternalRectButton/__snapshots__/InternalRectButton.test.tsx.snap
@@ -1,31 +1,166 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalRectButton matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c5 {
+  font-family: Lexend,sans-serif;
+}
+
+.c7 {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.c9 {
+  font-family: Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c8 {
+  object-fit: contain;
+}
+
+.c3 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  color: #ebfbeb;
+  background: #bef2bd;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  border: 0.125rem solid;
+  border-color: #dff9de;
+  border-radius: 0.25rem;
+}
+
+.c3:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.c4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #f6e8a0;
+  background: #ffe555;
+  border-color: #fff7cc;
+}
+
+.c4:active {
+  background: #bef2bd;
+  border-color: #dff9de;
+  color: #ebfbeb;
+}
+
+.c4:disabled {
+  background: #f2f2f2;
+  border-color: #e4e4e4;
+  color: #cacaca;
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:hover) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:hover) {
+  box-shadow: none;
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:active) {
+  box-shadow: 0.3rem 0.3rem 0 rgba(87,87,87,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:active) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
 <div
-  className="sc-aXZVg sc-dLMFU gjBRlG hiGqQW button-wrapper"
+  className="c0 c1 button-wrapper"
 >
   <div
-    className="sc-aXZVg eMhXxX grey-shadow"
+    className="c2 grey-shadow"
   />
   <div
-    className="sc-aXZVg eMhXxX yellow-shadow"
+    className="c2 yellow-shadow"
   />
   <button
-    className="sc-jlZhew sc-cPiKLX uoQCU jgnbzH internal-button"
+    className="c3 c4 internal-button"
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
     type="button"
   >
     <div
-      className="sc-aXZVg sc-gEvEer dPEvkO joqyk"
+      className="c5 c6"
     >
       <div
-        className="sc-aXZVg cgcTZj"
+        className="c7"
       >
         <img
           alt="arrow-right"
-          className="sc-dcJsrY lrHNt"
+          className="c8"
           data-nimg="fill"
           decoding="async"
           loading="lazy"
@@ -49,7 +184,7 @@ exports[`InternalRectButton matches snapshot 1`] = `
         />
       </div>
       <span
-        className="sc-eqUAAy jHFWoD"
+        className="c9"
       >
         Click Me
       </span>

--- a/src/components/ui/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
+++ b/src/components/ui/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
@@ -1,18 +1,121 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakCheckBox matches snapshot 1`] = `
+.c4 {
+  -webkit-appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  margin: 0;
+  outline: none;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.125rem;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.c4:checked {
+  background: #222222;
+}
+
+.c4:disabled {
+  pointer-events: none;
+}
+
+.c6:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
+}
+
+.c2 {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c8 {
+  position: absolute;
+  top: 0rem;
+  left: 0rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c10 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c11 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  object-fit: contain;
+}
+
+.c0 {
+  font-family: Lexend,sans-serif;
+  color: #222222;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 1rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
+  pointer-events: none;
+  opacity: 0;
+}
+
+input:checked + .c7 {
+  opacity: 1;
+}
+
+@media (hover:hover) {
+  .c5:hover:not(.c3:checked):not(.c3:disabled)::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 60%;
+    height: 60%;
+    -webkit-transform: translate(-50%,-50%);
+    -ms-transform: translate(-50%,-50%);
+    transform: translate(-50%,-50%);
+    border-radius: 0.125rem;
+    background: #222222;
+  }
+}
+
 <label
-  className="sc-cPiKLX sc-dLMFU drolBn dxcRFk"
+  className="c0 c1"
   disabled={false}
   htmlFor="checkbox-1"
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >
   <div
-    className="sc-dcJsrY hwgOs"
+    className="c2"
   >
     <input
-      className="sc-aXZVg sc-gEvEer sc-fqkvVR eapjSX gLsbmo tJZSL"
+      className="c3 c4 c5 c6"
       defaultChecked={false}
       disabled={false}
       id="checkbox-1"
@@ -23,14 +126,14 @@ exports[`OakCheckBox matches snapshot 1`] = `
       value="Option 1"
     />
     <div
-      className="sc-dcJsrY sc-eldPxv dUhKlF cCzUhO"
+      className="c7 c8 c9"
     >
       <div
-        className="sc-dcJsrY cOkRUk"
+        className="c10"
       >
         <img
           alt="tick"
-          className="sc-imWYAI riIre"
+          className="c11"
           data-nimg="fill"
           decoding="async"
           loading="lazy"

--- a/src/components/ui/OakLoadingSpinner/__snapshots__/OakLoadingSpinner.test.tsx.snap
+++ b/src/components/ui/OakLoadingSpinner/__snapshots__/OakLoadingSpinner.test.tsx.snap
@@ -1,11 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakLoadingSpinner matches snapshot 1`] = `
+.c1 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.c0 {
+  --width: 1.25rem;
+  --inner-width: calc(var(--width) / 10 * 8);
+  --thickness: calc(var(--width) / 12);
+  position: absolute;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: var(--width);
+  height: var(--width);
+}
+
+.c0::after {
+  content: " ";
+  display: block;
+  width: var(--inner-width);
+  height: var(--inner-width);
+  margin: var(--thickness);
+  border-radius: 50%;
+  border: var(--thickness) solid currentcolor;
+  border-color: currentcolor currentcolor currentcolor transparent;
+  -webkit-animation: epmXAj 1.2s linear infinite;
+  animation: epmXAj 1.2s linear infinite;
+}
+
 <span
-  className="sc-gEvEer eNhdgU"
+  className="c0"
 >
   <span
-    className="sc-aXZVg gDZdFS"
+    className="c1"
   >
     Loading
   </span>

--- a/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -1,31 +1,168 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPrimaryButton matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c5 {
+  font-family: Lexend,sans-serif;
+}
+
+.c7 {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.c9 {
+  font-family: Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c8 {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  object-fit: contain;
+}
+
+.c3 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  color: #ffffff;
+  background: #222222;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.25rem;
+}
+
+.c3:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.c4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #ffffff;
+  background: #575757;
+  border-color: #575757;
+}
+
+.c4:active {
+  background: #222222;
+  border-color: #222222;
+  color: #ffffff;
+}
+
+.c4:disabled {
+  background: #808080;
+  border-color: #808080;
+  color: #ffffff;
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:hover) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:hover) {
+  box-shadow: none;
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:active) {
+  box-shadow: 0.3rem 0.3rem 0 rgba(87,87,87,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:active) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
 <div
-  className="sc-aXZVg sc-dLMFU gjBRlG hiGqQW button-wrapper"
+  className="c0 c1 button-wrapper"
 >
   <div
-    className="sc-aXZVg eMhXxX grey-shadow"
+    className="c2 grey-shadow"
   />
   <div
-    className="sc-aXZVg eMhXxX yellow-shadow"
+    className="c2 yellow-shadow"
   />
   <button
-    className="sc-jlZhew sc-cPiKLX fwbIkR kLPvZM internal-button"
+    className="c3 c4 internal-button"
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
     type="button"
   >
     <div
-      className="sc-aXZVg sc-gEvEer dPEvkO joqyk"
+      className="c5 c6"
     >
       <div
-        className="sc-aXZVg cgcTZj"
+        className="c7"
       >
         <img
           alt="arrow-right"
-          className="sc-dcJsrY eRtzRJ"
+          className="c8"
           data-nimg="fill"
           decoding="async"
           loading="lazy"
@@ -49,7 +186,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
         />
       </div>
       <span
-        className="sc-eqUAAy jHFWoD"
+        className="c9"
       >
         Click Me
       </span>

--- a/src/components/ui/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
+++ b/src/components/ui/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
@@ -1,24 +1,127 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RadioGroup matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  color: #222222;
+  font-family: Lexend,sans-serif;
+}
+
+.c8 {
+  width: 1.5rem;
+  height: 1.5rem;
+  background: #ffffff;
+  border: 0.125rem solid;
+  border-color: #222222;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 1rem;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c2 {
+  font-family: Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c4 {
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 1.5rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.c10 {
+  border-radius: 50%;
+}
+
+.c5:focus-visible ~ .c7::before {
+  content: "";
+  height: 2rem;
+  width: 2rem;
+  background: "transparent" display:block;
+  position: absolute;
+  border-radius: 50%;
+  border: 0.125rem solid #575757;
+  box-shadow: inset 0 0 0 0.13rem #ffe555;
+}
+
+.c5:checked ~ .c7::after {
+  content: "";
+  height: 1rem;
+  width: 1rem;
+  background: #222222;
+  position: absolute;
+  border-radius: 50%;
+  border: 0.125rem solid #ffffff;
+}
+
 <div
-  className="sc-aXZVg sc-gEvEer dPEvkO hnMCey"
+  className="c0 c1"
   role="radiogroup"
 >
   <label
-    className="sc-dAlyuH bwhjDg"
+    className="c2"
   />
   <div
-    className="sc-aXZVg cCcRch"
+    className="c3"
   >
     <label
-      className="sc-dAlyuH sc-jlZhew bwhjDg izhUcW"
+      className="c2 c4"
       data-testid="radio-1"
       htmlFor="radio-1"
     >
       <input
         checked={false}
-        className="sc-cwHptR frvrbm"
+        className="c5 c6"
         id="radio-1"
         name="test"
         onChange={[Function]}
@@ -26,21 +129,21 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="1"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC kbYGZT eIypJK estjvb"
+        className="c7 c8 c9 c10"
       />
       Option 1
     </label>
   </div>
   <div
-    className="sc-aXZVg cCcRch"
+    className="c3"
   >
     <label
-      className="sc-dAlyuH sc-jlZhew bwhjDg izhUcW"
+      className="c2 c4"
       htmlFor="radio-2"
     >
       <input
         checked={false}
-        className="sc-cwHptR frvrbm"
+        className="c5 c6"
         id="radio-2"
         name="test"
         onChange={[Function]}
@@ -48,21 +151,21 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="2"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC kbYGZT eIypJK estjvb"
+        className="c7 c8 c9 c10"
       />
       Option 2
     </label>
   </div>
   <div
-    className="sc-aXZVg cCcRch"
+    className="c3"
   >
     <label
-      className="sc-dAlyuH sc-jlZhew bwhjDg izhUcW"
+      className="c2 c4"
       htmlFor="radio-3"
     >
       <input
         checked={false}
-        className="sc-cwHptR frvrbm"
+        className="c5 c6"
         id="radio-3"
         name="test"
         onChange={[Function]}
@@ -70,7 +173,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="3"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC kbYGZT eIypJK estjvb"
+        className="c7 c8 c9 c10"
       />
       Option 3
     </label>

--- a/src/components/ui/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
+++ b/src/components/ui/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
@@ -1,24 +1,127 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RadioGroup matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  color: #222222;
+  font-family: Lexend,sans-serif;
+}
+
+.c8 {
+  width: 1.5rem;
+  height: 1.5rem;
+  background: #ffffff;
+  border: 0.125rem solid;
+  border-color: #222222;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 1rem;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c2 {
+  font-family: Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c4 {
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 1.5rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.c10 {
+  border-radius: 50%;
+}
+
+.c5:focus-visible ~ .c7::before {
+  content: "";
+  height: 2rem;
+  width: 2rem;
+  background: "transparent" display:block;
+  position: absolute;
+  border-radius: 50%;
+  border: 0.125rem solid #575757;
+  box-shadow: inset 0 0 0 0.13rem #ffe555;
+}
+
+.c5:checked ~ .c7::after {
+  content: "";
+  height: 1rem;
+  width: 1rem;
+  background: #222222;
+  position: absolute;
+  border-radius: 50%;
+  border: 0.125rem solid #ffffff;
+}
+
 <div
-  className="sc-aXZVg sc-gEvEer dPEvkO hnMCey"
+  className="c0 c1"
   role="radiogroup"
 >
   <label
-    className="sc-dAlyuH bwhjDg"
+    className="c2"
   />
   <div
-    className="sc-aXZVg cCcRch"
+    className="c3"
   >
     <label
-      className="sc-dAlyuH sc-jlZhew bwhjDg izhUcW"
+      className="c2 c4"
       data-testid="radio-1"
       htmlFor="radio-1"
     >
       <input
         checked={false}
-        className="sc-cwHptR frvrbm"
+        className="c5 c6"
         id="radio-1"
         name="test"
         onChange={[Function]}
@@ -26,21 +129,21 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="1"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC kbYGZT eIypJK estjvb"
+        className="c7 c8 c9 c10"
       />
       Option 1
     </label>
   </div>
   <div
-    className="sc-aXZVg cCcRch"
+    className="c3"
   >
     <label
-      className="sc-dAlyuH sc-jlZhew bwhjDg izhUcW"
+      className="c2 c4"
       htmlFor="radio-2"
     >
       <input
         checked={false}
-        className="sc-cwHptR frvrbm"
+        className="c5 c6"
         id="radio-2"
         name="test"
         onChange={[Function]}
@@ -48,21 +151,21 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="2"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC kbYGZT eIypJK estjvb"
+        className="c7 c8 c9 c10"
       />
       Option 2
     </label>
   </div>
   <div
-    className="sc-aXZVg cCcRch"
+    className="c3"
   >
     <label
-      className="sc-dAlyuH sc-jlZhew bwhjDg izhUcW"
+      className="c2 c4"
       htmlFor="radio-3"
     >
       <input
         checked={false}
-        className="sc-cwHptR frvrbm"
+        className="c5 c6"
         id="radio-3"
         name="test"
         onChange={[Function]}
@@ -70,7 +173,7 @@ exports[`RadioGroup matches snapshot 1`] = `
         value="3"
       />
       <div
-        className="sc-aXZVg sc-gEvEer sc-jEACwC kbYGZT eIypJK estjvb"
+        className="c7 c8 c9 c10"
       />
       Option 3
     </label>

--- a/src/components/ui/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
+++ b/src/components/ui/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
@@ -1,15 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakRoundIcon matches snapshot 1`] = `
+.c0 {
+  width: 3rem;
+  height: 3rem;
+  padding: 0.25rem;
+  background: #ffe555;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  object-fit: contain;
+}
+
 <div
-  className="sc-aXZVg dNqVNp"
+  className="c0"
 >
   <div
-    className="sc-aXZVg jnxfJj"
+    className="c1"
   >
     <img
       alt="home"
-      className="sc-dcJsrY iNyGVc"
+      className="c2"
       data-nimg="fill"
       decoding="async"
       loading="lazy"

--- a/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -1,31 +1,168 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSecondaryButton matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c5 {
+  font-family: Lexend,sans-serif;
+}
+
+.c7 {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.c9 {
+  font-family: Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c8 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  object-fit: contain;
+}
+
+.c3 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  color: #222222;
+  background: #ffffff;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.25rem;
+}
+
+.c3:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.c4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #222222;
+  background: #f2f2f2;
+  border-color: #222222;
+}
+
+.c4:active {
+  background: #ffffff;
+  border-color: #222222;
+  color: #222222;
+}
+
+.c4:disabled {
+  background: #e4e4e4;
+  border-color: #808080;
+  color: #808080;
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:hover) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:hover) {
+  box-shadow: none;
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:active) {
+  box-shadow: 0.3rem 0.3rem 0 rgba(87,87,87,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:active) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
 <div
-  className="sc-aXZVg sc-dLMFU gjBRlG hiGqQW button-wrapper"
+  className="c0 c1 button-wrapper"
 >
   <div
-    className="sc-aXZVg eMhXxX grey-shadow"
+    className="c2 grey-shadow"
   />
   <div
-    className="sc-aXZVg eMhXxX yellow-shadow"
+    className="c2 yellow-shadow"
   />
   <button
-    className="sc-jlZhew sc-cPiKLX ezcxpx cPqGbd internal-button"
+    className="c3 c4 internal-button"
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
     type="button"
   >
     <div
-      className="sc-aXZVg sc-gEvEer dPEvkO joqyk"
+      className="c5 c6"
     >
       <div
-        className="sc-aXZVg cgcTZj"
+        className="c7"
       >
         <img
           alt="arrow-right"
-          className="sc-dcJsrY giMUDV"
+          className="c8"
           data-nimg="fill"
           decoding="async"
           loading="lazy"
@@ -49,7 +186,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
         />
       </div>
       <span
-        className="sc-eqUAAy jHFWoD"
+        className="c9"
       >
         Click Me
       </span>

--- a/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -1,18 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTertiaryButton matches snapshot 1`] = `
+.c2 {
+  height: 3rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.c4 {
+  color: #222222;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c0 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  border-radius: 0.25rem;
+}
+
+.c0:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c1:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
 <button
-  className="sc-jlZhew sc-cwHptR dtToJh hkrMvC"
+  className="c0 c1"
   onClick={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
   type="button"
 >
   <div
-    className="sc-aXZVg sc-gEvEer kEIIQV OzInM"
+    className="c2 c3"
   >
     <span
-      className="sc-eqUAAy bUYyl"
+      className="c4"
     >
       Click Me
     </span>

--- a/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -2,12 +2,116 @@
 
 exports[`OakTextInput matches snapshot 1`] = `
 [
-  <div
-    className="sc-gEvEer sc-eqUAAy sc-cwHptR hEQZUC kUreFU bmxVLQ"
+  .c3 {
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  appearance: none !important;
+  border: 0;
+  border-radius: 0;
+  border-color: transparent;
+  box-shadow: none;
+  font-family: inherit;
+  background: transparent;
+  outline: none;
+  color: inherit;
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+  height: 4.5rem;
+}
+
+.c3::-webkit-input-placeholder {
+  color: #575757;
+}
+
+.c3::-moz-placeholder {
+  color: #575757;
+}
+
+.c3:-ms-input-placeholder {
+  color: #575757;
+}
+
+.c3::placeholder {
+  color: #575757;
+}
+
+.c3::-webkit-search-decoration,
+.c3::-webkit-search-cancel-button,
+.c3::-webkit-search-results-button,
+.c3::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.c3:disabled {
+  cursor: not-allowed;
+}
+
+.c0 {
+  position: relative;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  color: #222222;
+  background: #ffffff;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c0:hover {
+  cursor: pointer;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+.c2 {
+  background: #ffffff;
+}
+
+.c2:hover {
+  cursor: text;
+}
+
+.c2:focus-within {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+@media (max-width:750px) {
+  .c3 {
+    font-size: 16px;
+  }
+}
+
+@media (hover:hover) {
+  .c2:hover:not(:focus-within) {
+    background: #f2f2f2;
+  }
+}
+
+<div
+    className="c0 c1 c2"
     onClick={[Function]}
   >
     <input
-      className="sc-aXZVg htVdEQ"
+      className="c3"
       defaultValue="A nice text value"
       onFocus={[Function]}
       type="text"

--- a/src/components/ui/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
+++ b/src/components/ui/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
@@ -1,19 +1,100 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTooltip matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  position: absolute;
+  top: 0rem;
+  left: 0rem;
+  -webkit-transform: translateY(calc(-100% - 16px));
+  -ms-transform: translateY(calc(-100% - 16px));
+  transform: translateY(calc(-100% - 16px));
+  font-family: Lexend,sans-serif;
+  z-index: 300;
+}
+
+.c4 {
+  position: relative;
+  max-width: 22.5rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  color: #222222;
+  background: #ffe555;
+  border-bottom-right-radius: 0.5rem;
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+  font-family: Lexend,sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  pointer-events: none;
+}
+
+.c6 {
+  position: absolute;
+  bottom: -16px;
+  left: 0;
+  fill: #ffe555;
+}
+
+@media (min-width:750px) {
+  .c4 {
+    max-width: 40rem;
+  }
+}
+
 <div
-  className="sc-aXZVg sc-gEvEer iBTklz dnJeoC"
+  className="c0 c1"
 >
   <div
-    className="sc-aXZVg sc-gEvEer cBEgJK iQgtgu"
+    className="c2 c3"
     role="tooltip"
   >
     <div
-      className="sc-aXZVg sc-gEvEer sc-eqUAAy xkKAF dnJeoC hYnrwb"
+      className="c4 c1 c5"
     >
       Hello there
       <svg
-        className="sc-fqkvVR kgkVhH"
+        className="c6"
         height="16"
         width="16"
       >

--- a/src/test-helpers/setupTests.ts
+++ b/src/test-helpers/setupTests.ts
@@ -1,0 +1,1 @@
+import "jest-styled-components";


### PR DESCRIPTION
Improves the snapshot testing experience by adding the ability to see styles in the snapshots instead of relying on non-deterministic class names.