### PR TITLE
PUPIL-546 Randomise options in `OakQuizMatch`

### DIFF
--- a/src/components/organisms/pupil/OakQuizMatch/OakQuizMatch.test.tsx
+++ b/src/components/organisms/pupil/OakQuizMatch/OakQuizMatch.test.tsx
@@ -44,6 +44,14 @@ const slots = [
 ];
 
 describe(OakQuizMatch, () => {
+  beforeEach(() => {
+    // Seed Math.random so that the order of the options is predictable
+    const randomSpy = jest.spyOn(Math, "random");
+    for (let i = 0; i < 10; i++) {
+      randomSpy.mockReturnValueOnce(0.1 * i);
+    }
+  });
+
   it("matches snapshot", () => {
     const tree = create(
       <ThemeProvider theme={oakDefaultTheme}>
@@ -79,7 +87,7 @@ describe(OakQuizMatch, () => {
       getAllByRoleWithin(getByTestId("holding-pen"), "option").map(
         (item) => item.textContent,
       ),
-    ).toEqual(["Exclamation mark", "Full stop", "Question mark"]);
+    ).toEqual(["Question mark", "Full stop", "Exclamation mark"]);
 
     // Drag the first item into the first slot
     act(() => {
@@ -93,7 +101,7 @@ describe(OakQuizMatch, () => {
       getAllByRoleWithin(getByTestId("holding-pen"), "option").map(
         (item) => item.textContent,
       ),
-    ).toEqual(["Full stop", "Question mark"]);
+    ).toEqual(["Question mark", "Full stop"]);
     expect(getByTestIdWithin(firstSlot, "label").textContent).toEqual(
       "conveys intense emotion",
     );
@@ -113,7 +121,7 @@ describe(OakQuizMatch, () => {
       getAllByRoleWithin(getByTestId("holding-pen"), "option").map(
         (item) => item.textContent,
       ),
-    ).toEqual(["Exclamation mark", "Question mark"]);
+    ).toEqual(["Question mark", "Exclamation mark"]);
     // The first slot should now contain the second option
     expect(getByRoleWithin(firstSlot, "option").textContent).toEqual(
       "Full stop",
@@ -131,7 +139,7 @@ describe(OakQuizMatch, () => {
       getAllByRoleWithin(getByTestId("holding-pen"), "option").map(
         (item) => item.textContent,
       ),
-    ).toEqual(["Exclamation mark", "Full stop", "Question mark"]);
+    ).toEqual(["Question mark", "Full stop", "Exclamation mark"]);
     expect(getByTestIdWithin(firstSlot, "label").textContent).toEqual(
       "conveys intense emotion",
     );

--- a/src/components/organisms/pupil/OakQuizMatch/OakQuizMatch.tsx
+++ b/src/components/organisms/pupil/OakQuizMatch/OakQuizMatch.tsx
@@ -158,7 +158,9 @@ export const OakQuizMatch = ({
   onChange,
 }: OakQuizMatchProps) => {
   const [matches, setMatches] = useState<Matches>({});
-  const draggables = useRef(initialOptions).current;
+  const draggables = useRef(
+    initialOptions.slice().sort(() => Math.random() - 0.5),
+  ).current;
   const droppables = useRef(initialSlots).current;
   const [activeId, setActiveId] = useState<DraggableId | null>(null);
   const activeDraggable = draggables.find((item) => item.id === activeId);

--- a/src/components/organisms/pupil/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
+++ b/src/components/organisms/pupil/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
@@ -384,7 +384,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
           <div
             className="c11 c12"
           >
-            Exclamation mark
+            Question mark
           </div>
         </div>
       </div>
@@ -492,7 +492,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
           <div
             className="c11 c12"
           >
-            Question mark
+            Exclamation mark
           </div>
         </div>
       </div>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Until now the options in a match question lined up perfectly with the slots to drop them in. If a pupil realised this they could answer the question easily by dropping the first option into the first slot, the second into the second and so forth.

This change randomises the option on the first render of the component so that the randomised order is stable over subsequent renders until the the component is unmounted.

## A link to the component in the deployment preview
https://deploy-preview-141--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-pupil-oakquizmatch--docs

## Testing instructions
It should be enough to refresh the page in Storybook to see that the order of options changes.
