### PR TITLE
feat: a11y aria current

### DIFF
--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.stories.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import { OakTertiaryOLNav, OakTertiaryOLNavProps } from "./OakTertiaryOLNav";
@@ -53,14 +53,9 @@ type Story = StoryObj<typeof OakTertiaryOLNav>;
 
 export const Default: Story = {
   render: (args) => {
-    const [currentHref, setCurrentHref] = useState<string | null>(null);
     return (
       <>
-        <OakTertiaryOLNav
-          {...args}
-          currentHref={currentHref}
-          onClick={(e) => setCurrentHref(e.currentTarget.hash)}
-        />
+        <OakTertiaryOLNav {...args} />
         <OakFlex
           $flexDirection={"column"}
           $mt={"space-between-l"}

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.stories.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.stories.tsx
@@ -1,7 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import { OakTertiaryOLNav, OakTertiaryOLNavProps } from "./OakTertiaryOLNav";
+
+import { OakAnchorTarget, OakFlex } from "@/components/atoms";
+import { OakLink } from "@/components/molecules";
 
 const items: OakTertiaryOLNavProps = {
   items: [
@@ -20,11 +23,24 @@ const items: OakTertiaryOLNavProps = {
   ],
   ariaLabel: "navigation",
   title: "contents",
+  anchorTarget: "nav",
 };
 /**
+ * `OakTertiaryOLNav` provides a styled ordered list navigation.
  *
- * OakTertiaryOLNav is a styled ol list nav.
+ * Each navigation link can be activated to represent the current view in a single-page layout or a sectioned page,
+ * with an `aria-current` attribute that dynamically updates based on the `currentHref` prop to indicate the currently active section.
  *
+ * ### Props
+ *
+ * - `title?: string`: Optional. Title displayed at the top of the navigation list.
+ * - `items: { title: string; href: string }[]`: Required. An array of objects, each with a title and href, representing the navigation items.
+ * - `ariaLabel?: string`: Optional. Aria-label for the navigation element to improve accessibility.
+ * - `anchorTarget?: string`: Optional. An ID used to link to the target section, useful for anchor navigation.
+ * - `currentHref?: string`: Optional. The href of the currently active section, used to dynamically set `aria-current`.
+ * - `onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void`: Optional. Callback function triggered on click events on navigation items.
+ 
+ * ```
  */
 const meta: Meta<typeof OakTertiaryOLNav> = {
   component: OakTertiaryOLNav,
@@ -36,6 +52,37 @@ export default meta;
 type Story = StoryObj<typeof OakTertiaryOLNav>;
 
 export const Default: Story = {
-  render: (args) => <OakTertiaryOLNav {...args} />,
+  render: (args) => {
+    const [currentHref, setCurrentHref] = useState<string | null>(null);
+    return (
+      <>
+        <OakTertiaryOLNav
+          {...args}
+          currentHref={currentHref}
+          onClick={(e) => setCurrentHref(e.currentTarget.hash)}
+        />
+        <OakFlex
+          $flexDirection={"column"}
+          $mt={"space-between-l"}
+          $gap={"all-spacing-16"}
+          $background={"aqua30"}
+          $pa={"inner-padding-m"}
+        >
+          <OakFlex $position={"relative"}>
+            <OakAnchorTarget id="solid-explanations" />
+            <OakLink href={"#nav"}>Content 1</OakLink>
+          </OakFlex>
+          <OakFlex $position={"relative"}>
+            <OakAnchorTarget id="short-item" />
+            <OakLink href={"#nav"}>Content 2</OakLink>
+          </OakFlex>
+          <OakFlex $position={"relative"}>
+            <OakAnchorTarget id="lesson-plan" />
+            <OakLink href={"#nav"}>Content 3</OakLink>
+          </OakFlex>
+        </OakFlex>
+      </>
+    );
+  },
   args: items,
 };

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.test.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { create } from "react-test-renderer";
+import userEvent from "@testing-library/user-event";
 
 import { OakTertiaryOLNav, OakTertiaryOLNavProps } from "./OakTertiaryOLNav";
 
@@ -56,13 +57,12 @@ describe("Component OakTertiaryOLNav", () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
-  it("applies aria-current to the current active link", () => {
-    const currentHref = "#item1";
-    const { getByText } = renderWithTheme(
-      <OakTertiaryOLNav {...baseProps} currentHref={currentHref} />,
-    );
+  it("applies aria-current to the current active link", async () => {
+    const { getByText } = renderWithTheme(<OakTertiaryOLNav {...baseProps} />);
 
     const item1 = getByText("Item 1");
+    await userEvent.tab();
+    await userEvent.keyboard("{Enter}");
 
     expect(item1.closest("a")).toHaveAttribute("aria-current", "true");
 

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.test.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.test.tsx
@@ -56,4 +56,17 @@ describe("Component OakTertiaryOLNav", () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it("applies aria-current to the current active link", () => {
+    const currentHref = "#item1";
+    const { getByText } = renderWithTheme(
+      <OakTertiaryOLNav {...baseProps} currentHref={currentHref} />,
+    );
+
+    const item1 = getByText("Item 1");
+
+    expect(item1.closest("a")).toHaveAttribute("aria-current", "true");
+
+    const item2 = getByText("Item 2");
+    expect(item2.closest("a")).not.toHaveAttribute("aria-current");
+  });
 });

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
@@ -97,7 +97,7 @@ export const OakTertiaryOLNav = ({
   const [currentHref, setCurrentHref] = useState<string | null>(null);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLAnchorElement>) => {
-    if (event.key) {
+    if (event.key && event.key !== "Tab") {
       setCurrentHref(event.currentTarget.hash);
     }
   };

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
 import { InternalLink } from "@/components/molecules/InternalLink";
@@ -83,7 +83,6 @@ export type OakTertiaryOLNavProps = {
   items: { title: string; href: string }[];
   ariaLabel?: string;
   anchorTarget?: string;
-  currentHref?: string | null;
   onClick?: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 };
 
@@ -92,10 +91,17 @@ export const OakTertiaryOLNav = ({
   ariaLabel,
   title,
   anchorTarget,
-  currentHref,
   onClick,
   ...rest
 }: OakTertiaryOLNavProps) => {
+  const [currentHref, setCurrentHref] = useState<string | null>(null);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (event.key === "Enter") {
+      setCurrentHref(event.currentTarget.hash);
+    }
+  };
+
   return (
     <StyledNav aria-label={ariaLabel} {...rest}>
       {anchorTarget && <OakAnchorTarget id={anchorTarget} />}
@@ -108,9 +114,10 @@ export const OakTertiaryOLNav = ({
         {items.map((item, index) => (
           <StyledOLItem $font={"heading-7"} key={index}>
             <StyledOakLink
-              aria-current={item.href === currentHref ? "true" : undefined}
               onClick={onClick}
               href={item.href}
+              aria-current={item.href === currentHref ? "true" : undefined}
+              onKeyDown={handleKeyDown}
             >
               {item.title}
             </StyledOakLink>

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
@@ -97,7 +97,7 @@ export const OakTertiaryOLNav = ({
   const [currentHref, setCurrentHref] = useState<string | null>(null);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLAnchorElement>) => {
-    if (event.key === "Enter") {
+    if (event.key) {
       setCurrentHref(event.currentTarget.hash);
     }
   };

--- a/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/OakTertiaryOLNav.tsx
@@ -83,6 +83,8 @@ export type OakTertiaryOLNavProps = {
   items: { title: string; href: string }[];
   ariaLabel?: string;
   anchorTarget?: string;
+  currentHref?: string | null;
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 };
 
 export const OakTertiaryOLNav = ({
@@ -90,24 +92,28 @@ export const OakTertiaryOLNav = ({
   ariaLabel,
   title,
   anchorTarget,
+  currentHref,
+  onClick,
   ...rest
 }: OakTertiaryOLNavProps) => {
   return (
-    <StyledNav tabIndex={0} aria-label={ariaLabel} {...rest}>
+    <StyledNav aria-label={ariaLabel} {...rest}>
       {anchorTarget && <OakAnchorTarget id={anchorTarget} />}
       {title && (
         <OakBox $mb={"space-between-m"}>
-          <OakSpan $font={"heading-light-7"}>{"Contents"}</OakSpan>
+          <OakSpan $font={"heading-light-7"}>{title}</OakSpan>
         </OakBox>
       )}
       <StyledOL role="list">
         {items.map((item, index) => (
-          <StyledOLItem
-            aria-label={`list item ${index + 1}`}
-            $font={"heading-7"}
-            key={index}
-          >
-            <StyledOakLink href={item.href}>{item.title}</StyledOakLink>
+          <StyledOLItem $font={"heading-7"} key={index}>
+            <StyledOakLink
+              aria-current={item.href === currentHref ? "true" : undefined}
+              onClick={onClick}
+              href={item.href}
+            >
+              {item.title}
+            </StyledOakLink>
           </StyledOLItem>
         ))}
       </StyledOL>

--- a/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
@@ -153,14 +153,12 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
 <nav
     aria-label="navigation"
     className="c0"
-    tabIndex={0}
   >
     <ol
       className="c1"
       role="list"
     >
       <li
-        aria-label="list item 1"
         className="c2 c3"
       >
         <a
@@ -175,7 +173,6 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
         </a>
       </li>
       <li
-        aria-label="list item 2"
         className="c2 c3"
       >
         <a

--- a/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
@@ -164,6 +164,7 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
         <a
           className="c4 c5"
           href="#item1"
+          onKeyDown={[Function]}
         >
           <span
             className="c6"
@@ -178,6 +179,7 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
         <a
           className="c4 c5"
           href="#item2"
+          onKeyDown={[Function]}
         >
           <span
             className="c6"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

-Removes tap index from nav
-Removes aria-label from li
-Adds "aria-current", "true" to selected link
-Improves docs
-Add tests

## Link to the design doc

## A link to the component in the deployment preview

https://deploy-preview-166--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-teacher-oaktertiaryolnav--docs

## Testing instructions

Check with screen reader, 'current item' should be included on last visited item.
Can not tab to nav
Only one aria label is read out

## ACs
