### PR TITLE
Fix/subject button aria disabled

### DIFF
--- a/src/components/organisms/pupil/OakPupilJourneySubjectButton/OakPupilJourneySubjectButton.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneySubjectButton/OakPupilJourneySubjectButton.tsx
@@ -63,6 +63,7 @@ export const OakPupilJourneySubjectButton = <C extends ElementType = "button">({
       iconName={subjectIconName}
       $minWidth={"all-spacing-12"}
       $minHeight={"all-spacing-12"}
+      aria-hidden="true"
     />
   );
 

--- a/src/components/organisms/pupil/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
@@ -165,6 +165,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
       className="c5 c6"
     >
       <div
+        aria-hidden="true"
         className="c7"
       >
         <img


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Screen readers read the icon name in addition to the inner content of the button. This is rather confusing so I've disabled the aria for the decorative icon . 

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

Go to 

https://deploy-preview-170--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-pupil-oakpupiljourneysubjectbutton--docs

try the screen reader

## ACs

[x] screen reader only reads the subject title
