### PR TITLE
feat(PUPIL-256): add `OakBackLink` component

### DIFF
--- a/src/components/ui/OakBackLink/OakBackLink.stories.tsx
+++ b/src/components/ui/OakBackLink/OakBackLink.stories.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakBackLink } from "./OakBackLink";
+
+const meta: Meta<typeof OakBackLink> = {
+  component: OakBackLink,
+  tags: ["autodocs"],
+  title: "components/ui/OakBackLink",
+  args: {
+    href: "#",
+  },
+  parameters: {
+    controls: {
+      include: [],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof OakBackLink>;
+
+export const Default: Story = {
+  render: (args) => <OakBackLink {...args} />,
+};
+
+export const DisabledButton: Story = {
+  render: () => <OakBackLink as="button" disabled />,
+};

--- a/src/components/ui/OakBackLink/OakBackLink.test.tsx
+++ b/src/components/ui/OakBackLink/OakBackLink.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+import { ThemeProvider } from "styled-components";
+
+import { OakBackLink } from "./OakBackLink";
+
+import { oakDefaultTheme } from "@/styles";
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+
+describe(OakBackLink, () => {
+  it("renders", () => {
+    const { queryByRole } = renderWithTheme(<OakBackLink href="#" />);
+
+    expect(queryByRole("link")).toBeInTheDocument();
+  });
+
+  it("matches snapshot", () => {
+    const tree = create(
+      <ThemeProvider theme={oakDefaultTheme}>
+        <OakBackLink />
+      </ThemeProvider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("is polymorphic", () => {
+    const { queryByRole } = renderWithTheme(<OakBackLink as="button" />);
+
+    expect(queryByRole("button")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/OakBackLink/OakBackLink.tsx
+++ b/src/components/ui/OakBackLink/OakBackLink.tsx
@@ -1,0 +1,84 @@
+import React, { ElementType, ComponentPropsWithoutRef } from "react";
+import styled from "styled-components";
+
+import { parseColor } from "@/styles/helpers/parseColor";
+import { parseColorFilter } from "@/styles/helpers/parseColorFilter";
+import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
+import { OakIcon } from "@/components/base";
+
+export type OakBackLinkProps<C extends ElementType> = {
+  as?: C;
+  label?: string;
+} & ComponentPropsWithoutRef<C>;
+
+const StyledBackLink = styled.a`
+  border-radius: 50%;
+  display: flex;
+  width: fit-content;
+  height: fit-content;
+  border: none;
+  padding: 0;
+  outline: none;
+
+  img {
+    pointer-events: none;
+  }
+
+  &:not(:disabled) {
+    cursor: pointer;
+  }
+
+  &:active {
+    box-shadow: ${parseDropShadow("drop-shadow-yellow")},
+      ${parseDropShadow("drop-shadow-grey")};
+  }
+
+  &:hover,
+  &:focus-visible {
+    background: ${parseColor("bg-btn-primary")};
+
+    img {
+      filter: ${parseColorFilter("text-inverted")};
+    }
+  }
+
+  &:focus-visible {
+    box-shadow: ${parseDropShadow("drop-shadow-centered-yellow")},
+      ${parseDropShadow("drop-shadow-centered-grey")};
+  }
+
+  &:disabled {
+    background: ${parseColor("bg-btn-primary-disabled")};
+
+    img {
+      filter: ${parseColorFilter("text-inverted")};
+    }
+  }
+`;
+
+/**
+ * Used to navigate the user back to the previous page in the app.
+ *
+ * Polymorphic rendering as any HTML element or component using `as` — defaults to `a`.
+ *
+ * E.g.
+ *
+ * * Default (Anchor) `<OakBackLink href="https://www.thenational.academy/" />`
+ * * Button `<OakBackLink as="button" onClick={() => goBack(-1)} />`
+ */
+export const OakBackLink = <C extends ElementType = "a">({
+  as,
+  label = "Back",
+  ...props
+}: OakBackLinkProps<C>) => {
+  return (
+    <StyledBackLink as={as ?? "a"} aria-label={label} {...props}>
+      <OakIcon
+        alt=""
+        iconName="chevron-left"
+        $width="all-spacing-8"
+        $height="all-spacing-8"
+      />
+    </StyledBackLink>
+  );
+};

--- a/src/components/ui/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
+++ b/src/components/ui/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakBackLink matches snapshot 1`] = `
+.c1 {
+  position: relative;
+  width: 2.5rem;
+  height: 2.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  object-fit: contain;
+}
+
+.c0 {
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  border: none;
+  padding: 0;
+  outline: none;
+}
+
+.c0 img {
+  pointer-events: none;
+}
+
+.c0:not(:disabled) {
+  cursor: pointer;
+}
+
+.c0:active {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.3rem 0.3rem 0 rgba(87,87,87,100%);
+}
+
+.c0:hover,
+.c0:focus-visible {
+  background: #222222;
+}
+
+.c0:hover img,
+.c0:focus-visible img {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+}
+
+.c0:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c0:disabled {
+  background: #808080;
+}
+
+.c0:disabled img {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+}
+
+<a
+  aria-label="Back"
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <img
+      alt=""
+      className="c2"
+      data-nimg="fill"
+      decoding="async"
+      loading="lazy"
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://undefined/undefined/v1699953962/icons/xpp10hijwzhyeqt6ylqf.svg"
+      style={
+        {
+          "bottom": 0,
+          "color": "transparent",
+          "height": "100%",
+          "left": 0,
+          "objectFit": undefined,
+          "objectPosition": undefined,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "width": "100%",
+        }
+      }
+    />
+  </div>
+</a>
+`;

--- a/src/components/ui/OakBackLink/index.tsx
+++ b/src/components/ui/OakBackLink/index.tsx
@@ -1,0 +1,1 @@
+export * from "./OakBackLink";

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,3 +9,4 @@ export * from "./OakCheckBox";
 export * from "./OakTextInput";
 export * from "./OakRoundIcon";
 export * from "./OakTooltip";
+export * from "./OakBackLink";


### PR DESCRIPTION
a button or link to navigate back to the previous page in the user's journey. This component will initially be used in the top nav for the pupil lesson flow.

Storybook 👉🏼  https://deploy-preview-66--lively-meringue-8ebd43.netlify.app/?path=/docs/components-ui-oakbacklink--docs


<img width="1123" alt="Screenshot 2024-01-16 at 11 28 28" src="https://github.com/oaknational/oak-components/assets/122096/0f4ab320-d0b6-4188-9d58-44ff1bd30bc4">


