### PR TITLE
feat(PUPIL-257) `OakLessonNavItem`

### DIFF
--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
@@ -49,7 +49,7 @@ const meta: Meta<typeof OakLessonNavItem> = {
       include: [
         "progress",
         "lessonSectionName",
-        "isDisabled",
+        "disabled",
         "grade",
         "numQuestions",
         "videoLength",

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakLessonNavItem } from "./OakLessonNavItem";
+
+import { OakFlex } from "@/components/base";
+
+const meta: Meta<typeof OakLessonNavItem> = {
+  component: OakLessonNavItem,
+  tags: ["autodocs"],
+  title: "components/integrated/OakLessonNavItem",
+  argTypes: {
+    label: {
+      control: {
+        type: "text",
+      },
+    },
+    summary: {
+      control: {
+        type: "text",
+      },
+    },
+  },
+  args: {
+    lessonSectionName: "intro",
+    progress: "not-started",
+    label: "Intro",
+    summary: "Get ready",
+    href: "#",
+  },
+  parameters: {
+    controls: {
+      include: [
+        "label",
+        "summary",
+        "progress",
+        "lessonSectionName",
+        "isDisabled",
+      ],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof OakLessonNavItem>;
+
+export const Default: Story = {
+  render: (args) => <OakLessonNavItem {...args} />,
+};
+
+export const NotStarted: Story = {
+  render: () => (
+    <>
+      <OakLessonNavItem
+        lessonSectionName="intro"
+        progress="not-started"
+        label="Intro"
+      />
+      <OakLessonNavItem
+        lessonSectionName="starter-quiz"
+        progress="not-started"
+        label="Starter quiz"
+      />
+      <OakLessonNavItem
+        lessonSectionName="video"
+        progress="not-started"
+        label="Video"
+      />
+      <OakLessonNavItem
+        lessonSectionName="exit-quiz"
+        progress="not-started"
+        label="Exit quiz"
+      />
+    </>
+  ),
+  decorators: [
+    (Story) => {
+      return (
+        <OakFlex $flexDirection="column" $gap="space-between-m">
+          {Story()}
+        </OakFlex>
+      );
+    },
+  ],
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+};

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
@@ -10,12 +10,20 @@ const meta: Meta<typeof OakLessonNavItem> = {
   tags: ["autodocs"],
   title: "components/integrated/OakLessonNavItem",
   argTypes: {
-    summary: {
+    numQuestions: {
       control: {
-        type: "text",
+        type: "number",
+      },
+    },
+    grade: {
+      control: {
+        type: "number",
       },
     },
     videoLength: {
+      control: {
+        type: "number",
+      },
       if: { arg: "lessonSectionName", eq: "video" },
     },
   },
@@ -55,6 +63,10 @@ type Story = StoryObj<typeof OakLessonNavItem>;
 
 export const Default: Story = {
   render: (args) => <OakLessonNavItem {...args} />,
+};
+
+export const AsAButton: Story = {
+  render: (args) => <OakLessonNavItem {...args} as="button" />,
 };
 
 export const NotStarted: Story = {

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
@@ -31,8 +31,8 @@ const meta: Meta<typeof OakLessonNavItem> = {
     lessonSectionName: "intro",
     progress: "not-started",
     href: "#",
-    answerCount: 4,
-    questionCount: 6,
+    grade: 4,
+    numQuestions: 6,
     videoLength: 20,
   },
   decorators: [
@@ -50,8 +50,8 @@ const meta: Meta<typeof OakLessonNavItem> = {
         "progress",
         "lessonSectionName",
         "isDisabled",
-        "answerCount",
-        "questionCount",
+        "grade",
+        "numQuestions",
         "videoLength",
       ],
     },
@@ -76,8 +76,8 @@ export const NotStarted: Story = {
       <OakLessonNavItem
         lessonSectionName="starter-quiz"
         progress="not-started"
-        questionCount={6}
-        answerCount={0}
+        numQuestions={6}
+        grade={0}
       />
       <OakLessonNavItem
         lessonSectionName="video"
@@ -87,8 +87,8 @@ export const NotStarted: Story = {
       <OakLessonNavItem
         lessonSectionName="exit-quiz"
         progress="not-started"
-        questionCount={4}
-        answerCount={0}
+        numQuestions={4}
+        grade={0}
       />
     </>
   ),
@@ -101,8 +101,8 @@ export const InProgress: Story = {
       <OakLessonNavItem
         lessonSectionName="starter-quiz"
         progress="in-progress"
-        questionCount={6}
-        answerCount={0}
+        numQuestions={6}
+        grade={0}
       />
       <OakLessonNavItem
         lessonSectionName="video"
@@ -112,8 +112,8 @@ export const InProgress: Story = {
       <OakLessonNavItem
         lessonSectionName="exit-quiz"
         progress="in-progress"
-        questionCount={6}
-        answerCount={0}
+        numQuestions={6}
+        grade={0}
       />
     </>
   ),
@@ -126,8 +126,8 @@ export const Complete: Story = {
       <OakLessonNavItem
         lessonSectionName="starter-quiz"
         progress="complete"
-        questionCount={6}
-        answerCount={5}
+        numQuestions={6}
+        grade={5}
       />
       <OakLessonNavItem
         lessonSectionName="video"
@@ -137,8 +137,8 @@ export const Complete: Story = {
       <OakLessonNavItem
         lessonSectionName="exit-quiz"
         progress="complete"
-        questionCount={4}
-        answerCount={4}
+        numQuestions={4}
+        grade={4}
       />
     </>
   ),

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
@@ -10,32 +10,41 @@ const meta: Meta<typeof OakLessonNavItem> = {
   tags: ["autodocs"],
   title: "components/integrated/OakLessonNavItem",
   argTypes: {
-    label: {
-      control: {
-        type: "text",
-      },
-    },
     summary: {
       control: {
         type: "text",
       },
     },
+    videoLength: {
+      if: { arg: "lessonSectionName", eq: "video" },
+    },
   },
   args: {
     lessonSectionName: "intro",
     progress: "not-started",
-    label: "Intro",
-    summary: "Get ready",
     href: "#",
+    answerCount: 4,
+    questionCount: 6,
+    videoLength: 20,
   },
+  decorators: [
+    (Story) => {
+      return (
+        <OakFlex $flexDirection="column" $gap="space-between-m">
+          {Story()}
+        </OakFlex>
+      );
+    },
+  ],
   parameters: {
     controls: {
       include: [
-        "label",
-        "summary",
         "progress",
         "lessonSectionName",
         "isDisabled",
+        "answerCount",
+        "questionCount",
+        "videoLength",
       ],
     },
   },
@@ -51,40 +60,74 @@ export const Default: Story = {
 export const NotStarted: Story = {
   render: () => (
     <>
-      <OakLessonNavItem
-        lessonSectionName="intro"
-        progress="not-started"
-        label="Intro"
-      />
+      <OakLessonNavItem lessonSectionName="intro" progress="not-started" />
       <OakLessonNavItem
         lessonSectionName="starter-quiz"
         progress="not-started"
-        label="Starter quiz"
+        questionCount={6}
+        answerCount={0}
       />
       <OakLessonNavItem
         lessonSectionName="video"
         progress="not-started"
-        label="Video"
+        videoLength={20}
       />
       <OakLessonNavItem
         lessonSectionName="exit-quiz"
         progress="not-started"
-        label="Exit quiz"
+        questionCount={4}
+        answerCount={0}
       />
     </>
   ),
-  decorators: [
-    (Story) => {
-      return (
-        <OakFlex $flexDirection="column" $gap="space-between-m">
-          {Story()}
-        </OakFlex>
-      );
-    },
-  ],
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
+};
+
+export const InProgress: Story = {
+  render: () => (
+    <>
+      <OakLessonNavItem lessonSectionName="intro" progress="in-progress" />
+      <OakLessonNavItem
+        lessonSectionName="starter-quiz"
+        progress="in-progress"
+        questionCount={6}
+        answerCount={0}
+      />
+      <OakLessonNavItem
+        lessonSectionName="video"
+        progress="in-progress"
+        videoLength={20}
+      />
+      <OakLessonNavItem
+        lessonSectionName="exit-quiz"
+        progress="in-progress"
+        questionCount={6}
+        answerCount={0}
+      />
+    </>
+  ),
+};
+
+export const Complete: Story = {
+  render: () => (
+    <>
+      <OakLessonNavItem lessonSectionName="intro" progress="complete" />
+      <OakLessonNavItem
+        lessonSectionName="starter-quiz"
+        progress="complete"
+        questionCount={6}
+        answerCount={5}
+      />
+      <OakLessonNavItem
+        lessonSectionName="video"
+        progress="complete"
+        videoLength={20}
+      />
+      <OakLessonNavItem
+        lessonSectionName="exit-quiz"
+        progress="complete"
+        questionCount={4}
+        answerCount={4}
+      />
+    </>
+  ),
 };

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.test.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.test.tsx
@@ -31,8 +31,8 @@ describe(OakLessonNavItem, () => {
           data-testid="starter-quiz"
           lessonSectionName="starter-quiz"
           progress="not-started"
-          questionCount={6}
-          answerCount={0}
+          numQuestions={6}
+          grade={0}
         />
         <OakLessonNavItem
           data-testid="video"
@@ -44,8 +44,8 @@ describe(OakLessonNavItem, () => {
           data-testid="exit-quiz"
           lessonSectionName="exit-quiz"
           progress="not-started"
-          questionCount={6}
-          answerCount={5}
+          numQuestions={6}
+          grade={5}
         />
       </>,
     );
@@ -70,8 +70,8 @@ describe(OakLessonNavItem, () => {
           data-testid="starter-quiz"
           lessonSectionName="starter-quiz"
           progress="in-progress"
-          questionCount={6}
-          answerCount={0}
+          numQuestions={6}
+          grade={0}
         />
         <OakLessonNavItem
           data-testid="video"
@@ -83,8 +83,8 @@ describe(OakLessonNavItem, () => {
           data-testid="exit-quiz"
           lessonSectionName="exit-quiz"
           progress="in-progress"
-          questionCount={6}
-          answerCount={5}
+          numQuestions={6}
+          grade={5}
         />
       </>,
     );
@@ -107,8 +107,8 @@ describe(OakLessonNavItem, () => {
           data-testid="starter-quiz"
           lessonSectionName="starter-quiz"
           progress="complete"
-          questionCount={6}
-          answerCount={0}
+          numQuestions={6}
+          grade={0}
         />
         <OakLessonNavItem
           data-testid="video"
@@ -120,8 +120,8 @@ describe(OakLessonNavItem, () => {
           data-testid="exit-quiz"
           lessonSectionName="exit-quiz"
           progress="complete"
-          questionCount={6}
-          answerCount={5}
+          numQuestions={6}
+          grade={5}
         />
       </>,
     );

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.test.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.test.tsx
@@ -131,4 +131,19 @@ describe(OakLessonNavItem, () => {
     expect(getByTestId("exit-quiz").textContent).toContain("Completed");
     expect(getByTestId("video").textContent).toContain("Completed");
   });
+
+  it("renders a div when the item is disabled", () => {
+    const { getByTestId } = renderWithTheme(
+      <>
+        <OakLessonNavItem
+          data-testid="intro"
+          lessonSectionName="intro"
+          progress="complete"
+          disabled
+        />
+      </>,
+    );
+
+    expect(getByTestId("intro").tagName).toBe("DIV");
+  });
 });

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.test.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.test.tsx
@@ -6,21 +6,129 @@ import { OakLessonNavItem } from "./OakLessonNavItem";
 
 import { OakThemeProvider } from "@/components/base";
 import { oakDefaultTheme } from "@/styles";
+import renderWithTheme from "@/test-helpers/renderWithTheme";
 
 describe(OakLessonNavItem, () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <OakLessonNavItem
-          lessonSectionName="intro"
-          progress="not-started"
-          label="Intro"
-          summary="Get ready"
-        />
-        ,
+        <OakLessonNavItem lessonSectionName="intro" progress="not-started" />,
       </OakThemeProvider>,
     ).toJSON();
 
     expect(tree).toMatchSnapshot();
+  });
+
+  it("renders copy for each lesson section that has not been started", () => {
+    const { getByTestId } = renderWithTheme(
+      <>
+        <OakLessonNavItem
+          data-testid="intro"
+          lessonSectionName="intro"
+          progress="not-started"
+        />
+        <OakLessonNavItem
+          data-testid="starter-quiz"
+          lessonSectionName="starter-quiz"
+          progress="not-started"
+          questionCount={6}
+          answerCount={0}
+        />
+        <OakLessonNavItem
+          data-testid="video"
+          lessonSectionName="video"
+          progress="not-started"
+          videoLength={20}
+        />
+        <OakLessonNavItem
+          data-testid="exit-quiz"
+          lessonSectionName="exit-quiz"
+          progress="not-started"
+          questionCount={6}
+          answerCount={5}
+        />
+      </>,
+    );
+
+    expect(getByTestId("intro").textContent).toContain("Get ready");
+    expect(getByTestId("starter-quiz").textContent).toContain("6 Questions");
+    expect(getByTestId("exit-quiz").textContent).toContain(
+      "Practice 6 questions",
+    );
+    expect(getByTestId("video").textContent).toContain("20 min");
+  });
+
+  it("renders copy for each lesson section that has not been started", () => {
+    const { getByTestId } = renderWithTheme(
+      <>
+        <OakLessonNavItem
+          data-testid="intro"
+          lessonSectionName="intro"
+          progress="in-progress"
+        />
+        <OakLessonNavItem
+          data-testid="starter-quiz"
+          lessonSectionName="starter-quiz"
+          progress="in-progress"
+          questionCount={6}
+          answerCount={0}
+        />
+        <OakLessonNavItem
+          data-testid="video"
+          lessonSectionName="video"
+          progress="in-progress"
+          videoLength={20}
+        />
+        <OakLessonNavItem
+          data-testid="exit-quiz"
+          lessonSectionName="exit-quiz"
+          progress="in-progress"
+          questionCount={6}
+          answerCount={5}
+        />
+      </>,
+    );
+
+    expect(getByTestId("intro").textContent).toContain("In progress...");
+    expect(getByTestId("starter-quiz").textContent).toContain("In progress...");
+    expect(getByTestId("exit-quiz").textContent).toContain("In progress...");
+    expect(getByTestId("video").textContent).toContain("In progress...");
+  });
+
+  it("renders copy for each lesson section that has not been started", () => {
+    const { getByTestId } = renderWithTheme(
+      <>
+        <OakLessonNavItem
+          data-testid="intro"
+          lessonSectionName="intro"
+          progress="complete"
+        />
+        <OakLessonNavItem
+          data-testid="starter-quiz"
+          lessonSectionName="starter-quiz"
+          progress="complete"
+          questionCount={6}
+          answerCount={0}
+        />
+        <OakLessonNavItem
+          data-testid="video"
+          lessonSectionName="video"
+          progress="complete"
+          videoLength={20}
+        />
+        <OakLessonNavItem
+          data-testid="exit-quiz"
+          lessonSectionName="exit-quiz"
+          progress="complete"
+          questionCount={6}
+          answerCount={5}
+        />
+      </>,
+    );
+
+    expect(getByTestId("intro").textContent).toContain("Completed");
+    expect(getByTestId("starter-quiz").textContent).toContain("Completed");
+    expect(getByTestId("exit-quiz").textContent).toContain("Completed");
+    expect(getByTestId("video").textContent).toContain("Completed");
   });
 });

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.test.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+
+import { OakLessonNavItem } from "./OakLessonNavItem";
+
+import { OakThemeProvider } from "@/components/base";
+import { oakDefaultTheme } from "@/styles";
+
+describe(OakLessonNavItem, () => {
+  it("matches snapshot", () => {
+    const tree = create(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakLessonNavItem
+          lessonSectionName="intro"
+          progress="not-started"
+          label="Intro"
+          summary="Get ready"
+        />
+        ,
+      </OakThemeProvider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
@@ -33,11 +33,11 @@ type QuizSectionProps = {
   /**
    * The number of questions in the quiz
    */
-  questionCount: number;
+  numQuestions: number;
   /**
    * The number of questions answered correctly
    */
-  answerCount: number;
+  grade: number;
 };
 
 type VideoSectionProps = {
@@ -185,10 +185,8 @@ function renderQuestionCounter(props: SectionProps) {
     case "starter-quiz":
       return (
         <OakBox $display={["none", "block"]} $mr="space-between-xxxl">
-          <OakSpan $font="heading-4">{props.answerCount}</OakSpan>
-          <OakSpan $font="heading-6">
-            &nbsp;/&nbsp;{props.questionCount}
-          </OakSpan>
+          <OakSpan $font="heading-4">{props.grade}</OakSpan>
+          <OakSpan $font="heading-6">&nbsp;/&nbsp;{props.numQuestions}</OakSpan>
         </OakBox>
       );
     default:
@@ -281,9 +279,9 @@ function pickSummaryForNotStarted(props: SectionProps) {
     case "intro":
       return "Get ready";
     case "starter-quiz":
-      return `${props.questionCount} Questions`;
+      return `${props.numQuestions} Questions`;
     case "exit-quiz":
-      return `Practice ${props.questionCount} questions`;
+      return `Practice ${props.numQuestions} questions`;
     case "video":
       return `${props.videoLength} min`;
   }
@@ -302,7 +300,7 @@ function pickSummaryForComplete(props: SectionProps) {
         <>
           <OakBox $display={["none", "block"]}>Completed</OakBox>
           <OakBox $display={["block", "none"]}>
-            {props.answerCount}/{props.questionCount} correct
+            {props.grade}/{props.numQuestions} correct
           </OakBox>
         </>
       );

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
@@ -1,0 +1,197 @@
+import React, { ComponentPropsWithoutRef, ElementType, ReactNode } from "react";
+import styled, { css } from "styled-components";
+
+import { OakBox, OakFlex, OakIcon, OakIconName } from "@/components/base";
+import { parseColor } from "@/styles/helpers/parseColor";
+import { OakRoundIcon } from "@/components/ui";
+import { parseColorFilter } from "@/styles/helpers/parseColorFilter";
+import { parseSpacing } from "@/styles/helpers/parseSpacing";
+import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
+import { OakCombinedColorToken } from "@/styles";
+
+type LessonSectionName = "intro" | "starter-quiz" | "video" | "exit-quiz";
+
+export type OakLessonNavItemProps<C extends ElementType> = {
+  as?: C;
+  lessonSectionName: LessonSectionName;
+  /**
+   * Denotes the progress in the lesson section
+   */
+  progress: "not-started" | "in-progress" | "completed";
+  /**
+   * Label for the section
+   */
+  label: ReactNode;
+  /**
+   * Optional accompanying text summarising the progress through the section
+   * if not provided preset text will be displayed
+   */
+  summary?: ReactNode;
+  /**
+   * Present the section as disabled.
+   *
+   * If this is a button the `disabled` prop should also be set.
+   * For a link the anchor should be replaced with a non interactive element
+   */
+  isDisabled?: boolean;
+} & ComponentPropsWithoutRef<C>;
+
+const StyledLabel = styled(OakBox)``;
+
+const StyledRoundIcon = styled(OakRoundIcon)<{
+  $isDisabled?: boolean;
+}>`
+  width: ${parseSpacing("all-spacing-8")};
+  height: ${parseSpacing("all-spacing-8")};
+  padding: 0;
+
+  background: transparent;
+
+  img {
+    filter: ${(props) =>
+      parseColorFilter(props.$isDisabled ? "icon-disabled" : "icon-inverted")};
+  }
+`;
+
+const StyledLessonNavItem = styled(OakFlex)<{ $isDisabled?: boolean }>`
+  outline: none;
+
+  &:focus-visible {
+    box-shadow: ${parseDropShadow("drop-shadow-centered-yellow")},
+      ${parseDropShadow("drop-shadow-centered-grey")};
+  }
+
+  ${(props) => props.$isDisabled && "cursor: default"}
+
+  ${(props) =>
+    !props.$isDisabled &&
+    css`
+      &:hover,
+      &:active {
+        ${StyledLabel} {
+          text-decoration: underline;
+        }
+
+        ${StyledRoundIcon} {
+          background: ${parseColor("bg-btn-primary")};
+
+          img {
+            filter: ${parseColorFilter("icon-main")};
+          }
+        }
+      }
+
+      &:active {
+        box-shadow: ${parseDropShadow("drop-shadow-yellow")},
+          ${parseDropShadow("drop-shadow-grey")};
+      }
+    `}
+`;
+
+/**
+ * Enables navigation to the given section of a lesson as well as displaying current progress
+ */
+export const OakLessonNavItem = <C extends ElementType = "a">({
+  as,
+  lessonSectionName,
+  progress,
+  label,
+  summary,
+  isDisabled,
+  ...rest
+}: OakLessonNavItemProps<C>) => {
+  const [notStartedBackgroundColor, backgroundColor, borderColor] =
+    pickColorsForSection(lessonSectionName);
+
+  return (
+    <StyledLessonNavItem
+      as={as ?? "a"}
+      $gap="space-between-m"
+      $alignItems="center"
+      $background={
+        progress === "not-started" ? notStartedBackgroundColor : backgroundColor
+      }
+      $ph={["inner-padding-m", "inner-padding-xl"]}
+      $pv="inner-padding-l"
+      $borderRadius="border-radius-l"
+      $borderColor={borderColor}
+      $ba="border-solid-l"
+      $isDisabled={isDisabled}
+      {...rest}
+    >
+      <OakFlex $width="all-spacing-13" $justifyContent="center">
+        <OakIcon
+          iconName={pickIconForSection(lessonSectionName)}
+          $width="all-spacing-10"
+          $height="all-spacing-10"
+        />
+      </OakFlex>
+      <OakBox>
+        <StyledLabel
+          as="strong"
+          $font={["heading-6", "heading-5"]}
+          $color={isDisabled ? "text-disabled" : "text-primary"}
+        >
+          {label}
+        </StyledLabel>
+        <OakBox $font={["body-2", "body-1"]}>{summary}</OakBox>
+      </OakBox>
+      <OakFlex
+        $flexBasis="space-between-none"
+        $flexDirection="column"
+        $flexGrow={1}
+      >
+        <OakFlex $alignSelf="flex-end">
+          <StyledRoundIcon iconName="chevron-right" $isDisabled={isDisabled} />
+        </OakFlex>
+      </OakFlex>
+    </StyledLessonNavItem>
+  );
+};
+
+function pickIconForSection(sectionName: LessonSectionName): OakIconName {
+  switch (sectionName) {
+    case "intro":
+      return "intro";
+    case "starter-quiz":
+    case "exit-quiz":
+      return "quiz";
+    case "video":
+      return "video";
+  }
+}
+
+function pickColorsForSection(
+  sectionName: LessonSectionName,
+): [
+  notStartedBackgroundColor: OakCombinedColorToken,
+  backgroundColor: OakCombinedColorToken,
+  borderColor: OakCombinedColorToken,
+] {
+  switch (sectionName) {
+    case "intro":
+      return [
+        "bg-decorative2-very-subdued",
+        "bg-decorative2-main",
+        "border-decorative2-stronger",
+      ];
+    case "starter-quiz":
+      return [
+        "bg-decorative1-very-subdued",
+        "bg-decorative1-main",
+        "border-decorative1-stronger",
+      ];
+    case "video":
+      return [
+        "bg-decorative4-very-subdued",
+        "bg-decorative4-main",
+        "border-decorative4-stronger",
+      ];
+    case "exit-quiz":
+      return [
+        "bg-decorative5-very-subdued",
+        "bg-decorative5-main",
+        "border-decorative5-stronger",
+      ];
+  }
+}

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
@@ -20,12 +20,9 @@ type LessonSectionName = "intro" | "starter-quiz" | "video" | "exit-quiz";
 type BaseOakLessonNavItemProps<C extends ElementType> = {
   as?: C;
   /**
-   * Present the section as disabled.
-   *
-   * If this is a button the `disabled` prop should also be set.
-   * For a link the anchor should be replaced with a non interactive element
+   * Disable the section preventing navigation to it.
    */
-  isDisabled?: boolean;
+  disabled?: boolean;
 } & ComponentPropsWithoutRef<C>;
 
 type QuizSectionProps = {
@@ -65,7 +62,7 @@ export type OakLessonNavItemProps<C extends ElementType> =
 const StyledLabel = styled(OakBox)``;
 
 const StyledRoundIcon = styled(OakRoundIcon)<{
-  $isDisabled?: boolean;
+  $disabled?: boolean;
 }>`
   width: ${parseSpacing("all-spacing-8")};
   height: ${parseSpacing("all-spacing-8")};
@@ -75,11 +72,11 @@ const StyledRoundIcon = styled(OakRoundIcon)<{
 
   img {
     filter: ${(props) =>
-      parseColorFilter(props.$isDisabled ? "icon-disabled" : "icon-inverted")};
+      parseColorFilter(props.$disabled ? "icon-disabled" : "icon-inverted")};
   }
 `;
 
-const StyledLessonNavItem = styled(OakFlex)<{ $isDisabled?: boolean }>`
+const StyledLessonNavItem = styled(OakFlex)<{ $disabled?: boolean }>`
   outline: none;
   text-align: initial;
 
@@ -88,10 +85,10 @@ const StyledLessonNavItem = styled(OakFlex)<{ $isDisabled?: boolean }>`
       ${parseDropShadow("drop-shadow-centered-grey")};
   }
 
-  ${(props) => props.$isDisabled && "cursor: default"}
+  ${(props) => props.$disabled && "cursor: default"}
 
   ${(props) =>
-    !props.$isDisabled &&
+    !props.$disabled &&
     css`
       cursor: pointer;
 
@@ -127,13 +124,14 @@ const FlexedOakBox = styled(OakBox)`
 export const OakLessonNavItem = <C extends ElementType = "a">(
   props: OakLessonNavItemProps<C>,
 ) => {
-  const { as, lessonSectionName, progress, isDisabled, ...rest } = props;
+  const { as, lessonSectionName, progress, disabled, href, onClick, ...rest } =
+    props;
   const [notStartedBackgroundColor, backgroundColor, borderColor] =
     pickColorsForSection(lessonSectionName);
 
   return (
     <StyledLessonNavItem
-      as={as ?? "a"}
+      as={disabled ? "div" : as ?? "a"}
       $gap="space-between-m"
       $alignItems="center"
       $background={
@@ -144,7 +142,9 @@ export const OakLessonNavItem = <C extends ElementType = "a">(
       $borderRadius="border-radius-l"
       $borderColor={borderColor}
       $ba="border-solid-l"
-      $isDisabled={isDisabled}
+      $disabled={disabled}
+      href={disabled ? undefined : href}
+      onClick={disabled ? undefined : onClick}
       {...rest}
     >
       <OakFlex $width="all-spacing-13" $justifyContent="center">
@@ -158,7 +158,7 @@ export const OakLessonNavItem = <C extends ElementType = "a">(
         <StyledLabel
           as="strong"
           $font={["heading-6", "heading-5"]}
-          $color={isDisabled ? "text-disabled" : "text-primary"}
+          $color={disabled ? "text-disabled" : "text-primary"}
         >
           {pickLabelForSection(lessonSectionName)}
         </StyledLabel>
@@ -167,7 +167,7 @@ export const OakLessonNavItem = <C extends ElementType = "a">(
         </OakBox>
       </FlexedOakBox>
       {renderQuestionCounter(props)}
-      <StyledRoundIcon iconName="chevron-right" $isDisabled={isDisabled} />
+      <StyledRoundIcon iconName="chevron-right" $disabled={disabled} />
     </StyledLessonNavItem>
   );
 };

--- a/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c8 {
+.c9 {
   color: #222222;
   font-family: Lexend,sans-serif;
   font-weight: 600;
@@ -42,7 +42,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c9 {
+.c10 {
   font-family: Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -53,7 +53,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c12 {
+.c11 {
   width: 3rem;
   height: 3rem;
   padding: 0.25rem;
@@ -62,7 +62,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c15 {
+.c14 {
   position: relative;
   width: 100%;
   height: 100%;
@@ -92,70 +92,51 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-flex-basis: 0rem;
-  -ms-flex-preferred-size: 0rem;
-  flex-basis: 0rem;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-self: flex-end;
-  -ms-flex-item-align: end;
-  align-self: flex-end;
-}
-
 .c6 {
   object-fit: contain;
 }
 
-.c14 {
+.c13 {
   width: 2.5rem;
   height: 2.5rem;
   padding: 0;
   background: transparent;
 }
 
-.c14 img {
+.c13 img {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
 .c2 {
   outline: none;
+  text-align: initial;
+  cursor: pointer;
 }
 
 .c2:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c2:hover .c13,
-.c2:active .c13 {
+.c2:hover .c12,
+.c2:active .c12 {
   background: #222222;
 }
 
-.c2:hover .c13 img,
-.c2:active .c13 img {
+.c2:hover .c12 img,
+.c2:active .c12 img {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
 }
 
 .c2:active {
-  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.3rem 0.3rem 0 rgba(87,87,87,100%);
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
+}
+
+.c8 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 @media (min-width:750px) {
@@ -171,25 +152,25 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c9 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c9 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c9 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c9 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -198,25 +179,25 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c10 {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c10 {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c10 {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c10 {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
@@ -260,57 +241,49 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c7"
+      className="c7 c8"
     >
       <strong
-        className="c8"
+        className="c9"
       >
         Intro
       </strong>
       <div
-        className="c9"
+        className="c10"
       >
         Get ready
       </div>
     </div>
     <div
-      className="c7 c10"
+      className="c11 c12 c13"
     >
       <div
-        className="c7 c11"
+        className="c14"
       >
-        <div
-          className="c12 c13 c14"
-        >
-          <div
-            className="c15"
-          >
-            <img
-              alt="chevron-right"
-              className="c6"
-              data-nimg="fill"
-              decoding="async"
-              loading="lazy"
-              onError={[Function]}
-              onLoad={[Function]}
-              src="https://undefined/undefined/v1699895475/icons/rhzft6wnpdp3nvsmlyei.svg"
-              style={
-                {
-                  "bottom": 0,
-                  "color": "transparent",
-                  "height": "100%",
-                  "left": 0,
-                  "objectFit": undefined,
-                  "objectPosition": undefined,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "width": "100%",
-                }
-              }
-            />
-          </div>
-        </div>
+        <img
+          alt="chevron-right"
+          className="c6"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://undefined/undefined/v1699895475/icons/rhzft6wnpdp3nvsmlyei.svg"
+          style={
+            {
+              "bottom": 0,
+              "color": "transparent",
+              "height": "100%",
+              "left": 0,
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": "100%",
+            }
+          }
+        />
       </div>
     </div>
   </a>,

--- a/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -1,0 +1,253 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakLessonNavItem matches snapshot 1`] = `
+[
+  .c0 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+  background: #e7f6f5;
+  border: 0.188rem solid;
+  border-color: #7cd8d0;
+  border-radius: 1rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  width: 5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c5 {
+  position: relative;
+  width: 3.5rem;
+  height: 3.5rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c7 {
+  font-family: Lexend,sans-serif;
+}
+
+.c8 {
+  color: #222222;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1.5rem;
+  line-height: 2rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c9 {
+  font-family: Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c12 {
+  width: 3rem;
+  height: 3rem;
+  padding: 0.25rem;
+  background: #ffe555;
+  border-radius: 6.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c15 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-basis: 0rem;
+  -ms-flex-preferred-size: 0rem;
+  flex-basis: 0rem;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+}
+
+.c6 {
+  object-fit: contain;
+}
+
+.c14 {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  background: transparent;
+}
+
+.c14 img {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c2 {
+  outline: none;
+}
+
+.c2:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c2:hover .c13,
+.c2:active .c13 {
+  background: #222222;
+}
+
+.c2:hover .c13 img,
+.c2:active .c13 img {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+}
+
+.c2:active {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.3rem 0.3rem 0 rgba(87,87,87,100%);
+}
+
+<a
+    className="c0 c1 c2"
+  >
+    <div
+      className="c3 c4"
+    >
+      <div
+        className="c5"
+      >
+        <img
+          alt="intro"
+          className="c6"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://undefined/undefined/v1705416078/icons/dr0achdttjoe5b6lbcb7.svg"
+          style={
+            {
+              "bottom": 0,
+              "color": "transparent",
+              "height": "100%",
+              "left": 0,
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": "100%",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <strong
+        className="c8"
+      >
+        Intro
+      </strong>
+      <div
+        className="c9"
+      >
+        Get ready
+      </div>
+    </div>
+    <div
+      className="c7 c10"
+    >
+      <div
+        className="c7 c11"
+      >
+        <div
+          className="c12 c13 c14"
+        >
+          <div
+            className="c15"
+          >
+            <img
+              alt="chevron-right"
+              className="c6"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://undefined/undefined/v1699895475/icons/rhzft6wnpdp3nvsmlyei.svg"
+              style={
+                {
+                  "bottom": 0,
+                  "color": "transparent",
+                  "height": "100%",
+                  "left": 0,
+                  "objectFit": undefined,
+                  "objectPosition": undefined,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </a>,
+  ",",
+]
+`;

--- a/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
           loading="lazy"
           onError={[Function]}
           onLoad={[Function]}
-          src="https://undefined/undefined/v1705416078/icons/dr0achdttjoe5b6lbcb7.svg"
+          src="https://undefined/undefined/v1705662092/icons/pl7bnmb13txese9yxkjv.svg"
           style={
             {
               "bottom": 0,

--- a/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`OakLessonNavItem matches snapshot 1`] = `
 [
   .c0 {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
   background: #e7f6f5;
@@ -34,8 +34,8 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   color: #222222;
   font-family: Lexend,sans-serif;
   font-weight: 600;
-  font-size: 1.5rem;
-  line-height: 2rem;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
   -webkit-letter-spacing: 0.0115rem;
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;
@@ -45,8 +45,8 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 .c9 {
   font-family: Lexend,sans-serif;
   font-weight: 300;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
   -webkit-letter-spacing: -0.005rem;
   -moz-letter-spacing: -0.005rem;
   -ms-letter-spacing: -0.005rem;
@@ -156,6 +156,72 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 
 .c2:active {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.3rem 0.3rem 0 rgba(87,87,87,100%);
+}
+
+@media (min-width:750px) {
+  .c0 {
+    padding-left: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    padding-right: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c8 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:750px) {
+  .c8 {
+    font-size: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c8 {
+    line-height: 2rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c8 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c9 {
+    font-weight: 300;
+  }
+}
+
+@media (min-width:750px) {
+  .c9 {
+    font-size: 1.125rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c9 {
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c9 {
+    -webkit-letter-spacing: -0.005rem;
+    -moz-letter-spacing: -0.005rem;
+    -ms-letter-spacing: -0.005rem;
+    letter-spacing: -0.005rem;
+  }
 }
 
 <a

--- a/src/components/integrated/OakLessonNavItem/index.ts
+++ b/src/components/integrated/OakLessonNavItem/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakLessonNavItem";

--- a/src/components/integrated/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/integrated/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -258,7 +258,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
           loading="lazy"
           onError={[Function]}
           onLoad={[Function]}
-          src="https://undefined/undefined/v1705416078/icons/dr0achdttjoe5b6lbcb7.svg"
+          src="https://undefined/undefined/v1705662092/icons/pl7bnmb13txese9yxkjv.svg"
           style={
             {
               "bottom": 0,

--- a/src/components/integrated/index.ts
+++ b/src/components/integrated/index.ts
@@ -8,3 +8,4 @@ export * from "./OakQuizFeedback";
 export * from "./OakQuizCounter";
 export * from "./OakLessonLayout";
 export * from "./OakHintButton";
+export * from "./OakLessonNavItem";

--- a/src/components/ui/OakRoundIcon/OakRoundIcon.tsx
+++ b/src/components/ui/OakRoundIcon/OakRoundIcon.tsx
@@ -28,6 +28,7 @@ export const OakRoundIcon = ({
   $width = "all-spacing-9",
   $height = "all-spacing-9",
   $pa = "inner-padding-ssx",
+  className,
   ...rest
 }: OakRoundIconProps) => {
   const icon = rest.iconName ? (
@@ -38,6 +39,7 @@ export const OakRoundIcon = ({
 
   return (
     <OakBox
+      className={className}
       $background={$background}
       $borderRadius={$borderRadius}
       $width={$width}

--- a/src/image-map.json
+++ b/src/image-map.json
@@ -47,6 +47,6 @@
     "lightbulb": "v1705078631/icons/zldisxmbff36z68rwcef.svg",
     "quiz": "v1705416077/icons/kaaizjcudy0jfgfrrdel.svg",
     "video": "v1705416078/icons/wzey1zfxrvv3apeebbf5.svg",
-    "intro": "v1705416078/icons/dr0achdttjoe5b6lbcb7.svg"
+    "intro": "v1705662092/icons/pl7bnmb13txese9yxkjv.svg"
   }
 }


### PR DESCRIPTION
Enables navigation to the given section of a lesson as well as displaying current progress in that section.

Figma 👉🏼  https://www.figma.com/file/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?type=design&node-id=4604-17936&mode=dev

Storybook 👉🏼 https://deploy-preview-70--lively-meringue-8ebd43.netlify.app/?path=/docs/components-integrated-oaklessonnavitem--docs

**Tablet >=**
<img width="633" alt="Screenshot 2024-01-18 at 17 23 36" src="https://github.com/oaknational/oak-components/assets/122096/f398fc74-9d78-43f1-9b29-54a517ed1034">

**Mobile**
<img width="405" alt="Screenshot 2024-01-18 at 17 27 46" src="https://github.com/oaknational/oak-components/assets/122096/f48b691e-0e20-4723-88c0-cccc36483973">

