### PR TITLE
feat: add `grid-template-rows` prop to OakGrid component

### DIFF
--- a/src/components/base/OakGrid/OakGrid.stories.tsx
+++ b/src/components/base/OakGrid/OakGrid.stories.tsx
@@ -22,6 +22,9 @@ const meta: Meta<typeof OakGrid> = {
     $gridTemplateColumns: {
       control: { type: "text" },
     },
+    $gridTemplateRows: {
+      control: { type: "text" },
+    },
   },
   parameters: {
     controls: {
@@ -31,6 +34,7 @@ const meta: Meta<typeof OakGrid> = {
         "$gridAutoRows",
         "$gridTemplateAreas",
         "$gridTemplateColumns",
+        "$gridTemplateRows",
       ],
     },
   },

--- a/src/components/base/OakGrid/OakGrid.tsx
+++ b/src/components/base/OakGrid/OakGrid.tsx
@@ -17,6 +17,7 @@ const gridStyle = css<OakGridProps>`
     "grid-template-columns",
     (props) => props.$gridTemplateColumns,
   )}
+    ${responsiveStyle("grid-template-rows", (props) => props.$gridTemplateRows)}
 `;
 
 export type OakGridProps = OakBoxProps & {
@@ -26,6 +27,7 @@ export type OakGridProps = OakBoxProps & {
   $gridAutoRows?: ResponsiveValues<"1fr">;
   $gridTemplateAreas?: ResponsiveValues<string>;
   $gridTemplateColumns?: ResponsiveValues<string>;
+  $gridTemplateRows?: ResponsiveValues<string>;
 };
 
 export const OakGrid = styled(OakBox)<OakGridProps>`


### PR DESCRIPTION
this is a missing piece that lets us do a lot more with grid layouts.

I need this to properly layout the copyright notice on the lesson intro page.