### PR TITLE
feat(PUPIL-274): add missing sizing keywords and set a default button width

### DIFF
--- a/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/integrated/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`OakHintButton matches snapshot 1`] = `
 .c0 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/integrated/OakLessonBottomNav/OakLessonBottomNav.stories.tsx
+++ b/src/components/integrated/OakLessonBottomNav/OakLessonBottomNav.stories.tsx
@@ -55,7 +55,7 @@ export const WithButton: Story = {
         isTrailingIcon
         width={["100%", "auto"]}
       >
-        Continue
+        Next question
       </OakPrimaryButton>
     </OakLessonBottomNav>
   ),
@@ -85,32 +85,50 @@ export const WithFeedbackAndButton: Story = {
         <OakPrimaryButton
           iconName="arrow-right"
           isTrailingIcon
-          width={["100%", "auto"]}
+          width={["100%", "max-content"]}
         >
-          Continue
+          Next question
         </OakPrimaryButton>
       </OakLessonBottomNav>
       <OakLessonBottomNav {...args} feedback="incorrect">
         <OakPrimaryButton
           iconName="arrow-right"
           isTrailingIcon
-          width={["100%", "auto"]}
+          width={["100%", "max-content"]}
         >
-          Continue
+          Next question
         </OakPrimaryButton>
       </OakLessonBottomNav>
       <OakLessonBottomNav {...args} feedback="partially-correct">
         <OakPrimaryButton
           iconName="arrow-right"
           isTrailingIcon
-          width={["100%", "auto"]}
+          width={["100%", "max-content"]}
         >
-          Continue
+          Next question
         </OakPrimaryButton>
       </OakLessonBottomNav>
     </>
   ),
   args: {
     answerFeedback: "Good work!",
+  },
+};
+
+export const WithLongFeedbackAndButton: Story = {
+  render: (args) => (
+    <OakLessonBottomNav {...args} feedback="incorrect">
+      <OakPrimaryButton
+        iconName="arrow-right"
+        isTrailingIcon
+        width={["100%", "max-content"]}
+      >
+        Next question
+      </OakPrimaryButton>
+    </OakLessonBottomNav>
+  ),
+  args: {
+    answerFeedback:
+      "Correct answer: George Orwell, a renowned British author, penned the dystopian masterpiece '1984' in 1949, depicting a totalitarian society under constant surveillance, influencing literature and pop culture for decades.",
   },
 };

--- a/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/integrated/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -21,6 +21,9 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c5 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/integrated/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
+++ b/src/components/integrated/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
@@ -8,6 +8,9 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
 
 .c2 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/integrated/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
+++ b/src/components/integrated/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
@@ -13,6 +13,9 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
 
 .c3 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/integrated/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
+++ b/src/components/integrated/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`OakPrimaryNavItem matches snapshot 1`] = `
 .c0 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/integrated/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -15,6 +15,9 @@ exports[`OakQuizHint matches snapshot 1`] = `
 
 .c2 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/ui/InternalShadowRectButton/InternalShadowRectButton.tsx
+++ b/src/components/ui/InternalShadowRectButton/InternalShadowRectButton.tsx
@@ -117,7 +117,7 @@ export const InternalShadowRectButton = <C extends ElementType = "button">(
     isTrailingIcon,
     isLoading,
     disabled,
-    width,
+    width = "max-content",
     maxWidth,
     defaultBackground,
     defaultBorderColor,

--- a/src/components/ui/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
+++ b/src/components/ui/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`InternalShadowRectButton matches snapshot 1`] = `
 .c0 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/ui/InternalShadowRoundButton/InternalShadowRoundButton.tsx
+++ b/src/components/ui/InternalShadowRoundButton/InternalShadowRoundButton.tsx
@@ -107,7 +107,7 @@ export const InternalShadowRoundButton = <C extends ElementType = "button">(
     isTrailingIcon,
     isLoading,
     disabled,
-    width,
+    width = "max-content",
     maxWidth,
     iconBackgroundSize,
     iconSize,

--- a/src/components/ui/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
+++ b/src/components/ui/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`InternalShadowRoundButton matches snapshot 1`] = `
 .c0 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/ui/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`OakPrimaryButton matches snapshot 1`] = `
 .c0 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/ui/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/ui/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
 .c0 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/ui/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`OakSecondaryButton matches snapshot 1`] = `
 .c0 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/ui/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -3,6 +3,9 @@
 exports[`OakTertiaryButton matches snapshot 1`] = `
 .c0 {
   position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/styles/theme/spacing.ts
+++ b/src/styles/theme/spacing.ts
@@ -63,6 +63,8 @@ type AdditionalSpacingTypes =
   | "100vw"
   | "auto"
   | "fit-content"
+  | "max-content"
+  | "min-content"
   | "inherit"
   | "initial"
   | "unset";


### PR DESCRIPTION
* `min-content` and `max-content` are very useful.
* `max-content` seems like a sensible default for button widths (to prevent text wrapping)
  * we should be able to safely apply this since the buttons are only currently used in the pupil section and none have intentional wrapping
* I will use this to prevent wrapping in `OakLessonBottomNav`

<img width="1089" alt="Screenshot 2024-02-16 at 12 24 43" src="https://github.com/oaknational/oak-components/assets/122096/ce314d7c-5aa5-472d-9ad1-68cef26654e0">

<img width="1109" alt="Screenshot 2024-02-16 at 12 26 47" src="https://github.com/oaknational/oak-components/assets/122096/88546460-fb58-448f-9dd6-d6373e3fbdc8">

<img width="1093" alt="Screenshot 2024-02-16 at 12 30 12" src="https://github.com/oaknational/oak-components/assets/122096/c62054db-e54d-4b41-9a8d-ade44d9cc5ff">


