### PR TITLE
PUPIL-344 make button related components polymorphic

### DIFF
--- a/src/components/base/InternalButton/InternalButton.stories.tsx
+++ b/src/components/base/InternalButton/InternalButton.stories.tsx
@@ -54,3 +54,16 @@ export const Default: Story = {
     $borderRadius: "border-radius-m",
   },
 };
+
+export const AsLink: Story = {
+  render: (args) => <InternalButton {...args}>Click Me, I'm a link!</InternalButton>,
+  args: {
+    as: "a",
+    href: "/",
+    $background: "bg-btn-primary",
+    $color: "white",
+    $ba: "border-solid-s",
+    $pa: "inner-padding-s",
+    $borderRadius: "border-radius-m",
+  },
+};

--- a/src/components/base/InternalButton/InternalButton.stories.tsx
+++ b/src/components/base/InternalButton/InternalButton.stories.tsx
@@ -60,7 +60,7 @@ export const LinkStyledAsButton: Story = {
     <InternalButton {...args}>Click Me, I'm a link!</InternalButton>
   ),
   args: {
-    as: "a",
+    element: "a",
     href: "/",
     $background: "bg-btn-primary",
     $color: "white",

--- a/src/components/base/InternalButton/InternalButton.stories.tsx
+++ b/src/components/base/InternalButton/InternalButton.stories.tsx
@@ -55,7 +55,7 @@ export const Default: Story = {
   },
 };
 
