### PR TITLE
Feat/ remove alt from search checkbox 

### DIFF
--- a/src/components/organisms/teacher/OakSearchFilterCheckBox/OakSearchFilterCheckBox.tsx
+++ b/src/components/organisms/teacher/OakSearchFilterCheckBox/OakSearchFilterCheckBox.tsx
@@ -143,7 +143,7 @@ export const OakSearchFilterCheckBox = (
           ref={inputRef}
           {...rest}
         />
-        {icon && <StyledOakIcon iconName={icon} />}
+        {icon && <StyledOakIcon alt="" iconName={icon} />}
         <InternalCheckBoxLabelHoverDecor
           pointerEvents="none"
           htmlFor={id}

--- a/src/components/organisms/teacher/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
+++ b/src/components/organisms/teacher/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
         className="c7 "
       >
         <img
-          alt="subject-history"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Removes alt text from icons in search checkboxes - previously defaulted to icon title

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
