### PR TITLE
chore: skip pre-commit hooks when creating a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: 0
+          CI: true
         run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "build-storybook": "storybook build",
     "prepare": "husky install",
     "prepublishOnly": "./scripts/prepublish.sh",
-    "postpublish": "./scripts/postpublish.sh",
     "publish:local": "npm run build && yalc publish --no-scripts"
   },
   "author": "",

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -2,6 +2,11 @@
 
 echo "pre-publish"
 
+if [ "$CI" = "true" ]; then
+  echo "Skipping pre-publish checks on CI"
+  exit 0
+fi;
+
 branch="$(git rev-parse --abbrev-ref HEAD)"
 
 if [ "$branch" != "main" ]; then


### PR DESCRIPTION
This was a pain and I couldn't test it locally so it was a lot of trial and error — however I think it is finally working 🤞🏼 