### PR TITLE
fix(tooltip): dynamically set domelement

### DIFF
--- a/src/components/molecules/OakTooltip/OakTooltip.tsx
+++ b/src/components/molecules/OakTooltip/OakTooltip.tsx
@@ -42,11 +42,14 @@ export const OakTooltip = ({
   children,
   tooltip,
   isOpen,
-  domContainer = document.body,
+  domContainer,
   ...props
 }: OakTooltipProps) => {
   const [targetElement, setTargetElement] = useState<Element | null>(null);
   const [isIntersecting, setIsIntersecting] = useState(true);
+  const [domContainerState, setDomContainerState] = useState<
+    Element | undefined
+  >(domContainer);
   const isVisible = isOpen && isIntersecting;
 
   /**
@@ -123,39 +126,47 @@ export const OakTooltip = ({
     };
   }, [targetElement]);
 
+  useLayoutEffect(() => {
+    if (domContainerState) {
+      return;
+    }
+    setDomContainerState(document.body);
+  }, [domContainerState]);
+
   return (
     <>
-      {createPortal(
-        isVisible && (
-          <OakBox
-            $position="fixed"
-            style={overlayStyle}
-            $pointerEvents="none"
-            $zIndex="modal-dialog"
-          >
+      {domContainerState &&
+        createPortal(
+          isVisible && (
             <OakBox
-              $width="fit-content"
-              $height="fit-content"
-              $position="absolute"
-              {...getTooltipPositionProps(tooltipPosition)}
+              $position="fixed"
+              style={overlayStyle}
+              $pointerEvents="none"
+              $zIndex="modal-dialog"
             >
-              <InternalTooltip
-                $background="bg-decorative5-main"
-                $color="text-primary"
-                $pv="inner-padding-m"
-                $ph="inner-padding-xl"
-                $font="heading-light-7"
-                tooltipPosition={tooltipPosition}
-                {...props}
-                {...borderRadiusProps}
+              <OakBox
+                $width="fit-content"
+                $height="fit-content"
+                $position="absolute"
+                {...getTooltipPositionProps(tooltipPosition)}
               >
-                {tooltip}
-              </InternalTooltip>
+                <InternalTooltip
+                  $background="bg-decorative5-main"
+                  $color="text-primary"
+                  $pv="inner-padding-m"
+                  $ph="inner-padding-xl"
+                  $font="heading-light-7"
+                  tooltipPosition={tooltipPosition}
+                  {...props}
+                  {...borderRadiusProps}
+                >
+                  {tooltip}
+                </InternalTooltip>
+              </OakBox>
             </OakBox>
-          </OakBox>
-        ),
-        domContainer,
-      )}
+          ),
+          domContainerState,
+        )}
       <div
         ref={(domElement) => {
           setTargetElement(domElement?.firstElementChild ?? null);


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

dynamically set domElement to allow static import of tooltip

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
