### PR TITLE
feat(static-meesage-card): changes color at mobile breakpoint

### DIFF
--- a/src/components/ui/OakLessonInfoCard/OakLessonInfoCard.tsx
+++ b/src/components/ui/OakLessonInfoCard/OakLessonInfoCard.tsx
@@ -53,7 +53,14 @@ export const OakStaticMessageCard = (props: OakInfoCardProps) => {
   const { children, ...rest } = props;
 
   return (
-    <OakHandDrawnCard {...rest} fill={"bg-decorative2-subdued"}>
+    <OakHandDrawnCard
+      {...rest}
+      fill={[
+        "bg-decorative2-very-subdued",
+        "bg-decorative2-subdued",
+        "bg-decorative2-subdued",
+      ]}
+    >
       <OakFlex
         $pa={"inner-padding-none"}
         $flexDirection={"column"}


### PR DESCRIPTION
as it turns out the static message card changes color on mobile screen

have added responsive background color

<img width="446" alt="Screenshot 2024-02-06 at 15 21 24" src="https://github.com/oaknational/oak-components/assets/48293828/0907b473-a522-4aec-b5fb-0e0eee7f8f95">
<img width="826" alt="Screenshot 2024-02-06 at 15 21 39" src="https://github.com/oaknational/oak-components/assets/48293828/50b3b623-6c53-4a57-8bf5-3e26a091bc73">
