### PR TITLE
Fix/pupil 373/internal shadow round button default display prop

### DIFF
--- a/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -106,6 +106,7 @@ exports[`OakHintButton matches snapshot 1`] = `
 }
 
 .c4 {
+  display: inline-block;
   position: relative;
 }
 

--- a/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -168,6 +168,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 .c9 {
+  display: inline-block;
   position: relative;
 }
 

--- a/src/components/integrated/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
+++ b/src/components/integrated/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
@@ -124,6 +124,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
 }
 
 .c5 {
+  display: inline-block;
   position: relative;
 }
 

--- a/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
 }
 
 .c6 {
+  display: inline-block;
   position: relative;
 }
 

--- a/src/components/ui/InternalShadowRoundButton/InternalShadowRoundButton.stories.tsx
+++ b/src/components/ui/InternalShadowRoundButton/InternalShadowRoundButton.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { InternalShadowRoundButton } from "./InternalShadowRoundButton";
 
 import { oakIconNames } from "@/components/base/OakIcon";
-import { OakFlex, OakLI, OakUL } from "@/components/base";
+import { OakBox, OakFlex, OakLI, OakUL } from "@/components/base";
 import { borderArgTypes } from "@/storybook-helpers/borderStyleHelpers";
 import { colorArgTypes } from "@/storybook-helpers/colorStyleHelpers";
 import { sizeArgTypes } from "@/storybook-helpers/sizeStyleHelpers";
@@ -113,9 +113,9 @@ export const Default: Story = {
 
 export const LinkStyledAsButton: Story = {
   render: (args) => (
-    <OakFlex $gap="space-between-m">
+    <OakBox>
       <InternalShadowRoundButton {...args}>Link</InternalShadowRoundButton>
-    </OakFlex>
+    </OakBox>
   ),
   args: {
     as: "a",

--- a/src/components/ui/InternalShadowRoundButton/InternalShadowRoundButton.tsx
+++ b/src/components/ui/InternalShadowRoundButton/InternalShadowRoundButton.tsx
@@ -51,6 +51,7 @@ const StyledInternalButton = styled(InternalButton)<
   Omit<InternalShadowRoundButtonProps, "iconBackgroundSize" | "iconSize"> &
     SizeStyleProps
 >`
+  display: inline-block;
   ${positionStyle}
   ${sizeStyle}
   ${(props) => css`

--- a/src/components/ui/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
+++ b/src/components/ui/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
@@ -106,6 +106,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
 }
 
 .c3 {
+  display: inline-block;
   position: relative;
 }
 

--- a/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
 }
 
 .c3 {
+  display: inline-block;
   position: relative;
 }
 


### PR DESCRIPTION
http://localhost:6006/?path=/docs/components-ui-internalshadowroundbutton--docs

- Added a default display style of 'inline-block' to internalshadowroundbutton to override default style when element is set to link. 
- Ensures consitent behaviour between button and link versions.