### PR TITLE
fix(PUPIL-78): replace deprecated names for row and column gap

### DIFF
--- a/src/components/base/OakGrid/OakGrid.test.tsx
+++ b/src/components/base/OakGrid/OakGrid.test.tsx
@@ -32,13 +32,12 @@ describe("OakGrid", () => {
     );
   });
 
-  it.skip("adjusts column gap via $cg", () => {
-    // FIXME: This test is failing as no css is injected by styled-components but the behavior is working in storybook
+  it("adjusts column gap via $cg", () => {
     const { getByTestId } = render(
       <OakGrid data-testid="oak-grid" $cg={"all-spacing-1"}>
         <OakGridArea $colSpan={1} />
       </OakGrid>,
     );
-    expect(getByTestId("oak-grid")).toHaveStyle("grid-column-gap: 0.25rem;");
+    expect(getByTestId("oak-grid")).toHaveStyle("column-gap: 0.25rem;");
   });
 });

--- a/src/components/base/OakGrid/OakGrid.tsx
+++ b/src/components/base/OakGrid/OakGrid.tsx
@@ -9,8 +9,8 @@ import { parseSpacing } from "@/styles/helpers/parseSpacing";
 import { OakCombinedSpacingToken } from "@/styles";
 
 const gridStyle = css<OakGridProps>`
-  ${responsiveStyle("grid-row-gap", (props) => props.$rg, parseSpacing)}
-  ${responsiveStyle("grid-column-gap", (props) => props.$cg, parseSpacing)}
+  ${responsiveStyle("row-gap", (props) => props.$rg, parseSpacing)}
+  ${responsiveStyle("column-gap", (props) => props.$cg, parseSpacing)}
   ${responsiveStyle("grid-auto-rows", (props) => props.$gridAutoRows)}
   ${responsiveStyle("grid-template-areas", (props) => props.$gridTemplateAreas)}
   ${responsiveStyle(


### PR DESCRIPTION
`grid-column-gap` and `grid-row-gap` are deprecated names for `column-gap` and `row-gap`. They're still respected as aliases for the new property names but I suspect that is why they didn't appear in your test.