### PR TITLE
PUPIL-283: Interaction state fixes for `OakLessonNavItem` to support the lesson overview page

### DIFF
--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
@@ -76,6 +76,16 @@ const StyledRoundIcon = styled(OakRoundIcon)<{
   }
 `;
 
+const activeIconStyles = css`
+  ${StyledRoundIcon} {
+    background: ${parseColor("bg-btn-primary")};
+
+    img {
+      filter: ${parseColorFilter("icon-main")};
+    }
+  }
+`;
+
 const StyledLessonNavItem = styled(OakFlex)<{ $disabled?: boolean }>`
   outline: none;
   text-align: initial;
@@ -92,24 +102,21 @@ const StyledLessonNavItem = styled(OakFlex)<{ $disabled?: boolean }>`
     css`
       cursor: pointer;
 
-      &:hover,
-      &:active {
-        ${StyledLabel} {
-          text-decoration: underline;
-        }
-
-        ${StyledRoundIcon} {
-          background: ${parseColor("bg-btn-primary")};
-
-          img {
-            filter: ${parseColorFilter("icon-main")};
+      /* Don't apply hover styles on touch devices */
+      @media (hover: hover) {
+        &:hover {
+          ${StyledLabel} {
+            text-decoration: underline;
           }
+
+          ${activeIconStyles}
         }
       }
 
       &:active {
         box-shadow: ${parseDropShadow("drop-shadow-lemon")},
           ${parseDropShadow("drop-shadow-grey")};
+        ${activeIconStyles}
       }
     `}
 `;

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
@@ -143,6 +143,7 @@ export const OakLessonNavItem = <C extends ElementType = "a">(
       $borderColor={borderColor}
       $ba="border-solid-l"
       $disabled={disabled}
+      $color="text-primary"
       href={disabled ? undefined : href}
       onClick={disabled ? undefined : onClick}
       {...rest}

--- a/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -119,19 +119,17 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c2:hover .c12,
+.c2:active {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
+}
+
 .c2:active .c12 {
   background: #222222;
 }
 
-.c2:hover .c12 img,
 .c2:active .c12 img {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
-}
-
-.c2:active {
-  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
 .c8 {
@@ -203,6 +201,17 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;
     letter-spacing: -0.005rem;
+  }
+}
+
+@media (hover:hover) {
+  .c2:hover .c12 {
+    background: #222222;
+  }
+
+  .c2:hover .c12 img {
+    -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+    filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   }
 }
 

--- a/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   padding-right: 1rem;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
+  color: #222222;
   background: #e7f6f5;
   border: 0.188rem solid;
   border-color: #7cd8d0;


### PR DESCRIPTION
See https://github.com/oaknational/Oak-Web-Application/pull/2221#issuecomment-1923378463


* Fixes UA `color` being applied to `OakLessonNavItem` when presented as a `<button>` by making the `color` explicit
* Fixes the hover styles becoming stuck on touch devices (at least iOS) when the item is tapped.

Storybook 👉🏼  https://deploy-preview-95--lively-meringue-8ebd43.netlify.app/?path=/story/components-integrated-oaklessonnavitem--as-a-button

### Colour on iOS (before)

![301790320-d787a930-c7c4-48d6-8c4a-0d081a598d7e](https://github.com/oaknational/oak-components/assets/122096/52cf3b3e-50d3-4ae6-b3a8-b2cd86b63757)

### Colour on iOS (after)
![Simulator Screenshot - iPhone 14 Pro Max - 2024-02-02 at 11 10 21](https://github.com/oaknational/oak-components/assets/122096/fedc8a62-c1a8-4934-8f21-c527492e47a6)

### Active/pressed state on iOS
![Simulator Screenshot - iPhone 14 Pro Max - 2024-02-02 at 11 13 44](https://github.com/oaknational/oak-components/assets/122096/cbb2ff9b-fb14-4bde-964e-5b4d977e1048)
