### PR TITLE
Cookie modal design tweaks

### DIFF
--- a/src/components/atoms/InternalCheckBox/InternalCheckBox.tsx
+++ b/src/components/atoms/InternalCheckBox/InternalCheckBox.tsx
@@ -83,6 +83,8 @@ type StyledBaseCheckBoxProps = BaseCheckBoxProps &
   BorderStyleProps &
   SizeStyleProps & {
     $checkedBackground?: OakCombinedColorToken | null;
+    $checkedBorderColor?: OakCombinedColorToken;
+    $uncheckedBorderColor?: OakCombinedColorToken;
   };
 
 type HoverBaseCheckBoxProps = {
@@ -135,14 +137,23 @@ export const InternalCheckBox = styled(BaseCheckBox)<StyledBaseCheckBoxProps>`
   ${spacingStyle}
   ${sizeStyle}
 
+  border-color: ${(props) => parseColor(props.$uncheckedBorderColor)};
+
   &:checked {
     ${(props) => css`
       background: ${parseColor(props.$checkedBackground)};
+      border-color: ${parseColor(props.$checkedBorderColor)};
     `};
   }
 
   &:disabled {
     pointer-events: none;
+  }
+
+  @media (hover: hover) {
+    &:hover:not(:disabled) {
+      border-color: ${(props) => parseColor(props.$checkedBackground)};
+    }
   }
 `;
 
@@ -167,12 +178,8 @@ export const InternalCheckBoxHover = styled(InternalCheckBox)<
       width: 60%;
       height: 60%;
       transform: translate(-50%, -50%);
-      border-radius: ${(props) => css`
-        ${parseBorderRadius(props.$hoverBorderRadius)}
-      `};
-      background: ${(props) => css`
-        ${parseColor(props.$checkedBackground)}
-      `};
+      border-radius: ${(props) => parseBorderRadius(props.$hoverBorderRadius)};
+      background: ${(props) => parseColor(props.$checkedBackground)};
     }
   }
 `;

--- a/src/components/atoms/InternalCheckBox/__snapshots__/InternalCheckBox.test.tsx.snap
+++ b/src/components/atoms/InternalCheckBox/__snapshots__/InternalCheckBox.test.tsx.snap
@@ -22,6 +22,12 @@ exports[`InternalCheckBox matches snapshot 1`] = `
   pointer-events: none;
 }
 
+@media (hover:hover) {
+  .c0:hover:not(:disabled) {
+    border-color: #222222;
+  }
+}
+
 <input
   className="c0"
   id="checkbox-1"

--- a/src/components/atoms/OakP/OakP.tsx
+++ b/src/components/atoms/OakP/OakP.tsx
@@ -22,11 +22,4 @@ export const OakP = styled.p<OakPProps>`
   ${typographyStyle}
   ${colorStyle}
   ${marginStyle}
-
-  a {
-    color: ${(props) =>
-      props.theme &&
-      props.theme.uiColors &&
-      props.theme.uiColors["text-link-active"]};
-  }
 `;

