### PR TITLE
fix: icons shrinking when in a flex context

### DIFF
--- a/src/components/atoms/OakIcon/OakIcon.tsx
+++ b/src/components/atoms/OakIcon/OakIcon.tsx
@@ -34,6 +34,8 @@ export const OakIcon = (props: OakIconProps) => {
     alt,
     $width = "all-spacing-7",
     $height = "all-spacing-7",
+    $minHeight = $height,
+    $minWidth = $width,
     imageProps,
     ...rest
   } = props;
@@ -44,6 +46,8 @@ export const OakIcon = (props: OakIconProps) => {
       alt={alt ?? iconName}
       $width={$width}
       $height={$height}
+      $minHeight={$minHeight}
+      $minWidth={$minWidth}
       placeholder="empty"
       // Icons should not be optimised since the SVG is already as small as it can be and should be served directly
       unoptimized

--- a/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
+++ b/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`OakIcon matches snapshot 1`] = `
 .c0 {
   position: relative;
   width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
@@ -25,7 +25,9 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
 .c7 {
   position: relative;
   width: 1.5rem;
+  min-width: 1.5rem;
   height: 1.5rem;
+  min-height: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
@@ -36,7 +36,9 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
 .c9 {
   position: relative;
   width: 1.5rem;
+  min-width: 1.5rem;
   height: 1.5rem;
+  min-height: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
+++ b/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`OakBackLink matches snapshot 1`] = `
 .c1 {
   position: relative;
   width: 2.5rem;
+  min-width: 2.5rem;
   height: 2.5rem;
+  min-height: 2.5rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
+++ b/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
@@ -48,7 +48,9 @@ exports[`OakCheckBox matches snapshot 1`] = `
 .c10 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
+++ b/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
 .c3 {
   position: relative;
   width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
+++ b/src/components/molecules/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
@@ -20,7 +20,9 @@ exports[`OakDraggable matches snapshot 1`] = `
 .c5 {
   position: relative;
   width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
+++ b/src/components/molecules/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
@@ -22,7 +22,9 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
 .c5 {
   position: relative;
   width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
@@ -23,7 +23,9 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
 .c6 {
   position: relative;
   width: 4rem;
+  min-width: 4rem;
   height: 4rem;
+  min-height: 4rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -84,7 +86,19 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
 
 @media (min-width:750px) {
   .c6 {
+    min-width: 7.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c6 {
     height: 7.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c6 {
+    min-height: 7.5rem;
   }
 }
 

--- a/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
+++ b/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
@@ -15,7 +15,9 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
 .c4 {
   position: relative;
   width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -25,7 +25,9 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
 .c7 {
   position: relative;
   width: 1.5rem;
+  min-width: 1.5rem;
   height: 1.5rem;
+  min-height: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
@@ -25,7 +25,9 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
 .c7 {
   position: relative;
   width: 1.5rem;
+  min-width: 1.5rem;
   height: 1.5rem;
+  min-height: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
+++ b/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
@@ -13,7 +13,9 @@ exports[`OakRoundIcon matches snapshot 1`] = `
 .c1 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -25,7 +25,9 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
 .c7 {
   position: relative;
   width: 1.5rem;
+  min-width: 1.5rem;
   height: 1.5rem;
+  min-height: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/organisms/pupil/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -36,7 +36,9 @@ exports[`OakHintButton matches snapshot 1`] = `
 .c10 {
   position: relative;
   width: 1.5rem;
+  min-width: 1.5rem;
   height: 1.5rem;
+  min-height: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/organisms/pupil/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -54,7 +54,9 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 .c16 {
   position: relative;
   width: 1.5rem;
+  min-width: 1.5rem;
   height: 1.5rem;
+  min-height: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -359,7 +361,9 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 .c7 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 
@@ -551,7 +555,9 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 .c7 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 
@@ -761,7 +767,9 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 .c7 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/organisms/pupil/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -23,7 +23,9 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 .c5 {
   position: relative;
   width: 3.5rem;
+  min-width: 3.5rem;
   height: 3.5rem;
+  min-height: 3.5rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -66,7 +68,9 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 .c14 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
+++ b/src/components/organisms/pupil/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
@@ -26,7 +26,9 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
 .c4 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/organisms/pupil/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -13,7 +13,9 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 .c4 {
   position: relative;
   width: 2.5rem;
+  min-width: 2.5rem;
   height: 2.5rem;
+  min-height: 2.5rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -29,7 +31,9 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 .c8 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/pupil/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
@@ -37,7 +37,9 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
 .c11 {
   position: relative;
   width: 1.5rem;
+  min-width: 1.5rem;
   height: 1.5rem;
+  min-height: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
+++ b/src/components/organisms/pupil/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
@@ -18,7 +18,9 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 .c3 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 
@@ -118,7 +120,9 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 .c3 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 
@@ -236,7 +240,9 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 .c3 {
   position: relative;
   width: 100%;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/organisms/pupil/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -48,7 +48,9 @@ exports[`OakQuizHint matches snapshot 1`] = `
 .c12 {
   position: relative;
   width: 1.5rem;
+  min-width: 1.5rem;
   height: 1.5rem;
+  min-height: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
+++ b/src/components/organisms/pupil/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
@@ -14,7 +14,9 @@ exports[`OakQuizMatch matches snapshot 1`] = `
 .c4 {
   position: relative;
   width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -168,7 +170,9 @@ exports[`OakQuizMatch matches snapshot 1`] = `
 .c9 {
   position: relative;
   width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
+++ b/src/components/organisms/pupil/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
@@ -14,7 +14,9 @@ exports[`OakQuizOrder matches snapshot 1`] = `
 .c4 {
   position: relative;
   width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -168,7 +170,9 @@ exports[`OakQuizOrder matches snapshot 1`] = `
 .c12 {
   position: relative;
   width: 2rem;
+  min-width: 2rem;
   height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Description

This is a common bug where an icon is a direct descendent of a flex container it would shrink according to the flex algorithm — this change sets the min height and width to match the width and height ensuring that this won't happen.

We can reasonably expect that in all cases the icon shrinking would not be intentional and that we would expect to set the dimensions responsively when necessary for different breakpoints.

**Before**
<img width="354" alt="Screenshot 2024-03-15 at 10 20 41" src="https://github.com/oaknational/oak-components/assets/122096/f92145a8-84a1-4546-aa6a-46cd93969881">

**After**
<img width="355" alt="Screenshot 2024-03-15 at 10 20 51" src="https://github.com/oaknational/oak-components/assets/122096/9c88ea1c-92ed-4519-80ef-1bdb97233b3a">


## A link to the component in the deployment preview
https://deploy-preview-130--lively-meringue-8ebd43.netlify.app/?path=/docs/components-atoms-oakicon--docs
https://deploy-preview-130--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oakdraggable--docs