### PR TITLE
Fix/pupil 340/quiz text input widths

### DIFF
--- a/src/components/integrated/OakQuizTextInput/OakQuizTextInput.stories.tsx
+++ b/src/components/integrated/OakQuizTextInput/OakQuizTextInput.stories.tsx
@@ -40,3 +40,13 @@ export const WithIncorrectFeedback: Story = {
     <OakQuizTextInput value="An incorrect answer" feedback="incorrect" />
   ),
 };
+
+export const ResponsiveWidth: Story = {
+  render: () => (
+    <OakQuizTextInput
+      value="An incorrect answer"
+      feedback="incorrect"
+      wrapperWidth={["100%", "all-spacing-22"]}
+    />
+  ),
+};

--- a/src/components/integrated/OakQuizTextInput/OakQuizTextInput.stories.tsx
+++ b/src/components/integrated/OakQuizTextInput/OakQuizTextInput.stories.tsx
@@ -10,11 +10,11 @@ const meta: Meta<typeof OakQuizTextInput> = {
   tags: ["autodocs"],
   title: "components/integrated/OakQuizTextInput",
   argTypes: {
-    width: sizeArgTypes["$width"],
+    wrapperWidth: sizeArgTypes["$width"],
   },
   parameters: {
     controls: {
-      include: ["feedback", "width", "disabled"],
+      include: ["feedback", "wrapperWidth", "disabled"],
     },
   },
   args: {
@@ -42,11 +42,21 @@ export const WithIncorrectFeedback: Story = {
 };
 
 export const ResponsiveWidth: Story = {
-  render: () => (
+  render: (args) => (
     <OakQuizTextInput
-      value="An incorrect answer"
-      feedback="incorrect"
-      wrapperWidth={["100%", "all-spacing-22"]}
+      wrapperWidth={["100%", "all-spacing-20"]}
+      feedback={args.feedback}
+      defaultValue={args.defaultValue}
     />
   ),
+  args: {
+    feedback: "incorrect",
+    defaultValue:
+      "The pupil's answer which is longer than the width of the input",
+  },
+  parameters: {
+    controls: {
+      include: ["feedback"],
+    },
+  },
 };

--- a/src/components/integrated/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
+++ b/src/components/integrated/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
@@ -4,9 +4,6 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
 [
   .c0 {
   position: relative;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
@@ -24,6 +21,10 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
   cursor: pointer;
 }
 
+.c3 {
+  font-family: Lexend,sans-serif;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -36,7 +37,18 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
   gap: 1rem;
 }
 
-.c3 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c5 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -50,35 +62,36 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
   color: inherit;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
+  width: 100%;
   height: 4.5rem;
 }
 
-.c3::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c3::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #575757;
 }
 
-.c3:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #575757;
 }
 
-.c3::placeholder {
+.c5::placeholder {
   color: #575757;
 }
 
-.c3::-webkit-search-decoration,
-.c3::-webkit-search-cancel-button,
-.c3::-webkit-search-results-button,
-.c3::-webkit-search-results-decoration {
+.c5::-webkit-search-decoration,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button,
+.c5::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c3:disabled {
+.c5:disabled {
   cursor: not-allowed;
 }
 
@@ -95,7 +108,7 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
 }
 
 @media (max-width:750px) {
-  .c3 {
+  .c5 {
     font-size: 16px;
   }
 }
@@ -110,13 +123,17 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
     className="c0 c1 c2"
     onClick={[Function]}
   >
-    <input
-      className="c3"
-      defaultValue="An answer to a question"
-      onFocus={[Function]}
-      readOnly={false}
-      type="text"
-    />
+    <div
+      className="c3 c4"
+    >
+      <input
+        className="c5"
+        defaultValue="An answer to a question"
+        onFocus={[Function]}
+        readOnly={false}
+        type="text"
+      />
+    </div>
   </div>,
   ",",
 ]

--- a/src/components/ui/OakTextInput/OakTextInput.stories.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.stories.tsx
@@ -10,7 +10,8 @@ const meta: Meta<typeof OakTextInput> = {
   tags: ["autodocs"],
   title: "components/ui/OakTextInput",
   argTypes: {
-    width: sizeArgTypes["$width"],
+    wrapperWidth: sizeArgTypes["$width"],
+    wrapperMaxWidth: sizeArgTypes["$width"],
   },
   parameters: {
     controls: {
@@ -20,7 +21,8 @@ const meta: Meta<typeof OakTextInput> = {
         "validity",
         "disabled",
         "readOnly",
-        "width",
+        "wrapperWidth",
+        "wrapperMaxWidth",
         "iconName",
         "isTrailingIcon",
       ],

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -75,6 +75,9 @@ export type OakTextInputProps = {
   readOnlyBorderColor?: OakCombinedColorToken;
   disabledColor?: OakCombinedColorToken;
   readOnlyColor?: OakCombinedColorToken;
+  /**
+   * The width of the surrounding div - the input and icon will fill this
+   */
   wrapperWidth?: SizeStyleProps["$width"];
   wrapperMaxWidth?: SizeStyleProps["$maxWidth"];
   iconAlt?: string;
@@ -206,9 +209,11 @@ export const OakTextInput = ({
           iconName={iconName}
           $colorFilter={finalIconColor}
           $pointerEvents="none"
+          $width={"all-spacing-7"}
           alt={iconAlt}
         />
       )}
+
       <OakFlex $flexGrow={1}>
         <InternalTextInput
           type={type}
@@ -223,6 +228,7 @@ export const OakTextInput = ({
           iconName={iconName}
           $colorFilter={finalIconColor}
           $pointerEvents="none"
+          $width={"all-spacing-7"}
           alt={iconAlt}
         />
       )}

--- a/src/components/ui/OakTextInput/OakTextInput.tsx
+++ b/src/components/ui/OakTextInput/OakTextInput.tsx
@@ -75,8 +75,8 @@ export type OakTextInputProps = {
   readOnlyBorderColor?: OakCombinedColorToken;
   disabledColor?: OakCombinedColorToken;
   readOnlyColor?: OakCombinedColorToken;
-  width?: SizeStyleProps["$width"];
-  maxWidth?: SizeStyleProps["$maxWidth"];
+  wrapperWidth?: SizeStyleProps["$width"];
+  wrapperMaxWidth?: SizeStyleProps["$maxWidth"];
   iconAlt?: string;
 } & InternalTextInputProps;
 
@@ -148,8 +148,8 @@ export const OakTextInput = ({
   iconName,
   iconAlt,
   isTrailingIcon = false,
-  width,
-  maxWidth,
+  wrapperWidth,
+  wrapperMaxWidth,
   ...props
 }: OakTextInputProps) => {
   let finalBorderColor: OakCombinedColorToken;
@@ -176,8 +176,9 @@ export const OakTextInput = ({
 
   return (
     <StyledTextInputWrapper
-      $width="fit-content"
       $height="fit-content"
+      $width={wrapperWidth}
+      $maxWidth={wrapperMaxWidth}
       $borderStyle="solid"
       $borderRadius="border-radius-s"
       $ba="border-solid-m"
@@ -208,14 +209,15 @@ export const OakTextInput = ({
           alt={iconAlt}
         />
       )}
-      <InternalTextInput
-        type={type}
-        {...props}
-        $width={width}
-        $maxWidth={maxWidth}
-        $pv="inner-padding-l"
-        $height="all-spacing-12"
-      />
+      <OakFlex $flexGrow={1}>
+        <InternalTextInput
+          type={type}
+          {...props}
+          $width={"100%"}
+          $pv="inner-padding-l"
+          $height="all-spacing-12"
+        />
+      </OakFlex>
       {isTrailingIcon && iconName && (
         <OakIcon
           iconName={iconName}

--- a/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/ui/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakTextInput matches snapshot 1`] = `
 [
-  .c3 {
+  .c5 {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -16,43 +16,41 @@ exports[`OakTextInput matches snapshot 1`] = `
   color: inherit;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
+  width: 100%;
   height: 4.5rem;
 }
 
-.c3::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #575757;
 }
 
-.c3::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #575757;
 }
 
-.c3:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #575757;
 }
 
-.c3::placeholder {
+.c5::placeholder {
   color: #575757;
 }
 
-.c3::-webkit-search-decoration,
-.c3::-webkit-search-cancel-button,
-.c3::-webkit-search-results-button,
-.c3::-webkit-search-results-decoration {
+.c5::-webkit-search-decoration,
+.c5::-webkit-search-cancel-button,
+.c5::-webkit-search-results-button,
+.c5::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c3:disabled {
+.c5:disabled {
   cursor: not-allowed;
 }
 
 .c0 {
   position: relative;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
@@ -70,6 +68,10 @@ exports[`OakTextInput matches snapshot 1`] = `
   cursor: pointer;
 }
 
+.c3 {
+  font-family: Lexend,sans-serif;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -80,6 +82,17 @@ exports[`OakTextInput matches snapshot 1`] = `
   -ms-flex-align: center;
   align-items: center;
   gap: 1rem;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c2 {
@@ -95,7 +108,7 @@ exports[`OakTextInput matches snapshot 1`] = `
 }
 
 @media (max-width:750px) {
-  .c3 {
+  .c5 {
     font-size: 16px;
   }
 }
@@ -110,12 +123,16 @@ exports[`OakTextInput matches snapshot 1`] = `
     className="c0 c1 c2"
     onClick={[Function]}
   >
-    <input
-      className="c3"
-      defaultValue="A nice text value"
-      onFocus={[Function]}
-      type="text"
-    />
+    <div
+      className="c3 c4"
+    >
+      <input
+        className="c5"
+        defaultValue="A nice text value"
+        onFocus={[Function]}
+        type="text"
+      />
+    </div>
   </div>,
   ",",
 ]


### PR DESCRIPTION
### Story
The quiz text input should remain the same size when switching between input and feedback states . Currently it expands to accommodate the icon.

comments from designer:

“For the 2nd question of the starter quiz, and the 1st question of the exit quiz there is some shift in the size of the text input when submitting the question on desktop, and when the icon appears when in a valid or invalid state. The text input width shouldn't increase in width ideally across states. I think the width should be increased to something like 500px as a default for desktop. The text input should span the full width for tablet and mobile.” 

### Implementation details

- Modify the underlying textInput so that setting the width adjusts the wrapper width rather than attempt (and fail) to adjust the input width
- change width prop on this component to wrapperWidth so that the intention is clear but also there are no type clashes

### Testing 
https://deploy-preview-97--lively-meringue-8ebd43.netlify.app/?path=/story/components-integrated-oakquiztextinput--responsive-width
https://deploy-preview-97--lively-meringue-8ebd43.netlify.app/?path=/docs/components-ui-oaktextinput--docs


### Acceptance criteria

- [x]  **OakTextInput** should be able to set to 100% of the parent width
- [x] **OakTextInput**  & **OakQuizTextInput**  should accept responsive values for wrapperWidth