--- a/src/components/molecules/OakCheckBox/OakCheckBox.stories.tsx
+++ b/src/components/molecules/OakCheckBox/OakCheckBox.stories.tsx
@@ -39,6 +39,8 @@ const meta: Meta<typeof OakCheckBox> = {
         "checkboxSize",
         "checkboxBorder",
         "checkboxBorderRadius",
+        "checkedBorderColor",
+        "uncheckedBorderColor",
         "hoverBorderRadius",
         "iconPadding",
         "labelGap",

--- a/src/components/molecules/OakCheckBox/OakCheckBox.tsx
+++ b/src/components/molecules/OakCheckBox/OakCheckBox.tsx
@@ -21,6 +21,8 @@ export type OakCheckBoxProps = BaseCheckBoxProps & {
   checkboxSize?: OakAllSpacingToken;
   checkboxBorder?: OakBorderWidthToken;
   checkboxBorderRadius?: OakBorderRadiusToken;
+  checkedBorderColor?: OakCombinedColorToken;
+  uncheckedBorderColor?: OakCombinedColorToken;
   checkedIcon?: React.JSX.Element;
   checkedBackgroundFill?: boolean;
   hoverBorderRadius?: OakBorderRadiusToken;
@@ -72,6 +74,14 @@ export const OakCheckBox = (props: OakCheckBoxProps) => {
     checkboxBorder = "border-solid-m",
     checkboxBorderRadius = "border-radius-xs",
     defaultColor = "text-primary",
+    /**
+     * The outer border color of the checkbox when unchecked.
+     */
+    uncheckedBorderColor = "border-neutral",
+    /**
+     * The outer border color of the checkbox when checked.
+     */
+    checkedBorderColor = "border-primary",
     disabledColor = "text-disabled",
     labelGap = "space-between-s",
     labelAlignItems = "center",
@@ -95,6 +105,12 @@ export const OakCheckBox = (props: OakCheckBoxProps) => {
   };
 
   const currentColor = disabled ? disabledColor : defaultColor;
+  const currentCheckedBackgroundFill = disabled
+    ? disabledColor
+    : checkedBorderColor;
+  const currentCheckedBorderColor = disabled
+    ? disabledColor
+    : checkedBorderColor;
 
   return (
     <InternalCheckBoxLabel
@@ -117,8 +133,12 @@ export const OakCheckBox = (props: OakCheckBoxProps) => {
             $height={checkboxSize}
             $ba={checkboxBorder}
             $borderRadius={checkboxBorderRadius}
-            $borderColor={currentColor}
-            $checkedBackground={checkedBackgroundFill ? currentColor : null}
+            $borderColor={defaultColor}
+            $checkedBackground={
+              checkedBackgroundFill ? currentCheckedBackgroundFill : null
+            }
+            $checkedBorderColor={currentCheckedBorderColor}
+            $uncheckedBorderColor={uncheckedBorderColor}
             $hoverBorderRadius={hoverBorderRadius}
             onChange={onChange}
             onFocus={onFocus}

--- a/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
+++ b/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
@@ -14,10 +14,12 @@ exports[`OakCheckBox matches snapshot 1`] = `
   border-radius: 0.125rem;
   width: 1.5rem;
   height: 1.5rem;
+  border-color: #808080;
 }
 
 .c4:checked {
   background: #222222;
+  border-color: #222222;
 }
 
 .c4:disabled {
@@ -88,6 +90,12 @@ exports[`OakCheckBox matches snapshot 1`] = `
 
 input:checked + .c7 {
   opacity: 1;
+}
+
+@media (hover:hover) {
+  .c4:hover:not(:disabled) {
+    border-color: #222222;
+  }
 }
 
 @media (hover:hover) {

--- a/src/components/molecules/OakModal/OakModal.tsx
+++ b/src/components/molecules/OakModal/OakModal.tsx
@@ -142,6 +142,7 @@ export const OakModal = ({
             $zIndex="modal-dialog"
             $flexDirection="column"
             $transition="standard-ease"
+            $color="text-primary"
             role="dialog"
             $state={state}
             {...rest}

--- a/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
+++ b/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`OakModal matches snapshot 1`] = `
   bottom: 0rem;
   left: 0rem;
   width: 40rem;
+  color: #222222;
   background: #ffffff;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;

--- a/src/components/organisms/OakCookieBanner/OakCookieBanner.tsx
+++ b/src/components/organisms/OakCookieBanner/OakCookieBanner.tsx
@@ -70,6 +70,7 @@ export const OakCookieBanner = ({
       $right={isFixed ? "all-spacing-0" : undefined}
       $left={isFixed ? "all-spacing-0" : undefined}
       $zIndex={isFixed ? "in-front" : undefined}
+      $color="text-primary"
       data-testid="cookie-banner"
     >
       <OakBox $maxWidth={innerMaxWidth} $mh="auto">

--- a/src/components/organisms/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
+++ b/src/components/organisms/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`OakCookieBanner matches snapshot 1`] = `
 .c0 {
+  color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
   border-color: #808080;

--- a/src/components/organisms/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
+++ b/src/components/organisms/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`OakCookieConsent matches snapshot 1`] = `
 .c0 {
+  color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
   border-color: #808080;

--- a/src/components/organisms/OakCookieSettingsModal/OakCookieSettingsModal.tsx
+++ b/src/components/organisms/OakCookieSettingsModal/OakCookieSettingsModal.tsx
@@ -3,6 +3,7 @@ import React, { FormEvent, ReactNode } from "react";
 import {
   OakAccordion,
   OakCheckBox,
+  OakLink,
   OakModal,
   OakModalBody,
   OakModalFooter,
@@ -135,9 +136,9 @@ export const OakCookieSettingsModal = ({
 
         <OakP $mb="space-between-l">
           For more information, view our{" "}
-          <OakSecondaryLink href={policyURL} target="_blank">
+          <OakLink href={policyURL} target="_blank">
             cookie policy
-          </OakSecondaryLink>
+          </OakLink>
           .
         </OakP>
         <OakBox $mb="space-between-xl">

--- a/src/components/organisms/pupil/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
+++ b/src/components/organisms/pupil/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
@@ -170,6 +170,10 @@ input:checked + .c13 {
 }
 
 @media (hover:hover) {
+
+}
+
+@media (hover:hover) {
   .c12:hover:not(:disabled) {
     background: #ffffff;
   }


### PR DESCRIPTION
# How to review this PR

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

* Fixes a bug where link styles were overridden by `OakP` settings all links to the literal colour `navy`
* Switches to `OakLink` for the "cookie policy" link to apply `text-link-active` colours
* Applies `border-neutral` as the unchecked border colour for `OakCheckBox` to align it with Figma
* Applies a base text colour to the modal so that it defaults to `text-primary`

<img width="710" alt="Screenshot 2024-04-12 at 17 05 16" src="https://github.com/oaknational/oak-components/assets/122096/43fcde95-150e-4221-99ce-27a83e0bd10c">


## Link to the design doc

https://www.figma.com/file/Ru5PP6cdyDTDdqmQpNwXtl/Cookie-Banner?type=design&node-id=1-11625&mode=dev

## A link to the component in the deployment preview

https://deploy-preview-146--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-oakcookiesettingsmodal--docs
https://deploy-preview-146--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oakcheckbox--docs

## Testing instructions

These are subtle colour changes so they shouldn't have a significant risk of causing regressions.