### PR TITLE
feat: order list nav with tertiary styling

### DIFF
--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -18,3 +18,4 @@ export * from "./OakMaxWidth";
 export * from "./OakCloudinaryImage";
 export * from "./OakKbd";
 export * from "./OakGlobalStyle";
+export * from "./OakAnchorTarget";

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.stories.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.stories.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakTertiaryOLNav, OakTertiaryOLNavProps } from "./OakTertiaryOLNav";
+
+const items: OakTertiaryOLNavProps = {
+  items: [
+    {
+      title: "Creating solid explanations and good modelling",
+      href: "#solid-explanations",
+    },
+    {
+      title: "Short item",
+      href: "#short-item",
+    },
+    {
+      title: "What is a lesson plan",
+      href: "#lesson-plan",
+    },
+  ],
+  ariaLabel: "navigation",
+  title: "contents",
+};
+/**
+ *
+ * OakTertiaryOLNav is a styled ol list nav.
+ *
+ */
+const meta: Meta<typeof OakTertiaryOLNav> = {
+  component: OakTertiaryOLNav,
+  tags: ["autodocs"],
+  title: "components/organisms/teacher/OakTertiaryOLNav",
+};
+export default meta;
+
+type Story = StoryObj<typeof OakTertiaryOLNav>;
+
+export const Default: Story = {
+  render: (args) => <OakTertiaryOLNav {...args} />,
+  args: items,
+};

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.test.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.test.tsx
@@ -37,6 +37,16 @@ describe("Component OakTertiaryOLNav", () => {
     expect(link1.closest("a")).toHaveAttribute("href", "#item1");
     expect(link2.closest("a")).toHaveAttribute("href", "#item2");
   });