-export const AsLink: Story = {
+export const LinkStyledAsButton: Story = {
   render: (args) => (
     <InternalButton {...args}>Click Me, I'm a link!</InternalButton>
   ),

--- a/src/components/base/InternalButton/InternalButton.stories.tsx
+++ b/src/components/base/InternalButton/InternalButton.stories.tsx
@@ -56,7 +56,9 @@ export const Default: Story = {
 };
 
 export const AsLink: Story = {
-  render: (args) => <InternalButton {...args}>Click Me, I'm a link!</InternalButton>,
+  render: (args) => (
+    <InternalButton {...args}>Click Me, I'm a link!</InternalButton>
+  ),
   args: {
     as: "a",
     href: "/",

--- a/src/components/base/InternalButton/InternalButton.test.tsx
+++ b/src/components/base/InternalButton/InternalButton.test.tsx
@@ -82,7 +82,7 @@ describe("InternalButton", () => {
   });
 
   it("correctly fires for a form matching the id from its form props", () => {
-    const onSubmit = jest.fn();
+    const onSubmit = jest.fn((e) => e.preventDefault());
     const { getByRole } = render(
       <div>
         <form id="test-form" onSubmit={onSubmit}>

--- a/src/components/base/InternalButton/InternalButton.tsx
+++ b/src/components/base/InternalButton/InternalButton.tsx
@@ -48,17 +48,10 @@ const internalButtonCss = css<StyledButtonProps>`
 export type InternalButtonProps<C extends ElementType = "button"> =
   StyledButtonProps & {
     as?: C;
-    onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     onHovered?: (
       event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
       duration: number,
     ) => void;
-    // children?: React.ReactNode;
-    // className?: string;
-    // disabled?: boolean;
-    // "data-testid"?: string;
-    // type?: "button" | "submit" | "reset";
-    // form?: string;
   } & ComponentPropsWithoutRef<C>;
 
 const UnstyledInternalButton = (props: InternalButtonProps) => {
@@ -85,14 +78,9 @@ const UnstyledInternalButton = (props: InternalButtonProps) => {
 
   return (
     <Component
-      className={props.className}
-      // data-testid={props["data-testid"]}
-      // disabled={props.disabled}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      // type={props.type ?? "button"}
-      // form={props.form}
       {...rest}
     />
   );

--- a/src/components/base/InternalButton/InternalButton.tsx
+++ b/src/components/base/InternalButton/InternalButton.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType, useRef, ComponentPropsWithoutRef } from "react";
+import React, { ElementType, useRef } from "react";
 import styled, { css } from "styled-components";
 
 import { colorStyle, ColorStyleProps } from "@/styles/utils/colorStyle";
@@ -13,6 +13,7 @@ import {
   DropShadowStyleProps,
 } from "@/styles/utils/dropShadowStyle";
 import { borderStyle, BorderStyleProps } from "@/styles/utils/borderStyle";
+import { PolymorphicPropsWithoutRef } from "@/components/utils/polymorphic";
 
 type StyledButtonProps = TypographyStyleProps &
   SpacingStyleProps &
@@ -45,16 +46,16 @@ const internalButtonCss = css<StyledButtonProps>`
   }
 `;
 
-export type InternalButtonProps<C extends ElementType = "button"> =
-  StyledButtonProps & {
-    as?: C;
-    onHovered?: (
-      event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-      duration: number,
-    ) => void;
-  } & ComponentPropsWithoutRef<C>;
+export type InternalButtonProps = StyledButtonProps & {
+  onHovered?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    duration: number,
+  ) => void;
+};
 
-const UnstyledInternalButton = (props: InternalButtonProps) => {
+const UnstyledInternalButton = <C extends ElementType = "button">(
+  props: InternalButtonProps & PolymorphicPropsWithoutRef<C>,
+) => {
   const { onClick, onHovered, as: Component = "button", ...rest } = props;
 
   const hoverStart = useRef(Date.now());

--- a/src/components/base/InternalButton/InternalButton.tsx
+++ b/src/components/base/InternalButton/InternalButton.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { ElementType, useRef, ComponentPropsWithoutRef } from "react";
 import styled, { css } from "styled-components";
 
 import { colorStyle, ColorStyleProps } from "@/styles/utils/colorStyle";
@@ -45,22 +45,23 @@ const internalButtonCss = css<StyledButtonProps>`
   }
 `;
 
-export type InternalButtonProps = StyledButtonProps & {
+export type InternalButtonProps<C extends ElementType = "button"> = StyledButtonProps & {
+  as?: C;
   onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   onHovered?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
     duration: number,
   ) => void;
-  children?: React.ReactNode;
-  className?: string;
-  disabled?: boolean;
-  "data-testid"?: string;
-  type?: "button" | "submit" | "reset";
-  form?: string;
-};
+  // children?: React.ReactNode;
+  // className?: string;
+  // disabled?: boolean;
+  // "data-testid"?: string;
+  // type?: "button" | "submit" | "reset";
+  // form?: string;
+} & ComponentPropsWithoutRef<C>;
 
 const UnstyledInternalButton = (props: InternalButtonProps) => {
-  const { onClick, onHovered } = props;
+  const { onClick, onHovered, as: Component = "button", ...rest } = props;
 
   const hoverStart = useRef(Date.now());
 
@@ -82,18 +83,17 @@ const UnstyledInternalButton = (props: InternalButtonProps) => {
   };
 
   return (
-    <button
+    <Component
       className={props.className}
-      data-testid={props["data-testid"]}
-      disabled={props.disabled}
+      // data-testid={props["data-testid"]}
+      // disabled={props.disabled}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      type={props.type ?? "button"}
-      form={props.form}
-    >
-      {props.children}
-    </button>
+      // type={props.type ?? "button"}
+      // form={props.form}
+      {...rest}
+    />
   );
 };
 

--- a/src/components/base/InternalButton/InternalButton.tsx
+++ b/src/components/base/InternalButton/InternalButton.tsx
@@ -45,20 +45,21 @@ const internalButtonCss = css<StyledButtonProps>`
   }
 `;
 
-export type InternalButtonProps<C extends ElementType = "button"> = StyledButtonProps & {
-  as?: C;
-  onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-  onHovered?: (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    duration: number,
-  ) => void;
-  // children?: React.ReactNode;
-  // className?: string;
-  // disabled?: boolean;
-  // "data-testid"?: string;
-  // type?: "button" | "submit" | "reset";
-  // form?: string;
-} & ComponentPropsWithoutRef<C>;
+export type InternalButtonProps<C extends ElementType = "button"> =
+  StyledButtonProps & {
+    as?: C;
+    onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    onHovered?: (
+      event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+      duration: number,
+    ) => void;
+    // children?: React.ReactNode;
+    // className?: string;
+    // disabled?: boolean;
+    // "data-testid"?: string;
+    // type?: "button" | "submit" | "reset";
+    // form?: string;
+  } & ComponentPropsWithoutRef<C>;
 
 const UnstyledInternalButton = (props: InternalButtonProps) => {
   const { onClick, onHovered, as: Component = "button", ...rest } = props;

--- a/src/components/base/InternalButton/InternalButton.tsx
+++ b/src/components/base/InternalButton/InternalButton.tsx
@@ -56,7 +56,7 @@ export type InternalButtonProps = StyledButtonProps & {
 const UnstyledInternalButton = <C extends ElementType = "button">(
   props: InternalButtonProps & PolymorphicPropsWithoutRef<C>,
 ) => {
-  const { onClick, onHovered, as: Component = "button", ...rest } = props;
+  const { onClick, onHovered, element: Component = "button", ...rest } = props;
 
   const hoverStart = useRef(Date.now());
 
@@ -79,10 +79,10 @@ const UnstyledInternalButton = <C extends ElementType = "button">(
 
   return (
     <Component
+      {...rest}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      {...rest}
     />
   );
 };

--- a/src/components/base/InternalButton/__snapshots__/InternalButton.test.tsx.snap
+++ b/src/components/base/InternalButton/__snapshots__/InternalButton.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`InternalButton matches snapshot 1`] = `
   onClick={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
-  type="button"
 >
   Click Me
 </button>

--- a/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -162,11 +162,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   className="c0 c1 button-wrapper"
 >
   <button
-    className="c2 c3  c4"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    type="button"
+    className="c2 c3 c4"
   >
     <div
       className="c5 c6"

--- a/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -126,27 +126,27 @@ exports[`OakHintButton matches snapshot 1`] = `
   color: #808080;
 }
 
-.c1 button:focus-visible .shadow {
+.c1 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c1 button:hover .shadow {
+.c1 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c1 button:active .shadow {
+.c1 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c1 button:disabled .icon-container {
+.c1 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c1 button:hover .icon-container {
+.c1 > :first-child:hover .icon-container {
   background: #ffe555;
 }
 
-.c1 button:active .icon-container {
+.c1 > :first-child:active .icon-container {
   background: #ffe555;
 }
 

--- a/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -163,6 +163,9 @@ exports[`OakHintButton matches snapshot 1`] = `
 >
   <button
     className="c2 c3 c4"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <div
       className="c5 c6"

--- a/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -259,6 +259,8 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
         <button
           className="c7 c8 c9"
           onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
           <div
             className="c10 c11"

--- a/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -188,27 +188,27 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   color: #808080;
 }
 
-.c6 button:focus-visible .shadow {
+.c6 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c6 button:hover .shadow {
+.c6 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c6 button:active .shadow {
+.c6 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c6 button:disabled .icon-container {
+.c6 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c6 button:hover .icon-container {
+.c6 > :first-child:hover .icon-container {
   background: #ffe555;
 }
 
-.c6 button:active .icon-container {
+.c6 > :first-child:active .icon-container {
   background: #ffe555;
 }
 

--- a/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -257,11 +257,8 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
         className="c5 c6 button-wrapper"
       >
         <button
-          className="c7 c8  c9"
+          className="c7 c8 c9"
           onClick={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          type="button"
         >
           <div
             className="c10 c11"

--- a/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -186,6 +186,8 @@ exports[`OakQuizHint matches snapshot 1`] = `
       <button
         className="c4 c5 c6"
         onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
       >
         <div
           className="c7 c8"

--- a/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -184,11 +184,8 @@ exports[`OakQuizHint matches snapshot 1`] = `
       className="c2 c3 button-wrapper"
     >
       <button
-        className="c4 c5  c6"
+        className="c4 c5 c6"
         onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        type="button"
       >
         <div
           className="c7 c8"

--- a/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -145,27 +145,27 @@ exports[`OakQuizHint matches snapshot 1`] = `
   color: #808080;
 }
 
-.c3 button:focus-visible .shadow {
+.c3 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c3 button:hover .shadow {
+.c3 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c3 button:active .shadow {
+.c3 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c3 button:disabled .icon-container {
+.c3 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c3 button:hover .icon-container {
+.c3 > :first-child:hover .icon-container {
   background: #ffe555;
 }
 
-.c3 button:active .icon-container {
+.c3 > :first-child:active .icon-container {
   background: #ffe555;
 }
 

--- a/src/components/ui/InternalRectButton/InternalRectButton.stories.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.stories.tsx
@@ -111,7 +111,7 @@ export const LinkStyledAsButton: Story = {
     </OakFlex>
   ),
   args: {
-    as: "a",
+    element: "a",
     href: "/",
     iconName: "arrow-right",
     defaultBackground: "bg-btn-secondary",

--- a/src/components/ui/InternalRectButton/InternalRectButton.stories.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.stories.tsx
@@ -104,7 +104,7 @@ export const Default: Story = {
   },
 };
 
-export const LinkAsButton: Story = {
+export const LinkStyledAsButton: Story = {
   render: (args) => (
     <OakFlex $gap="space-between-m">
       <InternalRectButton {...args}>Link</InternalRectButton>

--- a/src/components/ui/InternalRectButton/InternalRectButton.stories.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.stories.tsx
@@ -103,3 +103,25 @@ export const Default: Story = {
     disabledTextColor: "text-disabled",
   },
 };
+
+export const LinkAsButton: Story = {
+  render: (args) => (
+    <OakFlex $gap="space-between-m">
+      <InternalRectButton {...args}>Link</InternalRectButton>
+    </OakFlex>
+  ),
+  args: {
+    as: "a",
+    href: "/",
+    iconName: "arrow-right",
+    defaultBackground: "bg-btn-secondary",
+    defaultTextColor: "text-primary",
+    defaultBorderColor: "text-primary",
+    hoverBackground: "bg-btn-secondary-hover",
+    hoverTextColor: "text-primary",
+    hoverBorderColor: "text-primary",
+    disabledBackground: "bg-btn-secondary-disabled",
+    disabledBorderColor: "text-disabled",
+    disabledTextColor: "text-disabled",
+  },
+};

--- a/src/components/ui/InternalRectButton/InternalRectButton.test.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.test.tsx
@@ -121,7 +121,6 @@ describe("InternalRectButton", () => {
       <InternalRectButton
         {...defaultArgs}
         as="button"
-        href="/"
         data-testid="test"
         onHovered={onHovered}
       >

--- a/src/components/ui/InternalRectButton/InternalRectButton.test.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.test.tsx
@@ -121,7 +121,6 @@ describe("InternalRectButton", () => {
     const { getByTestId } = render(
       <InternalRectButton
         {...defaultArgs}
-        as="button"
         data-testid="test"
         onHovered={onHovered}
       >

--- a/src/components/ui/InternalRectButton/InternalRectButton.test.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.test.tsx
@@ -120,6 +120,8 @@ describe("InternalRectButton", () => {
     const { getByTestId } = render(
       <InternalRectButton
         {...defaultArgs}
+        as="button"
+        href="/"
         data-testid="test"
         onHovered={onHovered}
       >

--- a/src/components/ui/InternalRectButton/InternalRectButton.test.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.test.tsx
@@ -49,7 +49,7 @@ describe("InternalRectButton", () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("renders the chidren", () => {
+  it("renders the children", () => {
     const { getByText } = render(
       <InternalRectButton {...defaultArgs}>Click</InternalRectButton>,
     );
@@ -78,6 +78,7 @@ describe("InternalRectButton", () => {
         Click
       </InternalRectButton>,
     );
+
     fireEvent.mouseEnter(getByTestId("test"));
     fireEvent.mouseLeave(getByTestId("test"));
     expect(onHovered).toHaveBeenCalledTimes(1);

--- a/src/components/ui/InternalRectButton/InternalRectButton.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.tsx
@@ -16,9 +16,10 @@ import {
 import { parseColor } from "@/styles/helpers/parseColor";
 import { OakCombinedColorToken } from "@/styles";
 import { SizeStyleProps, sizeStyle } from "@/styles/utils/sizeStyle";
+import { PolymorphicPropsWithoutRef } from "@/components/utils/polymorphic";
 
-export type InternalRectButtonProps<C extends ElementType = "button"> = Omit<
-  InternalButtonProps<C>,
+export type InternalRectButtonProps = Omit<
+  InternalButtonProps,
   | "$pa"
   | "$ph"
   | "$pv"
@@ -43,7 +44,7 @@ export type InternalRectButtonProps<C extends ElementType = "button"> = Omit<
   maxWidth?: SizeStyleProps["$maxWidth"];
 } & PositionStyleProps;
 
-const StyledInternalButton = styled(InternalButton) <
+const StyledInternalButton = styled(InternalButton)<
   InternalRectButtonProps & SizeStyleProps
 >`
   ${positionStyle}
@@ -90,7 +91,9 @@ const StyledButtonWrapper = styled(OakBox)`
   }
 `;
 
-export const InternalRectButton = <C extends ElementType = "button">(props: InternalRectButtonProps<C>) => {
+export const InternalRectButton = <C extends ElementType = "button">(
+  props: InternalRectButtonProps & PolymorphicPropsWithoutRef<C>,
+) => {
   const {
     as = "button",
     children,

--- a/src/components/ui/InternalRectButton/InternalRectButton.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.tsx
@@ -155,7 +155,6 @@ export const InternalRectButton = <C extends ElementType = "button">(
       <StyledInternalButton
         as={as}
         className="internal-button"
-        {...rest}
         $ba={"border-solid-m"}
         $background={props.defaultBackground}
         $borderColor={props.defaultBorderColor}
@@ -167,6 +166,7 @@ export const InternalRectButton = <C extends ElementType = "button">(
         disabled={disabled || isLoading}
         $width={"100%"}
         $height={"100%"}
+        {...rest}
       >
         <OakFlex
           $flexDirection={"row"}

--- a/src/components/ui/InternalRectButton/InternalRectButton.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ElementType } from "react";
 import styled, { css } from "styled-components";
 
 import { OakBox, OakFlex, OakSpan } from "@/components/base";
@@ -17,8 +17,8 @@ import { parseColor } from "@/styles/helpers/parseColor";
 import { OakCombinedColorToken } from "@/styles";
 import { SizeStyleProps, sizeStyle } from "@/styles/utils/sizeStyle";
 
-export type InternalRectButtonProps = Omit<
-  InternalButtonProps,
+export type InternalRectButtonProps<C extends ElementType = "button"> = Omit<
+  InternalButtonProps<C>,
   | "$pa"
   | "$ph"
   | "$pv"
@@ -43,11 +43,12 @@ export type InternalRectButtonProps = Omit<
   maxWidth?: SizeStyleProps["$maxWidth"];
 } & PositionStyleProps;
 
-const StyledInternalButton = styled(InternalButton)<
+const StyledInternalButton = styled(InternalButton) <
   InternalRectButtonProps & SizeStyleProps
 >`
   ${positionStyle}
   ${sizeStyle}
+  display: inline-block;
   ${(props) => css`
     &:hover {
       text-decoration: underline;
@@ -89,8 +90,9 @@ const StyledButtonWrapper = styled(OakBox)`
   }
 `;
 
-export const InternalRectButton = (props: InternalRectButtonProps) => {
+export const InternalRectButton = <C extends ElementType = "button">(props: InternalRectButtonProps<C>) => {
   const {
+    as = "button",
     children,
     iconName,
     isTrailingIcon,
@@ -148,6 +150,7 @@ export const InternalRectButton = (props: InternalRectButtonProps) => {
       />
 
       <StyledInternalButton
+        as={as}
         className="internal-button"
         {...rest}
         $ba={"border-solid-m"}

--- a/src/components/ui/InternalRectButton/InternalRectButton.tsx
+++ b/src/components/ui/InternalRectButton/InternalRectButton.tsx
@@ -45,7 +45,17 @@ export type InternalRectButtonProps = Omit<
 } & PositionStyleProps;
 
 const StyledInternalButton = styled(InternalButton)<
-  InternalRectButtonProps & SizeStyleProps
+  SizeStyleProps & {
+    $defaultTextColor: OakCombinedColorToken;
+    $defaultBackground: OakCombinedColorToken;
+    $defaultBorderColor: OakCombinedColorToken;
+    $hoverTextColor: OakCombinedColorToken;
+    $hoverBackground: OakCombinedColorToken;
+    $hoverBorderColor: OakCombinedColorToken;
+    $disabledBackground: OakCombinedColorToken;
+    $disabledBorderColor: OakCombinedColorToken;
+    $disabledTextColor: OakCombinedColorToken;
+  }
 >`
   ${positionStyle}
   ${sizeStyle}
@@ -53,19 +63,19 @@ const StyledInternalButton = styled(InternalButton)<
   ${(props) => css`
     &:hover {
       text-decoration: underline;
-      color: ${parseColor(props.hoverTextColor)};
-      background: ${parseColor(props.hoverBackground)};
-      border-color: ${parseColor(props.hoverBorderColor)};
+      color: ${parseColor(props.$hoverTextColor)};
+      background: ${parseColor(props.$hoverBackground)};
+      border-color: ${parseColor(props.$hoverBorderColor)};
     }
     &:active {
-      background: ${parseColor(props.defaultBackground)};
-      border-color: ${parseColor(props.defaultBorderColor)};
-      color: ${parseColor(props.defaultTextColor)};
+      background: ${parseColor(props.$defaultBackground)};
+      border-color: ${parseColor(props.$defaultBorderColor)};
+      color: ${parseColor(props.$defaultTextColor)};
     }
     &:disabled {
-      background: ${parseColor(props.disabledBackground)};
-      border-color: ${parseColor(props.disabledBorderColor)};
-      color: ${parseColor(props.disabledTextColor)};
+      background: ${parseColor(props.$disabledBackground)};
+      border-color: ${parseColor(props.$disabledBorderColor)};
+      color: ${parseColor(props.$disabledTextColor)};
     }
   `}
 `;
@@ -95,7 +105,7 @@ export const InternalRectButton = <C extends ElementType = "button">(
   props: InternalRectButtonProps & PolymorphicPropsWithoutRef<C>,
 ) => {
   const {
-    as = "button",
+    element = "button",
     children,
     iconName,
     isTrailingIcon,
@@ -103,6 +113,15 @@ export const InternalRectButton = <C extends ElementType = "button">(
     disabled,
     width,
     maxWidth,
+    defaultBackground,
+    defaultBorderColor,
+    defaultTextColor,
+    disabledTextColor,
+    hoverTextColor,
+    hoverBackground,
+    hoverBorderColor,
+    disabledBackground,
+    disabledBorderColor,
     ...rest
   } = props;
 
@@ -113,9 +132,7 @@ export const InternalRectButton = <C extends ElementType = "button">(
           iconName={iconName}
           $width={"all-spacing-6"}
           $height={"all-spacing-6"}
-          $colorFilter={
-            props.disabled ? props.disabledTextColor : props.defaultTextColor
-          }
+          $colorFilter={props.disabled ? disabledTextColor : defaultTextColor}
         />
       )}
     </>
@@ -153,12 +170,12 @@ export const InternalRectButton = <C extends ElementType = "button">(
       />
 
       <StyledInternalButton
-        as={as}
+        element={element}
         className="internal-button"
         $ba={"border-solid-m"}
-        $background={props.defaultBackground}
-        $borderColor={props.defaultBorderColor}
-        $color={props.defaultTextColor}
+        $background={defaultBackground}
+        $borderColor={defaultBorderColor}
+        $color={defaultTextColor}
         $pv={"inner-padding-xs"}
         $ph={"inner-padding-s"}
         $borderRadius={"border-radius-s"}
@@ -166,6 +183,15 @@ export const InternalRectButton = <C extends ElementType = "button">(
         disabled={disabled || isLoading}
         $width={"100%"}
         $height={"100%"}
+        $hoverTextColor={hoverTextColor}
+        $hoverBackground={hoverBackground}
+        $hoverBorderColor={hoverBorderColor}
+        $defaultTextColor={defaultTextColor}
+        $defaultBackground={defaultBackground}
+        $defaultBorderColor={defaultBorderColor}
+        $disabledTextColor={disabledTextColor}
+        $disabledBackground={disabledBackground}
+        $disabledBorderColor={disabledBorderColor}
         {...rest}
       >
         <OakFlex

--- a/src/components/ui/InternalRectButton/__snapshots__/InternalRectButton.test.tsx.snap
+++ b/src/components/ui/InternalRectButton/__snapshots__/InternalRectButton.test.tsx.snap
@@ -148,6 +148,9 @@ exports[`InternalRectButton matches snapshot 1`] = `
   />
   <button
     className="c3 c4 internal-button"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <div
       className="c5 c6"

--- a/src/components/ui/InternalRectButton/__snapshots__/InternalRectButton.test.tsx.snap
+++ b/src/components/ui/InternalRectButton/__snapshots__/InternalRectButton.test.tsx.snap
@@ -90,6 +90,7 @@ exports[`InternalRectButton matches snapshot 1`] = `
   position: relative;
   width: 100%;
   height: 100%;
+  display: inline-block;
 }
 
 .c4:hover {
@@ -147,10 +148,6 @@ exports[`InternalRectButton matches snapshot 1`] = `
   />
   <button
     className="c3 c4 internal-button"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    type="button"
   >
     <div
       className="c5 c6"

--- a/src/components/ui/InternalRoundButton/InternalRoundButton.stories.tsx
+++ b/src/components/ui/InternalRoundButton/InternalRoundButton.stories.tsx
@@ -104,7 +104,31 @@ export const Default: Story = {
     disabledTextColor: "text-disabled",
     disabledIconColor: "white",
     defaultIconColor: "white",
-    hoverIconBackground: "mint40",
+    hoverIconBackground: "mint50",
+    width: "auto",
+    iconBackgroundSize: "all-spacing-7",
+    iconSize: "all-spacing-6",
+  },
+};
+
+export const LinkStyledAsButton: Story = {
+  render: (args) => (
+    <OakFlex $gap="space-between-m">
+      <InternalRoundButton {...args}>Link</InternalRoundButton>
+    </OakFlex>
+  ),
+  args: {
+    as: "a",
+    href: "/",
+    iconName: "lightbulb",
+    defaultIconBackground: "mint",
+    defaultTextColor: "text-primary",
+    hoverTextColor: "text-primary",
+    disabledIconBackground: "bg-btn-primary-disabled",
+    disabledTextColor: "text-disabled",
+    disabledIconColor: "white",
+    defaultIconColor: "white",
+    hoverIconBackground: "mint50",
     width: "auto",
     iconBackgroundSize: "all-spacing-7",
     iconSize: "all-spacing-6",

--- a/src/components/ui/InternalRoundButton/InternalRoundButton.tsx
+++ b/src/components/ui/InternalRoundButton/InternalRoundButton.tsx
@@ -56,21 +56,21 @@ const StyledInternalButton = styled(InternalButton)<
   ${(props) => css`
     &:hover {
       text-decoration: underline;
-      color: ${parseColor(props.hoverTextColor)};
+      color: ${parseColor(props.$hoverTextColor)};
     }
     &:active {
-      color: ${parseColor(props.defaultTextColor)};
+      color: ${parseColor(props.$defaultTextColor)};
     }
     &:disabled {
-      color: ${parseColor(props.disabledTextColor)};
+      color: ${parseColor(props.$disabledTextColor)};
     }
   `}
 `;
 
 const StyledButtonWrapper = styled(OakBox)<{
-  disabledIconBackground: OakCombinedColorToken;
-  hoverIconBackground: OakCombinedColorToken;
-  defaultIconBackground: OakCombinedColorToken;
+  $disabledIconBackground: OakCombinedColorToken;
+  $hoverIconBackground: OakCombinedColorToken;
+  $defaultIconBackground: OakCombinedColorToken;
 }>`
   button:focus-visible .shadow {
     box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
@@ -85,13 +85,13 @@ const StyledButtonWrapper = styled(OakBox)<{
   }
   ${(props) => css`
     button:disabled .icon-container {
-      background: ${parseColor(props.disabledIconBackground)};
+      background: ${parseColor(props.$disabledIconBackground)};
     }
     button:hover .icon-container {
-      background: ${parseColor(props.hoverIconBackground)};
+      background: ${parseColor(props.$hoverIconBackground)};
     }
     button:active .icon-container {
-      background: ${parseColor(props.defaultIconBackground)};
+      background: ${parseColor(props.$defaultIconBackground)};
     }
   `}
 `;
@@ -100,7 +100,7 @@ const _InternalRoundButton = <C extends ElementType = "button">(
   props: InternalRoundButtonProps & PolymorphicPropsWithoutRef<C>,
 ) => {
   const {
-    as = "button",
+    element = "button",
     children,
     iconName,
     isTrailingIcon,
@@ -110,6 +110,14 @@ const _InternalRoundButton = <C extends ElementType = "button">(
     maxWidth,
     iconBackgroundSize,
     iconSize,
+    disabledIconBackground,
+    disabledTextColor,
+    defaultIconColor,
+    hoverIconBackground,
+    defaultIconBackground,
+    disabledIconColor,
+    defaultTextColor,
+    hoverTextColor,
     ...rest
   } = props;
 
@@ -122,9 +130,9 @@ const _InternalRoundButton = <C extends ElementType = "button">(
           $height={iconSize}
           $colorFilter={
             props.disabled
-              ? props.disabledIconColor
-              : props.defaultIconColor
-                ? props.defaultIconColor
+              ? disabledIconColor
+              : defaultIconColor
+                ? defaultIconColor
                 : null
           }
         />
@@ -167,14 +175,17 @@ const _InternalRoundButton = <C extends ElementType = "button">(
       $position={"relative"}
       $width={width}
       $maxWidth={maxWidth}
-      disabledIconBackground={props.disabledIconBackground}
-      hoverIconBackground={props.hoverIconBackground}
-      defaultIconBackground={props.defaultIconBackground}
+      $disabledIconBackground={disabledIconBackground}
+      $hoverIconBackground={hoverIconBackground}
+      $defaultIconBackground={defaultIconBackground}
     >
       <StyledInternalButton
-        as={as ?? "button"}
+        element={element ?? "button"}
         {...rest}
-        $color={props.defaultTextColor}
+        $hoverTextColor={hoverTextColor}
+        $defaultTextColor={defaultTextColor}
+        $disabledTextColor={disabledTextColor}
+        $color={defaultTextColor}
         $pv={"inner-padding-xs"}
         $ph={"inner-padding-s"}
         $position={"relative"}

--- a/src/components/ui/InternalRoundButton/InternalRoundButton.tsx
+++ b/src/components/ui/InternalRoundButton/InternalRoundButton.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { ElementType } from "react";
 import styled, { css } from "styled-components";
 
 import { OakRoundIconProps } from "../OakRoundIcon";
 
+import { PolymorphicPropsWithoutRef } from "@/components/utils/polymorphic";
 import { OakBox, OakFlex, OakSpan } from "@/components/base";
 import {
   InternalButton,
@@ -95,8 +96,11 @@ const StyledButtonWrapper = styled(OakBox)<{
   `}
 `;
 
-const _InternalRoundButton = (props: InternalRoundButtonProps) => {
+const _InternalRoundButton = <C extends ElementType = "button">(
+  props: InternalRoundButtonProps & PolymorphicPropsWithoutRef<C>,
+) => {
   const {
+    as = "button",
     children,
     iconName,
     isTrailingIcon,
@@ -168,6 +172,7 @@ const _InternalRoundButton = (props: InternalRoundButtonProps) => {
       defaultIconBackground={props.defaultIconBackground}
     >
       <StyledInternalButton
+        as={as ?? "button"}
         {...rest}
         $color={props.defaultTextColor}
         $pv={"inner-padding-xs"}
@@ -190,4 +195,4 @@ const _InternalRoundButton = (props: InternalRoundButtonProps) => {
   );
 };
 
-export const InternalRoundButton = styled(_InternalRoundButton)``;
+export const InternalRoundButton = _InternalRoundButton;

--- a/src/components/ui/InternalRoundButton/InternalRoundButton.tsx
+++ b/src/components/ui/InternalRoundButton/InternalRoundButton.tsx
@@ -72,25 +72,25 @@ const StyledButtonWrapper = styled(OakBox)<{
   $hoverIconBackground: OakCombinedColorToken;
   $defaultIconBackground: OakCombinedColorToken;
 }>`
-  button:focus-visible .shadow {
+  > :first-child:focus-visible .shadow {
     box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
       ${parseDropShadow("drop-shadow-centered-grey")};
   }
-  button:hover .shadow {
+  > :first-child:hover .shadow {
     box-shadow: ${parseDropShadow("drop-shadow-lemon")};
   }
-  button:active .shadow {
+  > :first-child:active .shadow {
     box-shadow: ${parseDropShadow("drop-shadow-lemon")},
       ${parseDropShadow("drop-shadow-grey")};
   }
   ${(props) => css`
-    button:disabled .icon-container {
+    > :first-child:disabled .icon-container {
       background: ${parseColor(props.$disabledIconBackground)};
     }
-    button:hover .icon-container {
+    > :first-child:hover .icon-container {
       background: ${parseColor(props.$hoverIconBackground)};
     }
-    button:active .icon-container {
+    > :first-child:active .icon-container {
       background: ${parseColor(props.$defaultIconBackground)};
     }
   `}

--- a/src/components/ui/InternalRoundButton/__snapshots__/InternalRoundButton.test.tsx.snap
+++ b/src/components/ui/InternalRoundButton/__snapshots__/InternalRoundButton.test.tsx.snap
@@ -155,6 +155,9 @@ exports[`InternalRoundButton matches snapshot 1`] = `
 >
   <button
     className="c2 c3"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <div
       className="c4 c5"

--- a/src/components/ui/InternalRoundButton/__snapshots__/InternalRoundButton.test.tsx.snap
+++ b/src/components/ui/InternalRoundButton/__snapshots__/InternalRoundButton.test.tsx.snap
@@ -154,11 +154,7 @@ exports[`InternalRoundButton matches snapshot 1`] = `
   className="c0 c1 button-wrapper"
 >
   <button
-    className="c2 c3 "
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    type="button"
+    className="c2 c3"
   >
     <div
       className="c4 c5"

--- a/src/components/ui/InternalRoundButton/__snapshots__/InternalRoundButton.test.tsx.snap
+++ b/src/components/ui/InternalRoundButton/__snapshots__/InternalRoundButton.test.tsx.snap
@@ -126,27 +126,27 @@ exports[`InternalRoundButton matches snapshot 1`] = `
   color: #cacaca;
 }
 
-.c1 button:focus-visible .shadow {
+.c1 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c1 button:hover .shadow {
+.c1 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c1 button:active .shadow {
+.c1 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c1 button:disabled .icon-container {
+.c1 > :first-child:disabled .icon-container {
   background: #f2f2f2;
 }
 
-.c1 button:hover .icon-container {
+.c1 > :first-child:hover .icon-container {
   background: #bef2bd;
 }
 
-.c1 button:active .icon-container {
+.c1 > :first-child:active .icon-container {
   background: #bef2bd;
 }
 

--- a/src/components/ui/OakPrimaryButton/OakPrimaryButton.stories.tsx
+++ b/src/components/ui/OakPrimaryButton/OakPrimaryButton.stories.tsx
@@ -72,7 +72,7 @@ export const LinkStyledAsButton: Story = {
     </OakFlex>
   ),
   args: {
-    as: "a",
+    element: "a",
     href: "/",
     iconName: "arrow-right",
   },

--- a/src/components/ui/OakPrimaryButton/OakPrimaryButton.stories.tsx
+++ b/src/components/ui/OakPrimaryButton/OakPrimaryButton.stories.tsx
@@ -77,4 +77,3 @@ export const LinkStyledAsButton: Story = {
     iconName: "arrow-right",
   },
 };
-

--- a/src/components/ui/OakPrimaryButton/OakPrimaryButton.stories.tsx
+++ b/src/components/ui/OakPrimaryButton/OakPrimaryButton.stories.tsx
@@ -68,7 +68,7 @@ export const Default: Story = {
 export const LinkStyledAsButton: Story = {
   render: (args) => (
     <OakFlex $gap="space-between-m">
-      <OakPrimaryButton {...args}>Link</OakPrimaryButton>
+      <OakPrimaryButton {...args}>Primary Link</OakPrimaryButton>
     </OakFlex>
   ),
   args: {

--- a/src/components/ui/OakPrimaryButton/OakPrimaryButton.stories.tsx
+++ b/src/components/ui/OakPrimaryButton/OakPrimaryButton.stories.tsx
@@ -64,3 +64,17 @@ export const Default: Story = {
     iconName: "arrow-right",
   },
 };
+
+export const LinkStyledAsButton: Story = {
+  render: (args) => (
+    <OakFlex $gap="space-between-m">
+      <OakPrimaryButton {...args}>Link</OakPrimaryButton>
+    </OakFlex>
+  ),
+  args: {
+    as: "a",
+    href: "/",
+    iconName: "arrow-right",
+  },
+};
+

--- a/src/components/ui/OakPrimaryButton/OakPrimaryButton.tsx
+++ b/src/components/ui/OakPrimaryButton/OakPrimaryButton.tsx
@@ -1,30 +1,27 @@
-import React from "react";
+import React, { ElementType } from "react";
 
 import {
   InternalRectButton,
   InternalRectButtonProps,
 } from "@/components/ui/InternalRectButton";
 
-export type OakPrimaryButtonProps = Pick<
-  InternalRectButtonProps,
-  | "children"
-  | "className"
-  | "data-testid"
-  | "onClick"
-  | "onHovered"
-  | "disabled"
-  | "isLoading"
-  | "iconName"
-  | "isTrailingIcon"
-  | "type"
-  | "width"
-  | "maxWidth"
-  | "form"
->;
+export type OakPrimaryButtonProps<C extends ElementType = "button"> = Omit<
+  InternalRectButtonProps<C>,
+  "defaultBorderColor"
+  | "defaultBackground"
+  | "defaultTextColor"
+  | "hoverBackground"
+  | "hoverBorderColor"
+  | "hoverTextColor"
+  | "disabledBackground"
+  | "disabledBorderColor"
+  | "disabledTextColor"
+> & { as?: C };
 
-export const OakPrimaryButton = (props: OakPrimaryButtonProps) => {
+export const OakPrimaryButton = <C extends ElementType = "button">({ as, ...rest }: OakPrimaryButtonProps<C>) => {
   return (
     <InternalRectButton
+      as={as ?? "button"}
       defaultBorderColor="bg-btn-primary"
       defaultBackground="bg-btn-primary"
       defaultTextColor="text-inverted"
@@ -34,7 +31,7 @@ export const OakPrimaryButton = (props: OakPrimaryButtonProps) => {
       disabledBackground="bg-btn-primary-disabled"
       disabledBorderColor="text-disabled"
       disabledTextColor="text-inverted"
-      {...props}
+      {...rest}
     />
   );
 };

--- a/src/components/ui/OakPrimaryButton/OakPrimaryButton.tsx
+++ b/src/components/ui/OakPrimaryButton/OakPrimaryButton.tsx
@@ -20,12 +20,12 @@ export type OakPrimaryButtonProps = Omit<
 >;
 
 export const OakPrimaryButton = <C extends ElementType = "button">({
-  as,
+  element,
   ...rest
 }: OakPrimaryButtonProps & PolymorphicPropsWithoutRef<C>) => {
   return (
     <InternalRectButton
-      as={as ?? "button"}
+      element={element ?? "button"}
       defaultBorderColor="bg-btn-primary"
       defaultBackground="bg-btn-primary"
       defaultTextColor="text-inverted"

--- a/src/components/ui/OakPrimaryButton/OakPrimaryButton.tsx
+++ b/src/components/ui/OakPrimaryButton/OakPrimaryButton.tsx
@@ -4,10 +4,11 @@ import {
   InternalRectButton,
   InternalRectButtonProps,
 } from "@/components/ui/InternalRectButton";
+import { PolymorphicPropsWithoutRef } from "@/components/utils/polymorphic";
 
-export type OakPrimaryButtonProps<C extends ElementType = "button"> = Omit<
-  InternalRectButtonProps<C>,
-  "defaultBorderColor"
+export type OakPrimaryButtonProps = Omit<
+  InternalRectButtonProps,
+  | "defaultBorderColor"
   | "defaultBackground"
   | "defaultTextColor"
   | "hoverBackground"
@@ -16,9 +17,12 @@ export type OakPrimaryButtonProps<C extends ElementType = "button"> = Omit<
   | "disabledBackground"
   | "disabledBorderColor"
   | "disabledTextColor"
-> & { as?: C };
+>;
 
-export const OakPrimaryButton = <C extends ElementType = "button">({ as, ...rest }: OakPrimaryButtonProps<C>) => {
+export const OakPrimaryButton = <C extends ElementType = "button">({
+  as,
+  ...rest
+}: OakPrimaryButtonProps & PolymorphicPropsWithoutRef<C>) => {
   return (
     <InternalRectButton
       as={as ?? "button"}

--- a/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -92,6 +92,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   position: relative;
   width: 100%;
   height: 100%;
+  display: inline-block;
 }
 
 .c4:hover {
@@ -149,10 +150,6 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   />
   <button
     className="c3 c4 internal-button"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    type="button"
   >
     <div
       className="c5 c6"

--- a/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -150,6 +150,9 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   />
   <button
     className="c3 c4 internal-button"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <div
       className="c5 c6"

--- a/src/components/ui/OakSecondaryButton/OakSecondaryButton.stories.tsx
+++ b/src/components/ui/OakSecondaryButton/OakSecondaryButton.stories.tsx
@@ -72,7 +72,7 @@ export const LinkStyledAsButton: Story = {
     </OakFlex>
   ),
   args: {
-    as: "a",
+    element: "a",
     href: "/",
     iconName: "arrow-right",
   },

--- a/src/components/ui/OakSecondaryButton/OakSecondaryButton.stories.tsx
+++ b/src/components/ui/OakSecondaryButton/OakSecondaryButton.stories.tsx
@@ -64,3 +64,16 @@ export const Default: Story = {
     iconName: "arrow-right",
   },
 };
+
+export const LinkStyledAsButton: Story = {
+  render: (args) => (
+    <OakFlex $gap="space-between-m">
+      <OakSecondaryButton {...args}>Secondary Link</OakSecondaryButton>
+    </OakFlex>
+  ),
+  args: {
+    as: "a",
+    href: "/",
+    iconName: "arrow-right",
+  },
+};

--- a/src/components/ui/OakSecondaryButton/OakSecondaryButton.tsx
+++ b/src/components/ui/OakSecondaryButton/OakSecondaryButton.tsx
@@ -20,12 +20,12 @@ export type OakSecondaryButtonProps = Omit<
 >;
 
 export const OakSecondaryButton = <C extends ElementType = "button">({
-  as,
+  element,
   ...rest
 }: OakSecondaryButtonProps & PolymorphicPropsWithoutRef<C>) => {
   return (
     <InternalRectButton
-      as={as ?? "button"}
+      element={element ?? "button"}
       defaultBorderColor="text-primary"
       defaultBackground="bg-btn-secondary"
       defaultTextColor="text-primary"

--- a/src/components/ui/OakSecondaryButton/OakSecondaryButton.tsx
+++ b/src/components/ui/OakSecondaryButton/OakSecondaryButton.tsx
@@ -1,30 +1,31 @@
-import React from "react";
+import React, { ElementType } from "react";
 
 import {
   InternalRectButton,
   InternalRectButtonProps,
 } from "@/components/ui/InternalRectButton";
+import { PolymorphicPropsWithoutRef } from "@/components/utils/polymorphic";
 
-export type OakSecondaryButtonProps = Pick<
+export type OakSecondaryButtonProps = Omit<
   InternalRectButtonProps,
-  | "children"
-  | "className"
-  | "data-testid"
-  | "onClick"
-  | "onHovered"
-  | "disabled"
-  | "isLoading"
-  | "iconName"
-  | "isTrailingIcon"
-  | "type"
-  | "width"
-  | "maxWidth"
-  | "form"
+  | "defaultBorderColor"
+  | "defaultBackground"
+  | "defaultTextColor"
+  | "hoverBackground"
+  | "hoverBorderColor"
+  | "hoverTextColor"
+  | "disabledBackground"
+  | "disabledBorderColor"
+  | "disabledTextColor"
 >;
 
-export const OakSecondaryButton = (props: OakSecondaryButtonProps) => {
+export const OakSecondaryButton = <C extends ElementType = "button">({
+  as,
+  ...rest
+}: OakSecondaryButtonProps & PolymorphicPropsWithoutRef<C>) => {
   return (
     <InternalRectButton
+      as={as ?? "button"}
       defaultBorderColor="text-primary"
       defaultBackground="bg-btn-secondary"
       defaultTextColor="text-primary"
@@ -34,7 +35,7 @@ export const OakSecondaryButton = (props: OakSecondaryButtonProps) => {
       disabledBackground="bg-btn-secondary-disabled"
       disabledBorderColor="text-disabled"
       disabledTextColor="text-disabled"
-      {...props}
+      {...rest}
     />
   );
 };

--- a/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -92,6 +92,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   position: relative;
   width: 100%;
   height: 100%;
+  display: inline-block;
 }
 
 .c4:hover {
@@ -149,10 +150,6 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   />
   <button
     className="c3 c4 internal-button"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    type="button"
   >
     <div
       className="c5 c6"

--- a/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -150,6 +150,9 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   />
   <button
     className="c3 c4 internal-button"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <div
       className="c5 c6"

--- a/src/components/ui/OakTertiaryButton/OakTertiaryButton.stories.tsx
+++ b/src/components/ui/OakTertiaryButton/OakTertiaryButton.stories.tsx
@@ -41,3 +41,16 @@ export const Default: Story = {
     iconName: "chevron-right",
   },
 };
+
+export const LinkStyledAsButton: Story = {
+  render: (args) => (
+    <OakFlex $flexWrap={"wrap"}>
+      <OakTertiaryButton {...args}>Tertiary Link</OakTertiaryButton>
+    </OakFlex>
+  ),
+  args: {
+    as: "a",
+    href: "/",
+    iconName: "chevron-right",
+  },
+};

--- a/src/components/ui/OakTertiaryButton/OakTertiaryButton.stories.tsx
+++ b/src/components/ui/OakTertiaryButton/OakTertiaryButton.stories.tsx
@@ -49,7 +49,7 @@ export const LinkStyledAsButton: Story = {
     </OakFlex>
   ),
   args: {
-    as: "a",
+    element: "a",
     href: "/",
     iconName: "chevron-right",
   },

--- a/src/components/ui/OakTertiaryButton/OakTertiaryButton.tsx
+++ b/src/components/ui/OakTertiaryButton/OakTertiaryButton.tsx
@@ -19,7 +19,7 @@ type OakTertiaryButtonProps = InternalButtonProps & {
  */
 
 export const OakTertiaryButton = <C extends ElementType = "button">({
-  as,
+  element,
   isTrailingIcon,
   iconName,
   children,
@@ -27,7 +27,7 @@ export const OakTertiaryButton = <C extends ElementType = "button">({
 }: OakTertiaryButtonProps & PolymorphicPropsWithoutRef<C>) => {
   return (
     <InternalRoundButton
-      as={as ?? "button"}
+      element={element ?? "button"}
       {...props}
       isTrailingIcon={isTrailingIcon}
       iconName={iconName}

--- a/src/components/ui/OakTertiaryButton/OakTertiaryButton.tsx
+++ b/src/components/ui/OakTertiaryButton/OakTertiaryButton.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { ElementType } from "react";
 
 import { OakRoundIconProps } from "../OakRoundIcon";
 import { InternalRoundButton } from "../InternalRoundButton";
 
 import { OakIconName } from "@/components/base";
 import { InternalButtonProps } from "@/components/base/InternalButton";
+import { PolymorphicPropsWithoutRef } from "@/components/utils/polymorphic";
 
 type OakTertiaryButtonProps = InternalButtonProps & {
   iconBackground?: OakRoundIconProps["$background"];
@@ -17,17 +18,17 @@ type OakTertiaryButtonProps = InternalButtonProps & {
  * An implementation of InternalRoundButton, its a subtle button with no border and a round icon.
  */
 
-export const OakTertiaryButton = ({
+export const OakTertiaryButton = <C extends ElementType = "button">({
+  as,
   isTrailingIcon,
   iconName,
   children,
-  disabled,
   ...props
-}: OakTertiaryButtonProps) => {
+}: OakTertiaryButtonProps & PolymorphicPropsWithoutRef<C>) => {
   return (
     <InternalRoundButton
+      as={as ?? "button"}
       {...props}
-      disabled={disabled}
       isTrailingIcon={isTrailingIcon}
       iconName={iconName}
       defaultIconColor={"white"}

--- a/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -143,11 +143,7 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
   className="c0 c1 button-wrapper"
 >
   <button
-    className="c2 c3 "
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    type="button"
+    className="c2 c3"
   >
     <div
       className="c4 c5"

--- a/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -144,6 +144,9 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
 >
   <button
     className="c2 c3"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <div
       className="c4 c5"

--- a/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -115,27 +115,27 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
   color: #808080;
 }
 
-.c1 button:focus-visible .shadow {
+.c1 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c1 button:hover .shadow {
+.c1 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c1 button:active .shadow {
+.c1 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c1 button:disabled .icon-container {
+.c1 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c1 button:hover .icon-container {
+.c1 > :first-child:hover .icon-container {
   background: #575757;
 }
 
-.c1 button:active .icon-container {
+.c1 > :first-child:active .icon-container {
   background: #222222;
 }
 

--- a/src/components/utils/polymorphic.ts
+++ b/src/components/utils/polymorphic.ts
@@ -1,5 +1,8 @@
 import type { ComponentPropsWithoutRef, ElementType } from "react";
 
-export type PolymorphicPropsWithoutRef<C extends ElementType> = {
-  as?: C;
-} & ComponentPropsWithoutRef<C>;
+type ElementProp<C extends ElementType> = {
+  element?: C;
+};
+
+export type PolymorphicPropsWithoutRef<C extends ElementType> = ElementProp<C> &
+  ComponentPropsWithoutRef<C>;

--- a/src/components/utils/polymorphic.ts
+++ b/src/components/utils/polymorphic.ts
@@ -1,0 +1,5 @@
+import type { ComponentPropsWithoutRef, ElementType } from "react";
+
+export type PolymorphicPropsWithoutRef<C extends ElementType> = {
+  as?: C;
+} & ComponentPropsWithoutRef<C>;


### PR DESCRIPTION
Convert button related components into polymorphic components so they can use any tag as a base tag. This will allow us to use them as links styled like buttons without duplicating the code.

Added relevant stories to Storybook.