### PR TITLE
fix: style corrections for buttons

### DIFF
--- a/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -73,13 +73,13 @@ exports[`OakHintButton matches snapshot 1`] = `
 
 .c12 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c11 {

--- a/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -135,13 +135,13 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c17 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c16 {

--- a/src/components/integrated/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
+++ b/src/components/integrated/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
@@ -61,13 +61,13 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
 
 .c10 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c2 {
@@ -91,10 +91,10 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
   border: 0.125rem solid;
   border-color: #ffffff;
   border-radius: 0.25rem;
@@ -118,10 +118,10 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;

--- a/src/components/integrated/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
+++ b/src/components/integrated/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
@@ -40,13 +40,13 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
 
 .c7 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c3 {
@@ -62,10 +62,10 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
   border: 0.125rem solid;
   border-color: #ffffff;
   border-radius: 0.25rem;

--- a/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -92,13 +92,13 @@ exports[`OakQuizHint matches snapshot 1`] = `
 
 .c14 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c13 {

--- a/src/components/ui/InternalShadowRectButton/InternalShadowRectButton.tsx
+++ b/src/components/ui/InternalShadowRectButton/InternalShadowRectButton.tsx
@@ -187,8 +187,8 @@ export const InternalShadowRectButton = <C extends ElementType = "button">(
         $background={defaultBackground}
         $borderColor={defaultBorderColor}
         $color={defaultTextColor}
-        $pv={"inner-padding-xs"}
-        $ph={"inner-padding-s"}
+        $pv={"inner-padding-s"}
+        $ph={"inner-padding-m"}
         $borderRadius={"border-radius-s"}
         $position={"relative"}
         disabled={disabled || isLoading}
@@ -212,7 +212,7 @@ export const InternalShadowRectButton = <C extends ElementType = "button">(
           $justifyContent="center"
         >
           {!isTrailingIcon && iconLogic}
-          <OakSpan $font={"body-1-bold"}>{children}</OakSpan>
+          <OakSpan $font={"heading-7"}>{children}</OakSpan>
           {isTrailingIcon && iconLogic}
         </OakFlex>
       </StyledInternalButton>

--- a/src/components/ui/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
+++ b/src/components/ui/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
@@ -47,13 +47,13 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
 
 .c9 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c8 {
@@ -73,10 +73,10 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
   color: #ebfbeb;
   background: #bef2bd;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
   border: 0.125rem solid;
   border-color: #dff9de;
   border-radius: 0.25rem;

--- a/src/components/ui/InternalShadowRoundButton/InternalShadowRoundButton.tsx
+++ b/src/components/ui/InternalShadowRoundButton/InternalShadowRoundButton.tsx
@@ -198,7 +198,7 @@ export const InternalShadowRoundButton = <C extends ElementType = "button">(
           $justifyContent="center"
         >
           {!isTrailingIcon && iconLogic}
-          <OakSpan $font={"body-1-bold"}>{children}</OakSpan>
+          <OakSpan $font={"heading-7"}>{children}</OakSpan>
           {isTrailingIcon && iconLogic}
         </OakFlex>
       </StyledInternalButton>

--- a/src/components/ui/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
+++ b/src/components/ui/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
@@ -73,13 +73,13 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
 
 .c11 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c10 {

--- a/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -47,13 +47,13 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
 
 .c9 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c8 {
@@ -75,10 +75,10 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;

--- a/src/components/ui/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/ui/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
@@ -47,13 +47,13 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
 
 .c9 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c8 {
@@ -75,10 +75,10 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
   border: 0.125rem solid;
   border-color: #ffffff;
   border-radius: 0.25rem;

--- a/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -47,13 +47,13 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
 
 .c9 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c8 {
@@ -75,10 +75,10 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;

--- a/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -66,13 +66,13 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
 
 .c9 {
   font-family: Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c2 {


### PR DESCRIPTION

### Story
The buttons padding and spacing doesn't quite look to match the [[Figma component](https://www.figma.com/file/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?type=design&node-id=3029%3A11820&mode=dev)](https://www.figma.com/file/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?type=design&node-id=3029%3A11820&mode=dev) 

### Implementation details
Also, can we check if the label of the button is using the correct FontToken - ‘heading-7’, as it looks to be bold when compared to the design kit in Figma.

- Actually this has been applied to all buttons as the issue was in the InternalButtons in the ui folder

### testing
https://deploy-preview-100--lively-meringue-8ebd43.netlify.app/?path=/docs/components-ui-internalshadowrectbutton--docs
https://deploy-preview-100--lively-meringue-8ebd43.netlify.app/?path=/docs/components-ui-internalshadowroundbutton--docs

#### Before 
![image](https://github.com/oaknational/oak-components/assets/1030540/db86b8a1-a384-4ff8-afd5-afc5a769d8d6)

#### After
![image](https://github.com/oaknational/oak-components/assets/1030540/d631b101-4ce7-4dc7-b999-86372deb3287)



### Acceptance criteria

- [ x] correct font
- [ x]  correct padding
