### PR TITLE
PUPIL-351: `OakLessonNavItem` copy changes

### DIFF
--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.stories.tsx
@@ -20,12 +20,6 @@ const meta: Meta<typeof OakLessonNavItem> = {
         type: "number",
       },
     },
-    videoLength: {
-      control: {
-        type: "number",
-      },
-      if: { arg: "lessonSectionName", eq: "video" },
-    },
   },
   args: {
     lessonSectionName: "intro",
@@ -33,7 +27,6 @@ const meta: Meta<typeof OakLessonNavItem> = {
     href: "#",
     grade: 4,
     numQuestions: 6,
-    videoLength: 20,
   },
   decorators: [
     (Story) => {
@@ -52,7 +45,6 @@ const meta: Meta<typeof OakLessonNavItem> = {
         "disabled",
         "grade",
         "numQuestions",
-        "videoLength",
       ],
     },
   },
@@ -79,11 +71,7 @@ export const NotStarted: Story = {
         numQuestions={6}
         grade={0}
       />
-      <OakLessonNavItem
-        lessonSectionName="video"
-        progress="not-started"
-        videoLength={20}
-      />
+      <OakLessonNavItem lessonSectionName="video" progress="not-started" />
       <OakLessonNavItem
         lessonSectionName="exit-quiz"
         progress="not-started"
@@ -104,11 +92,7 @@ export const InProgress: Story = {
         numQuestions={6}
         grade={0}
       />
-      <OakLessonNavItem
-        lessonSectionName="video"
-        progress="in-progress"
-        videoLength={20}
-      />
+      <OakLessonNavItem lessonSectionName="video" progress="in-progress" />
       <OakLessonNavItem
         lessonSectionName="exit-quiz"
         progress="in-progress"
@@ -129,11 +113,7 @@ export const Complete: Story = {
         numQuestions={6}
         grade={5}
       />
-      <OakLessonNavItem
-        lessonSectionName="video"
-        progress="complete"
-        videoLength={20}
-      />
+      <OakLessonNavItem lessonSectionName="video" progress="complete" />
       <OakLessonNavItem
         lessonSectionName="exit-quiz"
         progress="complete"

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.test.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.test.tsx
@@ -38,7 +38,6 @@ describe(OakLessonNavItem, () => {
           data-testid="video"
           lessonSectionName="video"
           progress="not-started"
-          videoLength={20}
         />
         <OakLessonNavItem
           data-testid="exit-quiz"
@@ -50,12 +49,14 @@ describe(OakLessonNavItem, () => {
       </>,
     );
 
-    expect(getByTestId("intro").textContent).toContain("Get ready");
-    expect(getByTestId("starter-quiz").textContent).toContain("6 Questions");
-    expect(getByTestId("exit-quiz").textContent).toContain(
-      "Practice 6 questions",
+    expect(getByTestId("intro").textContent).toContain("Prepare");
+    expect(getByTestId("starter-quiz").textContent).toContain(
+      "Activate - 6 Questions",
     );
-    expect(getByTestId("video").textContent).toContain("20 min");
+    expect(getByTestId("exit-quiz").textContent).toContain(
+      "Check - 6 questions",
+    );
+    expect(getByTestId("video").textContent).toContain("Learn");
   });
 
   it("renders copy for each lesson section that has not been started", () => {
@@ -77,7 +78,6 @@ describe(OakLessonNavItem, () => {
           data-testid="video"
           lessonSectionName="video"
           progress="in-progress"
-          videoLength={20}
         />
         <OakLessonNavItem
           data-testid="exit-quiz"
@@ -114,7 +114,6 @@ describe(OakLessonNavItem, () => {
           data-testid="video"
           lessonSectionName="video"
           progress="complete"
-          videoLength={20}
         />
         <OakLessonNavItem
           data-testid="exit-quiz"

--- a/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
+++ b/src/components/integrated/OakLessonNavItem/OakLessonNavItem.tsx
@@ -39,10 +39,6 @@ type QuizSectionProps = {
 
 type VideoSectionProps = {
   lessonSectionName: "video";
-  /**
-   * The length of the video in minutes
-   */
-  videoLength: number;
 };
 
 type IntroSectionProps = {
@@ -252,11 +248,11 @@ function pickColorsForSection(
 function pickLabelForSection(sectionName: LessonSectionName): string {
   switch (sectionName) {
     case "intro":
-      return "Intro";
+      return "Introduction";
     case "starter-quiz":
       return "Starter quiz";
     case "video":
-      return "Watch video";
+      return "Lesson video";
     case "exit-quiz":
       return "Exit quiz";
   }
@@ -285,13 +281,13 @@ function pickSummaryForProgress(props: SectionProps) {
 function pickSummaryForNotStarted(props: SectionProps) {
   switch (props.lessonSectionName) {
     case "intro":
-      return "Get ready";
+      return "Prepare";
     case "starter-quiz":
-      return `${props.numQuestions} Questions`;
+      return `Activate - ${props.numQuestions} Questions`;
     case "exit-quiz":
-      return `Practice ${props.numQuestions} questions`;
+      return `Check - ${props.numQuestions} questions`;
     case "video":
-      return `${props.videoLength} min`;
+      return "Learn";
   }
 }
 

--- a/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/integrated/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -256,12 +256,12 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
       <strong
         className="c9"
       >
-        Intro
+        Introduction
       </strong>
       <div
         className="c10"
       >
-        Get ready
+        Prepare
       </div>
     </div>
     <div

--- a/src/components/integrated/OakLessonReviewItem/OakPupilLessonReviewItem.tsx
+++ b/src/components/integrated/OakLessonReviewItem/OakPupilLessonReviewItem.tsx
@@ -105,14 +105,14 @@ const pickSummaryForIncomplete = (props: OakLessonReviewItemProps) => {
     case "exit-quiz":
       return `Check - ${props.numQuestions} questions`;
     case "video":
-      return `Learn`;
+      return "Learn";
   }
 };
 
 const pickLabelForSection = (sectionName: LessonSectionName): string => {
   switch (sectionName) {
     case "intro":
-      return "Intro";
+      return "Introduction";
     case "starter-quiz":
       return "Starter quiz";
     case "video":

--- a/src/components/integrated/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
+++ b/src/components/integrated/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
@@ -202,7 +202,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
       <div
         className="c8"
       >
-        Intro
+        Introduction
       </div>
       <div
         className="c9"


### PR DESCRIPTION
Storybook: https://deploy-preview-106--lively-meringue-8ebd43.netlify.app/?path=/docs/components-integrated-oaklessonnavitem--docs
Figma: https://www.figma.com/file/G7z5ufo2T0CHk14CkadeuB/Pupils-high-fidelity-designs?type=design&node-id=2980-65763&mode=dev

<img width="1110" alt="Screenshot 2024-02-15 at 11 24 16" src="https://github.com/oaknational/oak-components/assets/122096/95544385-2883-471b-9e40-d52243766190">
<img width="1114" alt="Screenshot 2024-02-15 at 11 24 13" src="https://github.com/oaknational/oak-components/assets/122096/e4dd6e70-e7a4-4542-9025-de364bde2358">
<img width="1091" alt="Screenshot 2024-02-15 at 11 24 10" src="https://github.com/oaknational/oak-components/assets/122096/584bc901-f39e-434a-b8a8-9d1c4cb4990f">
