### PR TITLE
Fix tooltip positioning incorrectly inside a fixed element

### DIFF
--- a/src/components/molecules/OakTooltip/OakTooltip.stories.tsx
+++ b/src/components/molecules/OakTooltip/OakTooltip.stories.tsx
@@ -44,3 +44,26 @@ type Story = StoryObj<typeof OakTooltip>;
 export const Default: Story = {
   render: (args) => <OakTooltip {...args} />,
 };
+
+export const FixedPosition: Story = {
+  render: (args) => (
+    <>
+      <OakBox $position="fixed" $top="all-spacing-2">
+        <OakTooltip {...args} />
+      </OakBox>
+      <OakBox $position="fixed" $bottom="all-spacing-2">
+        <OakTooltip {...args} tooltipPosition="top-left" />
+      </OakBox>
+      <OakBox style={{ height: "1000px" }} />
+    </>
+  ),
+};
+
+export const WithinAScrollingContainer: Story = {
+  render: (args) => (
+    <OakBox $overflow="scroll" $height="all-spacing-20">
+      <OakTooltip {...args} />
+      <OakBox style={{ height: "1000px" }} />
+    </OakBox>
+  ),
+};

--- a/src/components/molecules/OakTooltip/OakTooltip.test.tsx
+++ b/src/components/molecules/OakTooltip/OakTooltip.test.tsx
@@ -21,6 +21,19 @@ class MockResizeObserver implements ResizeObserver {
   unobserve() {}
 }
 window.ResizeObserver = window.ResizeObserver ?? MockResizeObserver;
+class MockIntersectionObserver implements IntersectionObserver {
+  root = document.documentElement;
+  rootMargin = "0px";
+  thresholds = [1];
+  takeRecords(): IntersectionObserverEntry[] {
+    throw new Error("Method not implemented.");
+  }
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+}
+window.IntersectionObserver =
+  window.IntersectionObserver ?? MockIntersectionObserver;
 
 describe(OakTooltip, () => {
   it("matches snapshot", () => {

--- a/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
+++ b/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakTooltip matches snapshot 1`] = `
 [
   .c0 {
-  position: absolute;
+  position: fixed;
   pointer-events: none;
   font-family: Lexend,sans-serif;
   z-index: 300;


### PR DESCRIPTION
# How to review this PR

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Fixes the tooltip being rendered relative to the root of the document instead of the viewport. Also ensures that the tooltip is hidden when the target element leaves the viewport.

**Before**

https://github.com/oaknational/oak-components/assets/122096/58007b01-c340-4ad7-b6d0-0acbeed6d2db

**After**

https://github.com/oaknational/oak-components/assets/122096/95b4ca11-2648-4713-9e4b-4a60e26724ca

## A link to the component in the deployment preview

https://deploy-preview-136--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oaktooltip--docs

## Testing instructions

There are a couple new stories to demonstrate the tooltip in more complicated contexts. 
https://deploy-preview-136--lively-meringue-8ebd43.netlify.app/?path=/story/components-molecules-oaktooltip--fixed-position

https://deploy-preview-136--lively-meringue-8ebd43.netlify.app/?path=/story/components-molecules-oaktooltip--within-a-scrolling-container


