### PR TITLE
feat(PUPIL-229): add `OakLessonTopNav` component

### DIFF
--- a/src/components/base/OakIcon/OakIcon.tsx
+++ b/src/components/base/OakIcon/OakIcon.tsx
@@ -52,9 +52,7 @@ export const oakIconNames = [
   "warning",
   "lightbulb",
   "lightbulb-yellow",
-  "signed-video-4",
-  "video-3",
-  "quiz-6",
+  "intro",
 ] as const;
 
 export type OakIconName = (typeof oakIconNames)[number];

--- a/src/components/base/OakIcon/OakIcon.tsx
+++ b/src/components/base/OakIcon/OakIcon.tsx
@@ -52,6 +52,9 @@ export const oakIconNames = [
   "warning",
   "lightbulb",
   "lightbulb-yellow",
+  "signed-video-4",
+  "video-3",
+  "quiz-6",
 ] as const;
 
 export type OakIconName = (typeof oakIconNames)[number];

--- a/src/components/integrated/OakLessonTopNav/OakLessonTopNav.stories.tsx
+++ b/src/components/integrated/OakLessonTopNav/OakLessonTopNav.stories.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakQuizCounter } from "../OakQuizCounter";
+
+import { OakLessonTopNav } from "./OakLessonTopNav";
+
+import { OakFlex } from "@/components/base";
+import { OakBackLink } from "@/components/ui";
+
+const meta: Meta<typeof OakLessonTopNav> = {
+  component: OakLessonTopNav,
+  tags: ["autodocs"],
+  title: "components/integrated/OakLessonTopNav",
+  decorators: [
+    (Story) => (
+      <OakFlex
+        $mt="space-between-xl"
+        $flexDirection="column"
+        $gap="space-between-m"
+      >
+        <Story />
+      </OakFlex>
+    ),
+  ],
+  argTypes: {
+    heading: {
+      control: { type: "text" },
+    },
+    mobileSummary: {
+      control: { type: "text" },
+    },
+  },
+  args: {
+    lessonSectionName: "intro",
+    heading: "Intro",
+    mobileSummary: "Introduction to the lesson",
+    backLinkSlot: <OakBackLink type="button" />,
+  },
+  parameters: {
+    controls: {
+      include: ["lessonSectionName", "heading", "mobileSummary"],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof OakLessonTopNav>;
+
+export const Default: Story = {
+  render: (args) => <OakLessonTopNav {...args} />,
+};
+
+export const WithCounter: Story = {
+  render: (args) => (
+    <OakLessonTopNav
+      {...args}
+      lessonSectionName="starter-quiz"
+      heading="Starter quiz"
+      mobileSummary="Question 4 of 6"
+      counterSlot={<OakQuizCounter counter={4} total={6} />}
+    />
+  ),
+};

--- a/src/components/integrated/OakLessonTopNav/OakLessonTopNav.test.tsx
+++ b/src/components/integrated/OakLessonTopNav/OakLessonTopNav.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+
+import { OakLessonTopNav, OakLessonTopNavProps } from "./OakLessonTopNav";
+
+import { OakThemeProvider } from "@/components/base";
+import { oakDefaultTheme } from "@/styles";
+import { OakBackLink } from "@/components/ui";
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+
+const baseProps: OakLessonTopNavProps = {
+  lessonSectionName: "intro",
+  heading: "Intro",
+  backLinkSlot: <OakBackLink type="button" />,
+  mobileSummary: "In progress&hellip;",
+};
+
+describe(OakLessonTopNav, () => {
+  it("matches snapshot", () => {
+    const tree = create(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakLessonTopNav {...baseProps} />
+      </OakThemeProvider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders the back link", async () => {
+    const { getByRole } = renderWithTheme(
+      <OakLessonTopNav
+        {...baseProps}
+        backLinkSlot={<OakBackLink href="#" />}
+      />,
+    );
+
+    expect(getByRole("link").getAttribute("href")).toEqual("#");
+  });
+
+  it("renders the optional count", async () => {
+    const { queryByText } = renderWithTheme(
+      <OakLessonTopNav {...baseProps} counterSlot={<div>4 of 6</div>} />,
+    );
+
+    expect(queryByText("4 of 6")).toBeInTheDocument();
+  });
+});

--- a/src/components/integrated/OakLessonTopNav/OakLessonTopNav.tsx
+++ b/src/components/integrated/OakLessonTopNav/OakLessonTopNav.tsx
@@ -1,0 +1,100 @@
+import React, { ReactNode } from "react";
+import styled from "styled-components";
+
+import {
+  OakBox,
+  OakFlex,
+  OakHeading,
+  OakIconProps,
+  OakSpan,
+} from "@/components/base";
+import { OakRoundIcon } from "@/components/ui";
+import { getBreakpoint } from "@/styles/utils/responsiveStyle";
+
+type LessonSectionName = "intro" | "starter-quiz" | "video" | "exit-quiz";
+
+const StyledMobileSummary = styled(OakSpan)`
+  @media (min-width: ${getBreakpoint("small")}px) {
+    display: none;
+  }
+`;
+
+export type OakLessonTopNavProps = {
+  lessonSectionName: LessonSectionName;
+  /**
+   * Slot to render `OakBackLink` or similar
+   */
+  backLinkSlot: ReactNode;
+  heading: ReactNode;
+  /**
+   * Displayed at the mobile breakpoint where the counter is not rendered.
+   * Provides alternative content for the counter/progress in the lesson.
+   */
+  mobileSummary: ReactNode;
+  /**
+   * Slot to render `OakQuizCounter` or similar
+   */
+  counterSlot?: ReactNode;
+};
+
+/**
+ * Controls for navigating back and displaying progress in a lesson
+ */
+export const OakLessonTopNav = ({
+  lessonSectionName,
+  backLinkSlot,
+  counterSlot,
+  heading,
+  mobileSummary,
+}: OakLessonTopNavProps) => {
+  return (
+    <OakFlex $gap="space-between-m" $alignItems="center">
+      {backLinkSlot}
+      <OakFlex $flexGrow="none">
+        <OakRoundIcon
+          {...pickSectionIcon(lessonSectionName)}
+          $width="all-spacing-8"
+          $height="all-spacing-8"
+        />
+      </OakFlex>
+      <OakBox>
+        <OakHeading tag="h1" $font={["heading-7", "heading-5"]}>
+          {heading}
+        </OakHeading>
+        <StyledMobileSummary $font="body-3">
+          {mobileSummary}
+        </StyledMobileSummary>
+      </OakBox>
+      <OakFlex $flexGrow={1} $justifyContent="flex-end">
+        <OakBox $display={["none", "block"]}>{counterSlot}</OakBox>
+      </OakFlex>
+    </OakFlex>
+  );
+};
+
+function pickSectionIcon(
+  sectionName: LessonSectionName,
+): Pick<OakIconProps, "iconName" | "$background"> {
+  switch (sectionName) {
+    case "intro":
+      return {
+        iconName: "signed-video-4",
+        $background: "aqua110",
+      };
+    case "starter-quiz":
+      return {
+        iconName: "quiz-6",
+        $background: "mint110",
+      };
+    case "video":
+      return {
+        iconName: "video-3",
+        $background: "pink110",
+      };
+    case "exit-quiz":
+      return {
+        iconName: "quiz-6",
+        $background: "lemon110",
+      };
+  }
+}

--- a/src/components/integrated/OakLessonTopNav/OakLessonTopNav.tsx
+++ b/src/components/integrated/OakLessonTopNav/OakLessonTopNav.tsx
@@ -78,22 +78,22 @@ function pickSectionIcon(
   switch (sectionName) {
     case "intro":
       return {
-        iconName: "signed-video-4",
+        iconName: "intro",
         $background: "aqua110",
       };
     case "starter-quiz":
       return {
-        iconName: "quiz-6",
+        iconName: "quiz",
         $background: "mint110",
       };
     case "video":
       return {
-        iconName: "video-3",
+        iconName: "video",
         $background: "pink110",
       };
     case "exit-quiz":
       return {
-        iconName: "quiz-6",
+        iconName: "quiz",
         $background: "lemon110",
       };
   }

--- a/src/components/integrated/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/integrated/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt="signed-video-4"
+          alt="intro"
           className="c4"
           data-nimg="fill"
           decoding="async"

--- a/src/components/integrated/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/integrated/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -1,0 +1,287 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakLessonTopNav matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  position: relative;
+  width: 2.5rem;
+  height: 2.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0.25rem;
+  background: #7cd8d0;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c7 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c12 {
+  display: none;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: none;
+  -webkit-flex-grow: none;
+  -ms-flex-positive: none;
+  flex-grow: none;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c9 {
+  font-family: Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c4 {
+  object-fit: contain;
+}
+
+.c8 {
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c2 {
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  border: none;
+  padding: 0;
+  outline: none;
+}
+
+.c2 img {
+  pointer-events: none;
+}
+
+.c2:not(:disabled) {
+  cursor: pointer;
+}
+
+.c2:active {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.3rem 0.3rem 0 rgba(87,87,87,100%);
+}
+
+.c2:hover,
+.c2:focus-visible {
+  background: #222222;
+}
+
+.c2:hover img,
+.c2:focus-visible img {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+}
+
+.c2:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c2:disabled {
+  background: #808080;
+}
+
+.c2:disabled img {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+}
+
+@media (min-width:750px) {
+  .c12 {
+    display: block;
+  }
+}
+
+@media (min-width:750px) {
+  .c8 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:750px) {
+  .c8 {
+    font-size: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c8 {
+    line-height: 2rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c8 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c10 {
+    display: none;
+  }
+}
+
+<div
+  className="c0 c1"
+>
+  <a
+    aria-label="Back"
+    className="c2"
+    type="button"
+  >
+    <div
+      className="c3"
+    >
+      <img
+        alt=""
+        className="c4"
+        data-nimg="fill"
+        decoding="async"
+        loading="lazy"
+        onError={[Function]}
+        onLoad={[Function]}
+        src="https://undefined/undefined/v1699953962/icons/xpp10hijwzhyeqt6ylqf.svg"
+        style={
+          {
+            "bottom": 0,
+            "color": "transparent",
+            "height": "100%",
+            "left": 0,
+            "objectFit": undefined,
+            "objectPosition": undefined,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "100%",
+          }
+        }
+      />
+    </div>
+  </a>
+  <div
+    className="c0 c5"
+  >
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <img
+          alt="signed-video-4"
+          className="c4"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://undefined/undefined/v1705416078/icons/dr0achdttjoe5b6lbcb7.svg"
+          style={
+            {
+              "bottom": 0,
+              "color": "transparent",
+              "height": "100%",
+              "left": 0,
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": "100%",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="c0"
+  >
+    <h1
+      className="c8"
+    >
+      Intro
+    </h1>
+    <span
+      className="c9 c10"
+    >
+      In progress&hellip;
+    </span>
+  </div>
+  <div
+    className="c0 c11"
+  >
+    <div
+      className="c12"
+    />
+  </div>
+</div>
+`;

--- a/src/components/integrated/OakLessonTopNav/index.ts
+++ b/src/components/integrated/OakLessonTopNav/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakLessonTopNav";

--- a/src/components/integrated/OakQuizFeedback/index.ts
+++ b/src/components/integrated/OakQuizFeedback/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakQuizFeedback";

--- a/src/components/integrated/index.ts
+++ b/src/components/integrated/index.ts
@@ -2,3 +2,7 @@ export * from "./OakQuizCheckBox";
 export * from "./OakQuizTextInput";
 export * from "./OakQuizRadioButton";
 export * from "./OakQuizHint";
+export * from "./OakQuizBottomNav";
+export * from "./OakLessonTopNav";
+export * from "./OakQuizFeedback";
+export * from "./OakQuizCounter";

--- a/src/image-map.json
+++ b/src/image-map.json
@@ -3,7 +3,6 @@
     "home": "v1699887218/icons/gvqxjxcw07ei2kkmwnes.svg",
     "send": "v1699893673/icons/rmvytilpjgvh3pgwc8ph.svg",
     "rocket": "v1699894015/icons/u26xm5hteot875ozfnk9.svg",
-    "video": "v1699894089/icons/aubeswd1rfom600gckze.svg",
     "edit": "v1699894149/icons/qxlunbg5tfrdherzsvlt.svg",
     "hamburger": "v1699895123/icons/jaqdnomtbhqvjcap962u.svg",
     "cross": "v1699895179/icons/xigimrbivcaxt4omxamp.svg",
@@ -37,7 +36,6 @@
     "copyright": "v1699954118/icons/boiod3rflocgsnfokyo8.svg",
     "arrow-down": "v1699954152/icons/wpfmbmwpyfinipg0d61y.svg",
     "project": "v1699954186/icons/zofq5pheud6spnwjpewk.svg",
-    "quiz": "v1699954212/icons/big9spbeitueppasyogb.svg",
     "slide-deck": "v1699954241/icons/sjjy5f3g4eciwcuxxr33.svg",
     "content-guidance": "v1699954277/icons/tm3uhcqenaznq4fxys7j.svg",
     "tick": "v1699954310/icons/efd3esaor6zqk7seh6kt.svg",
@@ -47,8 +45,8 @@
     "warning": "v1704901279/icons/zzszodmk7fvxm9xzzg9s.svg",
     "lightbulb-yellow": "v1705078631/icons/q2v4sqxouy1ngcajoavv.svg",
     "lightbulb": "v1705078631/icons/zldisxmbff36z68rwcef.svg",
-    "quiz-6": "v1705416077/icons/kaaizjcudy0jfgfrrdel.svg",
-    "video-3": "v1705416078/icons/wzey1zfxrvv3apeebbf5.svg",
-    "signed-video-4": "v1705416078/icons/dr0achdttjoe5b6lbcb7.svg"
+    "quiz": "v1705416077/icons/kaaizjcudy0jfgfrrdel.svg",
+    "video": "v1705416078/icons/wzey1zfxrvv3apeebbf5.svg",
+    "intro": "v1705416078/icons/dr0achdttjoe5b6lbcb7.svg"
   }
 }

--- a/src/image-map.json
+++ b/src/image-map.json
@@ -46,6 +46,9 @@
     "dot-png": "v1699954394/icons/qecbh291nzwmhcvqayqd.png",
     "warning": "v1704901279/icons/zzszodmk7fvxm9xzzg9s.svg",
     "lightbulb-yellow": "v1705078631/icons/q2v4sqxouy1ngcajoavv.svg",
-    "lightbulb": "v1705078631/icons/zldisxmbff36z68rwcef.svg"
+    "lightbulb": "v1705078631/icons/zldisxmbff36z68rwcef.svg",
+    "quiz-6": "v1705416077/icons/kaaizjcudy0jfgfrrdel.svg",
+    "video-3": "v1705416078/icons/wzey1zfxrvv3apeebbf5.svg",
+    "signed-video-4": "v1705416078/icons/dr0achdttjoe5b6lbcb7.svg"
   }
 }


### PR DESCRIPTION
This will render the navigation bar at the top of a lesson.

It includes slots for the back link and counter. These are included to keep the component dumb and leave it up to the host to decide how to hook up the back link and counter to the lesson state.

Figma 👉🏼  https://www.figma.com/file/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?type=design&node-id=4604-14267&mode=dev

Storybook 👉🏼 https://deploy-preview-67--lively-meringue-8ebd43.netlify.app/?path=/docs/components-integrated-oaklessontopnav--docs 

A `mobileSummary` prop is included to allow the host to pass in alternate content when at the mobile breakpoint since the counter is not displayed.

**Mobile**
<img width="635" alt="Screenshot 2024-01-16 at 15 37 06" src="https://github.com/oaknational/oak-components/assets/122096/4051d519-c9cf-46ed-bb03-d304c7bc5062">


**Above**
<img width="1068" alt="Screenshot 2024-01-16 at 15 37 11" src="https://github.com/oaknational/oak-components/assets/122096/7535cd69-e85e-403f-8505-c4503fbfc38e">
