### PR TITLE
fix(PUPIL-269) Align radio and checkbox styles

### DIFF
--- a/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.tsx
+++ b/src/components/integrated/OakQuizCheckBox/OakQuizCheckBox.tsx
@@ -102,7 +102,7 @@ const StyledFlexBox = styled(OakFlex)<StyledFlexBoxProps>`
       height: 100%;
       pointer-events: none;
       position: absolute;
-      border: ${parseBorder("border-solid-l")};
+      outline: ${parseBorder("border-solid-xl")};
       border-radius: ${parseBorderRadius("border-radius-m2")};
    }
 
@@ -114,9 +114,9 @@ const StyledFlexBox = styled(OakFlex)<StyledFlexBoxProps>`
       height: 100%;
       pointer-events: none;
       position: absolute;
-      border: ${parseBorder("border-solid-l")};
+      outline: ${parseBorder("border-solid-xl")};
       border-radius: ${parseBorderRadius("border-radius-m2")};
-      border-color: ${(props) => css`
+      outline-color: ${(props) => css`
         ${parseColor(props.overlayBorderColor ?? "text-disabled")}
       `};
   }

--- a/src/components/integrated/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
+++ b/src/components/integrated/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
@@ -222,7 +222,7 @@ input:checked + .c15 {
     height: 100%;
     pointer-events: none;
     position: absolute;
-    border: 0.188rem solid;
+    outline: 0.25rem solid;
     border-radius: 0.5rem;
   }
 
@@ -234,9 +234,9 @@ input:checked + .c15 {
     height: 100%;
     pointer-events: none;
     position: absolute;
-    border: 0.188rem solid;
+    outline: 0.25rem solid;
     border-radius: 0.5rem;
-    border-color: #808080;
+    outline-color: #808080;
   }
 }
 


### PR DESCRIPTION
This ensures that the `border-radius` for `OakQuizCheckbox` is applied inside the border
(as it is in Figma). This also ensures that the border does not subtract
from the width and height of the container so the layout is not impacted.

The other option is to switch to `content-box` and play with negative
margins which no one wants to do.

<img width="1011" alt="Screenshot 2024-01-15 at 12 09 33" src="https://github.com/oaknational/oak-components/assets/122096/415226bc-eaa8-4173-b323-94fa9a40f598">

<img width="1002" alt="Screenshot 2024-01-15 at 12 10 04" src="https://github.com/oaknational/oak-components/assets/122096/b35337c6-7162-469b-b73d-d0232ebb6595">

<img width="421" alt="Screenshot 2024-01-15 at 12 11 03" src="https://github.com/oaknational/oak-components/assets/122096/f7187de5-a65b-458a-b8f3-a0fd781803b5">

