### PR TITLE
chore: Allow CI to push updates to `package.json`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm audit signatures
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: 0
           CI: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
🎉 releases are now being published to NPM.

However the bump commit to update package.json with the new version number cannot be pushed to `main` because the branch is protected.

Following this doc https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md#pushing-packagejson-changes-to-a-master-branch I need someone with the power to add a repo secret `GITHUB_TOKEN` containing a Personal Access Token with the corresponding permissions to push to `main` bypassing the protected branch rules.

## TODO 
- [x] Add `RELEASE_GITHUB_TOKEN` to repo secrets