+  it("renders anchor target if passed as prop", () => {
+    const { getByTestId } = renderWithTheme(
+      <OakTertiaryOLNav
+        {...baseProps}
+        anchorTarget="target"
+        data-testid="test"
+      />,
+    );
+    expect(getByTestId("test").querySelector("#target")).toBeInTheDocument();
+  });
 
   it("matches snapshot", () => {
     const tree = create(

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.test.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+
+import { OakTertiaryOLNav, OakTertiaryOLNavProps } from "./OakTertiaryOLNav";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { OakThemeProvider } from "@/components/atoms";
+import { oakDefaultTheme } from "@/styles";
+
+const baseProps: OakTertiaryOLNavProps = {
+  items: [
+    { title: "Item 1", href: "#item1" },
+    { title: "Item 2", href: "#item2" },
+  ],
+  ariaLabel: "navigation",
+};
+
+describe("Component OakTertiaryOLNav", () => {
+  it("renders", () => {
+    const { getByTestId } = renderWithTheme(
+      <OakTertiaryOLNav {...baseProps} data-testid="test" />,
+    );
+    expect(getByTestId("test")).toBeInTheDocument();
+  });
+  it("conditionally renders the title", () => {
+    const { queryByText } = renderWithTheme(
+      <OakTertiaryOLNav {...baseProps} title="Contents" />,
+    );
+    expect(queryByText("Contents")).toBeInTheDocument();
+  });
+
+  it("renders items with correct title and href", () => {
+    const { getByText } = renderWithTheme(<OakTertiaryOLNav {...baseProps} />);
+    const link1 = getByText("Item 1");
+    const link2 = getByText("Item 2");
+    expect(link1.closest("a")).toHaveAttribute("href", "#item1");
+    expect(link2.closest("a")).toHaveAttribute("href", "#item2");
+  });
+
+  it("matches snapshot", () => {
+    const tree = create(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakTertiaryOLNav {...baseProps} />,
+      </OakThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import styled from "styled-components";
+
+import { InternalLink } from "@/components/molecules/InternalLink";
+import { parseColor } from "@/styles/helpers/parseColor";
+import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
+import { OakLI } from "@/components/atoms/OakLI";
+import { parseSpacing } from "@/styles/helpers/parseSpacing";
+import { OakBox, OakSpan } from "@/components/atoms";
+
+const StyledNav = styled.nav`
+  outline: none;
+`;
+const StyledOakLink = styled(InternalLink)`
+  text-decoration: none;
+  color: inherit;
+  width: 100%;
+  display: Flex;
+  width: 100%;
+  &:focus {
+    box-shadow: none;
+  }
+
+  &::before {
+    content: counter(list-counter);
+    min-width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background-color: ${parseColor("black")};
+    color: ${parseColor("white")};
+    text-align: center;
+    line-height: 32px;
+    margin-right: ${parseSpacing("space-between-xs")};
+    text-decoration: none;
+  }
+  &:hover::before {
+    background-color: ${parseColor("bg-btn-primary-hover")};
+    box-shadow: ${parseDropShadow("drop-shadow-lemon")};
+    text-decoration: none;
+  }
+
+  &:focus-within::before {
+    box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
+      ${parseDropShadow("drop-shadow-centered-grey")};
+    text-decoration: none;
+  }
+  &:active {
+    color: ${parseColor("black")};
+  }
+  &:active::before {
+    box-shadow: ${parseDropShadow("drop-shadow-lemon")},
+      ${parseDropShadow("drop-shadow-grey")};
+    background-color: ${parseColor("black")};
+  }
+`;
+
+const StyledOL = styled.ol`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  text-decoration: none;
+`;
+
+const StyledOLItem = styled(OakLI)`
+  position: relative;
+  counter-increment: list-counter;
+  display: flex;
+  align-items: center;
+  margin-bottom: ${parseSpacing("space-between-xs")};
+  min-height: 40px;
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  &:hover {
+    text-decoration: underline;
+    color: ${parseColor("bg-btn-primary-hover")};
+  }
+`;
+
+export type OakTertiaryOLNavProps = {
+  title?: string;
+  items: { title: string; href: string }[];
+  ariaLabel?: string;
+};
+
+export const OakTertiaryOLNav = ({
+  items,
+  ariaLabel,
+  title,
+  ...rest
+}: OakTertiaryOLNavProps) => {
+  return (
+    <StyledNav tabIndex={0} aria-label={ariaLabel} {...rest}>
+      {title && (
+        <OakBox $mb={"space-between-m"}>
+          <OakSpan $font={"heading-light-7"}>{"Contents"}</OakSpan>
+        </OakBox>
+      )}
+      <StyledOL role="list">
+        {items.map((item, index) => (
+          <StyledOLItem
+            aria-label={`list item ${index + 1}`}
+            $font={"heading-7"}
+            key={index}
+          >
+            <StyledOakLink href={item.href}>{item.title}</StyledOakLink>
+          </StyledOLItem>
+        ))}
+      </StyledOL>
+    </StyledNav>
+  );
+};

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
@@ -6,7 +6,7 @@ import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 import { OakLI } from "@/components/atoms/OakLI";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
-import { OakBox, OakSpan } from "@/components/atoms";
+import { OakAnchorTarget, OakBox, OakSpan } from "@/components/atoms";
 
 const StyledNav = styled.nav`
   outline: none;
@@ -82,16 +82,19 @@ export type OakTertiaryOLNavProps = {
   title?: string;
   items: { title: string; href: string }[];
   ariaLabel?: string;
+  anchorTarget?: string;
 };
 
 export const OakTertiaryOLNav = ({
   items,
   ariaLabel,
   title,
+  anchorTarget,
   ...rest
 }: OakTertiaryOLNavProps) => {
   return (
     <StyledNav tabIndex={0} aria-label={ariaLabel} {...rest}>
+      {anchorTarget && <OakAnchorTarget id={anchorTarget} />}
       {title && (
         <OakBox $mb={"space-between-m"}>
           <OakSpan $font={"heading-light-7"}>{"Contents"}</OakSpan>

--- a/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
+[
+  .c6 {
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  display: revert;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  display: revert;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.25rem;
+  outline: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font: inherit;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.c4:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c4[disabled] {
+  cursor: not-allowed;
+}
+
+.c0 {
+  outline: none;
+}
+
+.c5 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  width: 100%;
+  display: Flex;
+  width: 100%;
+}
+
+.c5:focus {
+  box-shadow: none;
+}
+
+.c5::before {
+  content: counter(list-counter);
+  min-width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: #222222;
+  color: #ffffff;
+  text-align: center;
+  line-height: 32px;
+  margin-right: 0.75rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5:hover::before {
+  background-color: #575757;
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5:focus-within::before {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5:active {
+  color: #222222;
+}
+
+.c5:active::before {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
+  background-color: #222222;
+}
+
+.c1 {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3 {
+  position: relative;
+  counter-increment: list-counter;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  min-height: 40px;
+}
+
+.c3:last-child {
+  margin-bottom: 0;
+}
+
+.c3:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #575757;
+}
+
+@media (hover:hover) {
+
+}
+
+<nav
+    aria-label="navigation"
+    className="c0"
+    tabIndex={0}
+  >
+    <ol
+      className="c1"
+      role="list"
+    >
+      <li
+        aria-label="list item 1"
+        className="c2 c3"
+      >
+        <a
+          className="c4 c5"
+          href="#item1"
+        >
+          <span
+            className="c6"
+          >
+            Item 1
+          </span>
+        </a>
+      </li>
+      <li
+        aria-label="list item 2"
+        className="c2 c3"
+      >
+        <a
+          className="c4 c5"
+          href="#item2"
+        >
+          <span
+            className="c6"
+          >
+            Item 2
+          </span>
+        </a>
+      </li>
+    </ol>
+  </nav>,
+  ",",
+]
+`;

--- a/src/components/organisms/teacher/OakTertiaryOLNav/index.ts
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakTertiaryOLNav";

--- a/src/components/organisms/teacher/index.ts
+++ b/src/components/organisms/teacher/index.ts
@@ -1,1 +1,2 @@
 export * from "./OakSearchFilterCheckBox";
+export * from "./OakTertiaryOLNav";


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

This is the order list nav component needed to complete the ticket below. A OWA PR will follow shortly after this is merged.

https://www.notion.so/oaknationalacademy/I-want-a-styled-sticky-contents-block-on-the-plan-a-lesson-page-415e0a416fed432bb35b8b0c18533219

## Link to the design doc

https://www.figma.com/file/XappQ4iolvVw6Ii3EmNKXD/Pillar-page%3A-Plan-a-lesson?node-id=6987-11019&mode=dev

## A link to the component in the deployment preview

https://deploy-preview-164--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-teacher-oaktertiaryolnav--docs

## Testing instructions

- Matches styles from figma
- Hover / Focused / Pressed styles are correct
- Is accessable

## ACs
