### PR TITLE
Fix `OakTooltip` breaking flex layout of the wrapped element

### DIFF
--- a/src/components/atoms/InternalTooltip/InternalTooltip.stories.tsx
+++ b/src/components/atoms/InternalTooltip/InternalTooltip.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
-import { InternalButton } from "../InternalButton";
 import { OakBox } from "../OakBox";
 
 import { InternalTooltip } from "./InternalTooltip";
@@ -16,7 +15,7 @@ const meta: Meta<typeof InternalTooltip> = {
   tags: ["autodocs"],
   title: "components/atoms/InternalTooltip",
   argTypes: {
-    tooltip: {
+    children: {
       control: {
         type: "text",
       },
@@ -29,8 +28,7 @@ const meta: Meta<typeof InternalTooltip> = {
   parameters: {
     controls: {
       include: [
-        "isOpen",
-        "tooltip",
+        "children",
         "tooltipPosition",
         ...Object.keys(colorArgTypes),
         ...Object.keys(spacingArgTypes),
@@ -47,10 +45,8 @@ const meta: Meta<typeof InternalTooltip> = {
     ),
   ],
   args: {
-    isOpen: true,
-    tooltip: "Hello there",
+    children: "Hello there",
     tooltipPosition: "bottom-left",
-    children: <InternalButton>Target</InternalButton>,
   },
 };
 export default meta;

--- a/src/components/atoms/InternalTooltip/InternalTooltip.test.tsx
+++ b/src/components/atoms/InternalTooltip/InternalTooltip.test.tsx
@@ -13,9 +13,7 @@ describe(InternalTooltip, () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <InternalTooltip tooltip="Hello there" isOpen>
-          Trigger!
-        </InternalTooltip>
+        <InternalTooltip>Hello there</InternalTooltip>
       </OakThemeProvider>,
     ).toJSON();
 
@@ -24,65 +22,43 @@ describe(InternalTooltip, () => {
 
   it("renders children", () => {
     const { getByText } = renderWithTheme(
-      <InternalTooltip tooltip="Hello there" isOpen={false}>
-        Trigger!
+      <InternalTooltip>Hello there</InternalTooltip>,
+    );
+
+    expect(getByText("Hello there")).toBeInTheDocument();
+  });
+
+  it('positions the arrow based on the "tooltipPosition" prop', () => {
+    const { rerender, getByTestId } = renderWithTheme(
+      <InternalTooltip>Hello there</InternalTooltip>,
+    );
+
+    expect(getByTestId("tooltip-arrow")).toHaveStyle("top: -1rem; left: 0rem");
+
+    rerender(
+      <InternalTooltip tooltipPosition="bottom-right">
+        Hello there
       </InternalTooltip>,
     );
 
-    expect(getByText("Trigger!")).toBeInTheDocument();
-  });
-
-  it("renders a tooltip when `isOpen` is true", () => {
-    const { rerender, queryByRole } = renderWithTheme(
-      <InternalTooltip tooltip="Hello there" isOpen={false} />,
-    );
-
-    expect(queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(getByTestId("tooltip-arrow")).toHaveStyle("top: -1rem; right: 0rem");
 
     rerender(
-      <InternalTooltip tooltip="Hello there" isOpen>
-        Trigger!
+      <InternalTooltip tooltipPosition="top-right">
+        Hello there
       </InternalTooltip>,
     );
 
-    expect(queryByRole("tooltip")).toBeInTheDocument();
-  });
-
-  it('positions the tooltip based on the "tooltipPosition" prop', () => {
-    const { rerender, getByRole } = renderWithTheme(
-      <InternalTooltip tooltip="Hello there" isOpen />,
+    expect(getByTestId("tooltip-arrow")).toHaveStyle(
+      "bottom: -1rem; right: 0rem",
     );
-
-    expect(getByRole("tooltip")).toHaveStyle("bottom: 0rem; left: 0rem");
 
     rerender(
-      <InternalTooltip
-        tooltip="Hello there"
-        isOpen
-        tooltipPosition="bottom-right"
-      />,
+      <InternalTooltip tooltipPosition="top-left">Hello there</InternalTooltip>,
     );
 
-    expect(getByRole("tooltip")).toHaveStyle("bottom: 0rem; right: 0rem");
-
-    rerender(
-      <InternalTooltip
-        tooltip="Hello there"
-        isOpen
-        tooltipPosition="top-right"
-      />,
+    expect(getByTestId("tooltip-arrow")).toHaveStyle(
+      "bottom: -1rem; left: 0rem",
     );
-
-    expect(getByRole("tooltip")).toHaveStyle("top: 0rem; right: 0rem");
-
-    rerender(
-      <InternalTooltip
-        tooltip="Hello there"
-        isOpen
-        tooltipPosition="top-left"
-      />,
-    );
-
-    expect(getByRole("tooltip")).toHaveStyle("top: 0rem; left: 0rem");
   });
 });

--- a/src/components/atoms/InternalTooltip/InternalTooltip.tsx
+++ b/src/components/atoms/InternalTooltip/InternalTooltip.tsx
@@ -10,8 +10,6 @@ import { responsiveStyle } from "@/styles/utils/responsiveStyle";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
 
 export type InternalTooltipProps = OakFlexProps & {
-  isOpen: boolean;
-  tooltip: ReactNode;
   children?: ReactNode;
   tooltipPosition?: "bottom-left" | "bottom-right" | "top-left" | "top-right";
 };
@@ -26,31 +24,33 @@ type StyledSvgProps = {
   $tooltipPosition?: InternalTooltipProps["tooltipPosition"];
 };
 
+const ARROW_SIZE = parseSpacing("all-spacing-4");
+
 const StyledSvg = styled.svg<StyledSvgProps>`
   position: absolute;
   ${({ $tooltipPosition }) => {
     switch ($tooltipPosition) {
       case "bottom-right":
         return css`
-          top: -${parseSpacing("space-between-s")};
-          right: ${parseSpacing("space-between-none")};
+          top: -${ARROW_SIZE};
+          right: ${parseSpacing("all-spacing-0")};
           transform: scale(-1, -1);
         `;
       case "top-right":
         return css`
-          bottom: -${parseSpacing("space-between-s")};
-          right: ${parseSpacing("space-between-none")};
+          bottom: -${ARROW_SIZE};
+          right: ${parseSpacing("all-spacing-0")};
           transform: scaleX(-1);
         `;
       case "top-left":
         return css`
-          bottom: -${parseSpacing("space-between-s")};
-          left: ${parseSpacing("space-between-none")};
+          bottom: -${ARROW_SIZE};
+          left: ${parseSpacing("all-spacing-0")};
         `;
       default:
         return css`
-          top: -${parseSpacing("space-between-s")};
-          left: ${parseSpacing("space-between-none")};
+          top: -${ARROW_SIZE};
+          left: ${parseSpacing("all-spacing-0")};
           transform: scaleY(-1);
         `;
     }
@@ -66,76 +66,31 @@ const StyledSvg = styled.svg<StyledSvgProps>`
  * A primitive tooltip to be used as a basis for more opinionated UI components.
  */
 export const InternalTooltip = ({
-  isOpen,
   children,
-  tooltip,
   $background = "black",
   $color = "text-inverted",
   tooltipPosition = "bottom-left",
   ...props
 }: InternalTooltipProps) => {
-  const positionProps = (() => {
-    const props: Partial<OakFlexProps> = {};
-
-    switch (tooltipPosition) {
-      case "top-left":
-      case "top-right":
-        props.$top = "space-between-none";
-        props.$transform = `translateY(calc(-100% - ${parseSpacing(
-          "space-between-s",
-        )}))`;
-        break;
-      default:
-        props.$bottom = "space-between-none";
-        props.$transform = `translateY(calc(100% + ${parseSpacing(
-          "space-between-s",
-        )}))`;
-        break;
-    }
-
-    switch (tooltipPosition) {
-      case "top-left":
-      case "bottom-left":
-        props.$left = "space-between-none";
-        break;
-      default:
-        props.$right = "space-between-none";
-        break;
-    }
-
-    return props;
-  })();
-
   return (
-    <OakFlex $position="relative" $width="fit-content" $height="fit-content">
-      {isOpen && (
-        <OakFlex
-          role="tooltip"
-          $position="absolute"
-          {...positionProps}
-          $zIndex="modal-dialog"
-          $flexDirection="column"
-        >
-          <StyledFlex
-            {...props}
-            $position="relative"
-            $background={$background}
-            $color={$color}
-            $maxWidth={["all-spacing-20", "all-spacing-22"]}
-          >
-            {tooltip}
-            <StyledSvg
-              width="16"
-              height="16"
-              $fill={$background}
-              $tooltipPosition={tooltipPosition}
-            >
-              <path d="M0 0H16L8 8L0 16V0Z" />
-            </StyledSvg>
-          </StyledFlex>
-        </OakFlex>
-      )}
+    <StyledFlex
+      role="tooltip"
+      {...props}
+      $position="relative"
+      $background={$background}
+      $color={$color}
+      $maxWidth={["all-spacing-20", "all-spacing-22"]}
+    >
       {children}
-    </OakFlex>
+      <StyledSvg
+        width={ARROW_SIZE}
+        height={ARROW_SIZE}
+        $fill={$background}
+        $tooltipPosition={tooltipPosition}
+        data-testid="tooltip-arrow"
+      >
+        <path d="M0 0H16L8 8L0 16V0Z" />
+      </StyledSvg>
+    </StyledFlex>
   );
 };

--- a/src/components/atoms/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
+++ b/src/components/atoms/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
@@ -3,28 +3,6 @@
 exports[`InternalTooltip matches snapshot 1`] = `
 .c0 {
   position: relative;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
-  font-family: Lexend,sans-serif;
-}
-
-.c2 {
-  position: absolute;
-  bottom: 0rem;
-  left: 0rem;
-  -webkit-transform: translateY(calc(100% + 1rem));
-  -ms-transform: translateY(calc(100% + 1rem));
-  transform: translateY(calc(100% + 1rem));
-  font-family: Lexend,sans-serif;
-  z-index: 300;
-}
-
-.c4 {
-  position: relative;
   max-width: 22.5rem;
   color: #ffffff;
   background: #222222;
@@ -38,24 +16,14 @@ exports[`InternalTooltip matches snapshot 1`] = `
   display: flex;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c5 {
+.c2 {
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
   pointer-events: none;
 }
 
-.c6 {
+.c3 {
   position: absolute;
   top: -1rem;
   left: 0rem;
@@ -66,33 +34,25 @@ exports[`InternalTooltip matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c0 {
     max-width: 40rem;
   }
 }
 
 <div
-  className="c0 c1"
+  className="c0 c1 c2"
+  role="tooltip"
 >
-  <div
-    className="c2 c3"
-    role="tooltip"
+  Hello there
+  <svg
+    className="c3"
+    data-testid="tooltip-arrow"
+    height="1rem"
+    width="1rem"
   >
-    <div
-      className="c4 c1 c5"
-    >
-      Hello there
-      <svg
-        className="c6"
-        height="16"
-        width="16"
-      >
-        <path
-          d="M0 0H16L8 8L0 16V0Z"
-        />
-      </svg>
-    </div>
-  </div>
-  Trigger!
+    <path
+      d="M0 0H16L8 8L0 16V0Z"
+    />
+  </svg>
 </div>
 `;

--- a/src/components/molecules/OakTooltip/OakTooltip.test.tsx
+++ b/src/components/molecules/OakTooltip/OakTooltip.test.tsx
@@ -1,5 +1,5 @@
 import { create } from "react-test-renderer";
-import React from "react";
+import React, { ReactNode } from "react";
 import "@testing-library/jest-dom";
 
 import { OakTooltip } from "./OakTooltip";
@@ -8,12 +8,26 @@ import renderWithTheme from "@/test-helpers/renderWithTheme";
 import { oakDefaultTheme } from "@/styles";
 import { OakThemeProvider } from "@/components/atoms";
 
+jest.mock("react-dom", () => {
+  return {
+    ...jest.requireActual("react-dom"),
+    createPortal: (node: ReactNode) => node,
+  };
+});
+
+class MockResizeObserver implements ResizeObserver {
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+}
+window.ResizeObserver = window.ResizeObserver ?? MockResizeObserver;
+
 describe(OakTooltip, () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
         <OakTooltip tooltip="Hello there" isOpen>
-          Trigger!
+          <div>Trigger!</div>
         </OakTooltip>
       </OakThemeProvider>,
     ).toJSON();
@@ -24,7 +38,7 @@ describe(OakTooltip, () => {
   it("renders", () => {
     const { getByRole } = renderWithTheme(
       <OakTooltip tooltip="Hello there" isOpen>
-        Trigger!
+        <div>Trigger!</div>
       </OakTooltip>,
     );
 

--- a/src/components/molecules/OakTooltip/OakTooltip.tsx
+++ b/src/components/molecules/OakTooltip/OakTooltip.tsx
@@ -1,20 +1,64 @@
-import React from "react";
+import React, {
+  ReactElement,
+  ReactNode,
+  useLayoutEffect,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
 
 import {
   InternalTooltip,
   InternalTooltipProps,
 } from "@/components/atoms/InternalTooltip/InternalTooltip";
+import { OakBox, OakBoxProps } from "@/components/atoms";
+import { parseSpacing } from "@/styles/helpers/parseSpacing";
+
+export type OakTooltipProps = Pick<InternalTooltipProps, "tooltipPosition"> & {
+  /**
+   * The target element that triggers the tooltip
+   */
+  children: ReactElement;
+  /**
+   * The content of the tooltip
+   */
+  tooltip: ReactNode;
+  /**
+   * Whether the tooltip is open or not
+   */
+  isOpen?: boolean;
+  /**
+   * The DOM container to render the tooltip portal into
+   *
+   * @default document.body
+   */
+  domContainer?: Element;
+};
 
 /**
- * A tooltip with oven-ready styling
+ * A tooltip with oven-ready styling and positioning.
  */
 export const OakTooltip = ({
   tooltipPosition,
+  children,
+  tooltip,
+  isOpen,
+  domContainer = document.body,
   ...props
-}: Pick<
-  InternalTooltipProps,
-  "isOpen" | "tooltip" | "children" | "tooltipPosition"
->) => {
+}: OakTooltipProps) => {
+  const [targetElement, setTargetElement] = useState<Element | null>(null);
+  /**
+   * The overlay is positioned on top of the target element in a portal.
+   * It tracks the target's size and position.
+   *
+   * we use it to position the tooltip relative to the target element without interfering
+   * with the page layout
+   */
+  const [overlayStyle, setOverlayStyle] = useState<{
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  }>();
   const squaredCornerRadiusProp: keyof InternalTooltipProps = (() => {
     switch (tooltipPosition) {
       case "bottom-right":
@@ -27,22 +71,111 @@ export const OakTooltip = ({
         return "$btlr";
     }
   })();
-
   const borderRadiusProps: Partial<InternalTooltipProps> = {
     $borderRadius: "border-radius-m",
     [squaredCornerRadiusProp]: "border-radius-square",
   };
 
+  useLayoutEffect(() => {
+    if (!targetElement) {
+      return;
+    }
+
+    const updateOverlayStyle = () => {
+      const rect = targetElement.getBoundingClientRect();
+
+      setOverlayStyle({
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      });
+    };
+
+    const observer = new ResizeObserver(updateOverlayStyle);
+    observer.observe(targetElement);
+    observer.observe(document.documentElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [targetElement]);
+
   return (
-    <InternalTooltip
-      $background="bg-decorative5-main"
-      $color="text-primary"
-      $pv="inner-padding-m"
-      $ph="inner-padding-xl"
-      $font="heading-light-7"
-      tooltipPosition={tooltipPosition}
-      {...props}
-      {...borderRadiusProps}
-    />
+    <>
+      {createPortal(
+        isOpen && (
+          <OakBox
+            $position="absolute"
+            style={overlayStyle}
+            $pointerEvents="none"
+            $zIndex="modal-dialog"
+          >
+            <OakBox
+              $width="fit-content"
+              $height="fit-content"
+              $position="absolute"
+              {...getTooltipPositionProps(tooltipPosition)}
+            >
+              <InternalTooltip
+                $background="bg-decorative5-main"
+                $color="text-primary"
+                $pv="inner-padding-m"
+                $ph="inner-padding-xl"
+                $font="heading-light-7"
+                tooltipPosition={tooltipPosition}
+                {...props}
+                {...borderRadiusProps}
+              >
+                {tooltip}
+              </InternalTooltip>
+            </OakBox>
+          </OakBox>
+        ),
+        domContainer,
+      )}
+      <div
+        ref={(domElement) => {
+          setTargetElement(domElement?.firstElementChild ?? null);
+        }}
+        style={{ display: "contents" }}
+      >
+        {children}
+      </div>
+    </>
   );
 };
+
+function getTooltipPositionProps(
+  tooltipPosition: OakTooltipProps["tooltipPosition"],
+) {
+  const props: Partial<OakBoxProps> = {};
+
+  switch (tooltipPosition) {
+    case "top-left":
+    case "top-right":
+      props.$top = "space-between-none";
+      props.$transform = `translateY(calc(-100% - ${parseSpacing(
+        "space-between-s",
+      )}))`;
+      break;
+    default:
+      props.$bottom = "space-between-none";
+      props.$transform = `translateY(calc(100% + ${parseSpacing(
+        "space-between-s",
+      )}))`;
+      break;
+  }
+
+  switch (tooltipPosition) {
+    case "top-left":
+    case "bottom-left":
+      props.$left = "space-between-none";
+      break;
+    default:
+      props.$right = "space-between-none";
+      break;
+  }
+
+  return props;
+}

--- a/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
+++ b/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
@@ -1,29 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTooltip matches snapshot 1`] = `
-.c0 {
-  position: relative;
+[
+  .c0 {
+  position: absolute;
+  pointer-events: none;
+  font-family: Lexend,sans-serif;
+  z-index: 300;
+}
+
+.c1 {
+  position: absolute;
+  right: 0rem;
+  bottom: 0rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  font-family: Lexend,sans-serif;
-}
-
-.c2 {
-  position: absolute;
-  bottom: 0rem;
-  left: 0rem;
   -webkit-transform: translateY(calc(100% + 1rem));
   -ms-transform: translateY(calc(100% + 1rem));
   transform: translateY(calc(100% + 1rem));
   font-family: Lexend,sans-serif;
-  z-index: 300;
 }
 
-.c4 {
+.c2 {
   position: relative;
   max-width: 22.5rem;
   padding-left: 1.5rem;
@@ -44,31 +46,21 @@ exports[`OakTooltip matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
-.c5 {
+.c4 {
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
   pointer-events: none;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   top: -1rem;
   left: 0rem;
@@ -79,33 +71,49 @@ exports[`OakTooltip matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c2 {
     max-width: 40rem;
   }
 }
 
 <div
-  className="c0 c1"
->
-  <div
-    className="c2 c3"
-    role="tooltip"
+    className="c0"
   >
     <div
-      className="c4 c1 c5"
+      className="c1"
     >
-      Hello there
-      <svg
-        className="c6"
-        height="16"
-        width="16"
+      <div
+        className="c2 c3 c4"
+        role="tooltip"
       >
-        <path
-          d="M0 0H16L8 8L0 16V0Z"
-        />
-      </svg>
+        Hello there
+        <svg
+          className="c5"
+          data-testid="tooltip-arrow"
+          height="1rem"
+          width="1rem"
+        >
+          <path
+            d="M0 0H16L8 8L0 16V0Z"
+          />
+        </svg>
+      </div>
     </div>
-  </div>
-  Trigger!
-</div>
+  </div>,
+  @media (min-width:750px) {
+
+}
+
+<div
+    style={
+      {
+        "display": "contents",
+      }
+    }
+  >
+    <div>
+      Trigger!
+    </div>
+  </div>,
+]
 `;

--- a/src/components/organisms/pupil/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/organisms/pupil/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -14,24 +14,13 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c5 {
   position: relative;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
-  font-family: Lexend,sans-serif;
-}
-
-.c7 {
-  position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
   font-family: Lexend,sans-serif;
 }
 
-.c13 {
+.c11 {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -42,7 +31,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c15 {
+.c13 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -51,7 +40,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c16 {
+.c14 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -60,7 +49,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c19 {
+.c17 {
   width: 100%;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -90,14 +79,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   align-items: center;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c12 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -116,7 +98,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   gap: 0.75rem;
 }
 
-.c14 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -131,7 +113,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c20 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -149,7 +131,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c18 {
+.c16 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -160,11 +142,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c17 {
+.c15 {
   object-fit: contain;
 }
 
-.c10 {
+.c8 {
   background: none;
   color: inherit;
   border: none;
@@ -178,59 +160,59 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   color: #222222;
 }
 
-.c10:disabled {
+.c8:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c11 {
+.c9 {
   display: inline-block;
   position: relative;
 }
 
-.c11:hover {
+.c9:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
 }
 
-.c11:active {
+.c9:active {
   color: #222222;
 }
 
-.c11:disabled {
+.c9:disabled {
   color: #808080;
 }
 
-.c8 > :first-child:focus-visible .shadow {
+.c6 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c8 > :first-child:hover .shadow {
+.c6 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c8 > :first-child:active .shadow {
+.c6 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c8 > :first-child:disabled .icon-container {
+.c6 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c8 > :first-child:hover .icon-container {
+.c6 > :first-child:hover .icon-container {
   background: #ffe555;
 }
 
-.c8 > :first-child:active .icon-container {
+.c6 > :first-child:active .icon-container {
   background: #ffe555;
 }
 
-.c9:hover .shadow {
+.c7:hover .shadow {
   box-shadow: none !important;
 }
 
-.c9:active .shadow {
+.c7:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%) !important;
 }
 
@@ -239,7 +221,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c19 {
+  .c17 {
     width: auto;
   }
 }
@@ -253,7 +235,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c18 {
     -webkit-box-pack: end;
     -webkit-justify-content: flex-end;
     -ms-flex-pack: end;
@@ -268,32 +250,36 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       className="c3 c4"
     >
       <div
-        className="c5 c6"
+        style={
+          {
+            "display": "contents",
+          }
+        }
       >
         <div
-          className="c7 c8 c9"
+          className="c5 c6 c7"
         >
           <button
-            className="c10 c11"
+            className="c8 c9"
             onClick={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
           >
             <div
-              className="c3 c12"
+              className="c3 c10"
             >
               <div
-                className="c13 c14 icon-container"
+                className="c11 c12 icon-container"
               >
                 <div
-                  className="c15 shadow"
+                  className="c13 shadow"
                 />
                 <div
-                  className="c16"
+                  className="c14"
                 >
                   <img
                     alt="lightbulb"
-                    className="c17"
+                    className="c15"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -318,7 +304,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
                 </div>
               </div>
               <span
-                className="c18"
+                className="c16"
               >
                 Need a hint?
               </span>
@@ -328,7 +314,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c19 c20"
+      className="c17 c18"
     />
   </div>,
   .c0 {

--- a/src/components/organisms/pupil/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/organisms/pupil/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -4,28 +4,17 @@ exports[`OakQuizHint matches snapshot 1`] = `
 [
   .c0 {
   position: relative;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
-  font-family: Lexend,sans-serif;
-}
-
-.c2 {
-  position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
   font-family: Lexend,sans-serif;
 }
 
-.c7 {
+.c5 {
   font-family: Lexend,sans-serif;
 }
 
-.c9 {
+.c7 {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -36,7 +25,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c11 {
+.c9 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,7 +34,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c12 {
+.c10 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -54,14 +43,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c8 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -80,7 +62,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   gap: 0.75rem;
 }
 
-.c10 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -95,7 +77,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c14 {
+.c12 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -106,11 +88,11 @@ exports[`OakQuizHint matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c13 {
+.c11 {
   object-fit: contain;
 }
 
-.c5 {
+.c3 {
   background: none;
   color: inherit;
   border: none;
@@ -124,89 +106,93 @@ exports[`OakQuizHint matches snapshot 1`] = `
   color: #222222;
 }
 
-.c5:disabled {
+.c3:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c6 {
+.c4 {
   display: inline-block;
   position: relative;
 }
 
-.c6:hover {
+.c4:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
 }
 
-.c6:active {
+.c4:active {
   color: #222222;
 }
 
-.c6:disabled {
+.c4:disabled {
   color: #808080;
 }
 
-.c3 > :first-child:focus-visible .shadow {
+.c1 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c3 > :first-child:hover .shadow {
+.c1 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c3 > :first-child:active .shadow {
+.c1 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c3 > :first-child:disabled .icon-container {
+.c1 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c3 > :first-child:hover .icon-container {
+.c1 > :first-child:hover .icon-container {
   background: #ffe555;
 }
 
-.c3 > :first-child:active .icon-container {
+.c1 > :first-child:active .icon-container {
   background: #ffe555;
 }
 
-.c4:hover .shadow {
+.c2:hover .shadow {
   box-shadow: none !important;
 }
 
-.c4:active .shadow {
+.c2:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%) !important;
 }
 
 <div
-    className="c0 c1"
+    style={
+      {
+        "display": "contents",
+      }
+    }
   >
     <div
-      className="c2 c3 c4"
+      className="c0 c1 c2"
     >
       <button
-        className="c5 c6"
+        className="c3 c4"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <div
-          className="c7 c8"
+          className="c5 c6"
         >
           <div
-            className="c9 c10 icon-container"
+            className="c7 c8 icon-container"
           >
             <div
-              className="c11 shadow"
+              className="c9 shadow"
             />
             <div
-              className="c12"
+              className="c10"
             >
               <img
                 alt="lightbulb"
-                className="c13"
+                className="c11"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -231,7 +217,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
             </div>
           </div>
           <span
-            className="c14"
+            className="c12"
           >
             Need a hint?
           </span>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
