### PR TITLE
chore: remove prepublish check for local changes

### DIFF
--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -11,5 +11,3 @@ fi
 
 npm run test:ci
 npm run build
-
-git diff-index --quiet HEAD -- || (echo "Error: You have uncommitted changes. Please commit or stash them before pushing." && exit 1)


### PR DESCRIPTION
This made sense when publishing locally but it now prevents the publish from happening in CI since the change to the version number isn't committed until after the publish is successful.

This should get automated publishing working 🤞