### PR TITLE
fix: export heading tags as const

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -17,6 +17,13 @@ const config = {
     name: "@storybook/nextjs",
     options: {},
   },
+  // Config from here https://storybook.js.org/docs/configure/typescript#the-types-are-not-being-generated-for-my-component
+  typescript: {
+    reactDocgen: "react-docgen-typescript",
+    // Provide your own options if necessary.
+    // See https://storybook.js.org/docs/configure/typescript for more information.
+    reactDocgenTypescriptOptions: {},
+  },
   docs: {
     autodocs: "tag",
   },

--- a/src/components/atoms/OakAspectRatio/OakAspectRatio.tsx
+++ b/src/components/atoms/OakAspectRatio/OakAspectRatio.tsx
@@ -6,11 +6,11 @@ import {
   responsiveStyle,
 } from "@/styles/utils/responsiveStyle";
 
-const oakAllApectRatios = ["7:8", "2:3", "1:1", "3:2", "16:9"];
-type OakAllApectRatios = (typeof oakAllApectRatios)[number];
+const oakAllApectRatiosConst = ["7:8", "2:3", "1:1", "3:2", "16:9"] as const;
+type OakAllApectRatios = (typeof oakAllApectRatiosConst)[number];
 
-const oakAllApecPercentages = [114, 150, 100, 66.66, 56.25];
-type OakAllApecPercentages = (typeof oakAllApecPercentages)[number];
+const oakAllApecPercentagesConst = [114, 150, 100, 66.66, 56.25] as const;
+type OakAllApecPercentages = (typeof oakAllApecPercentagesConst)[number];
 
 const oakAspectRatioPercentage: Record<
   OakAllApectRatios,

--- a/src/components/atoms/OakHeading/OakHeading.stories.tsx
+++ b/src/components/atoms/OakHeading/OakHeading.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof OakHeading> = {
     ...typographyArgTypes,
     tag: {
       options: oakHeadingTags,
+      control: "select",
     },
   },
   parameters: {

--- a/src/components/atoms/OakHeading/OakHeading.tsx
+++ b/src/components/atoms/OakHeading/OakHeading.tsx
@@ -9,9 +9,19 @@ import {
   typographyStyle,
 } from "@/styles/utils/typographyStyle";
 
-export const oakHeadingTags = ["div", "h1", "h2", "h3", "h4", "h5", "h6"];
+const oakHeadingTagsConst = [
+  "div",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+] as const;
 
-export type OakHeadingTag = (typeof oakHeadingTags)[number];
+export type OakHeadingTag = (typeof oakHeadingTagsConst)[number];
+
+export const oakHeadingTags = [...oakHeadingTagsConst];
 
 type OakHeadingTagProps = {
   children?: React.ReactNode;

--- a/src/styles/theme/color.ts
+++ b/src/styles/theme/color.ts
@@ -75,7 +75,7 @@ export const oakColorFilterTokens = {
 
 export type OakColorFilterToken = keyof typeof oakColorFilterTokens;
 
-export const oakUiRoleTokens = [
+const oakUiRoleTokensConst = [
   "text-primary",
   "text-subdued",
   "text-error",
@@ -143,9 +143,11 @@ export const oakUiRoleTokens = [
   "border-decorative6",
   "border-decorative6-stronger",
   "transparent",
-];
+] as const;
 
-export type OakUiRoleToken = (typeof oakUiRoleTokens)[number];
+export type OakUiRoleToken = (typeof oakUiRoleTokensConst)[number];
+
+export const oakUiRoleTokens = [...oakUiRoleTokensConst];
 
 export type UiRoleMap = Record<
   OakUiRoleToken,

--- a/src/styles/theme/typography.ts
+++ b/src/styles/theme/typography.ts
@@ -12,11 +12,11 @@ export const oakFontSizeTokens = {
 };
 export type OakFontSizeToken = keyof typeof oakFontSizeTokens;
 
-const fontWeights = [300, 400, 600, 700];
+const fontWeights = [300, 400, 600, 700] as const;
 type FontWeight = (typeof fontWeights)[number];
-const lineHeights = [16, 20, 24, 28, 32, 40, 48, 56, 64];
+const lineHeights = [16, 20, 24, 28, 32, 40, 48, 56, 64] as const;
 type LineHeight = (typeof lineHeights)[number];
-const letterSpacings = ["0.0115rem", "-0.005rem"];
+const letterSpacings = ["0.0115rem", "-0.005rem"] as const;
 type LetterSpacing = (typeof letterSpacings)[number];
 
 type FontParameters = readonly [
@@ -54,27 +54,37 @@ export const oakFontTokens = {
 
 export type OakFontToken = keyof typeof oakFontTokens;
 
-export const oakTextDecorations = [
+const oakTextDecorationsConst = [
   "underline",
   "overline",
   "line-through",
   "none",
-];
+] as const;
 
-export const oakWhiteSpaces = [
+const oakWhiteSpacesConst = [
   "normal",
   "nowrap",
   "pre",
   "pre-wrap",
   "pre-line",
   "break-spaces",
-];
+] as const;
 
-export const oakWordWraps = ["normal", "break-word", "initial", "inherit"];
+const oakWordWrapsConst = [
+  "normal",
+  "break-word",
+  "initial",
+  "inherit",
+] as const;
 
-export const oakTextOverflows = ["clip", "ellipsis"];
+const oakTextOverflowsConst = ["clip", "ellipsis"] as const;
 
-export type OakTextDecoration = (typeof oakTextDecorations)[number];
-export type OakWhiteSpace = (typeof oakWhiteSpaces)[number];
-export type OakWordWrap = (typeof oakWordWraps)[number];
-export type OakTextOverflow = (typeof oakTextOverflows)[number];
+export type OakTextDecoration = (typeof oakTextDecorationsConst)[number];
+export type OakWhiteSpace = (typeof oakWhiteSpacesConst)[number];
+export type OakWordWrap = (typeof oakWordWrapsConst)[number];
+export type OakTextOverflow = (typeof oakTextOverflowsConst)[number];
+
+export const oakTextDecorations = [...oakTextDecorationsConst];
+export const oakWhiteSpaces = [...oakWhiteSpacesConst];
+export const oakWordWraps = [...oakWordWrapsConst];
+export const oakTextOverflows = [...oakTextOverflowsConst];


### PR DESCRIPTION
# How to review this PR

Heading tag type used in OWA was degraded to string in the storybook upgrade, so this reinstates it as literal union. Ran check-types in OWA locally and not seeing any other issues. Had to defined the story control as select explicitly otherwise it infers text input type.

## A link to the component in the deployment preview
https://deploy-preview-174--lively-meringue-8ebd43.netlify.app/
