### PR TITLE
Fix: Header alt text and spacing

### DIFF
--- a/src/components/organisms/OakHeaderHero/OakHeaderHero.stories.tsx
+++ b/src/components/organisms/OakHeaderHero/OakHeaderHero.stories.tsx
@@ -15,6 +15,7 @@ const meta: Meta<typeof OakHeaderHero> = {
     authorTitle: { type: "string" },
     heroImageSrc: { type: "string" },
     heroImageAlt: { type: "string" },
+    authorImageSrc: { type: "string" },
     imageSrc: { type: "string" },
     imageAlt: { type: "string" },
     subHeadingText: { type: "string" },
@@ -41,6 +42,8 @@ const meta: Meta<typeof OakHeaderHero> = {
         <OakLink href="/lessons">Lessons</OakLink>
       </>
     ),
+    heroImageAlt: "Hero image",
+    authorImageAlt: "Author image",
     blogProfileAuthor: "Rachel Storm",
     authorTitle: "Head of School Support",
     authorName: "Rachel Storm",

--- a/src/components/organisms/OakHeaderHero/OakHeaderHero.test.tsx
+++ b/src/components/organisms/OakHeaderHero/OakHeaderHero.test.tsx
@@ -12,8 +12,10 @@ import { oakDefaultTheme } from "@/styles";
 const oakHeaderProps: OakHeaderHeroProps = {
   headingTitle: "How to plan a lesson: a helpful guide for teachers",
   authorTitle: "Head of School Support",
+  heroImageAlt: "Hero image",
   authorName: "Rachel Storm",
   authorImageSrc: "https://via.placeholder.com/150",
+  authorImageAlt: "Author image",
   breadcrumbs: <OakLink href="/home">Home</OakLink>,
   subHeadingText:
     "Body 1 Our guide for teachers, whether you're in your ITT, an ECT or a teacher of many years experience looking for a fresh look on lesson planning, is place to dive into expertise from across the sector.",

--- a/src/components/organisms/OakHeaderHero/OakHeaderHero.tsx
+++ b/src/components/organisms/OakHeaderHero/OakHeaderHero.tsx
@@ -18,6 +18,8 @@ export type OakHeaderHeroProps = {
   authorName: string;
   authorTitle: string;
   subHeadingText: string;
+  heroImageAlt: string;
+  authorImageAlt: string;
   breadcrumbs: ReactElement;
   children?: ReactNode;
 };
@@ -42,6 +44,8 @@ const UnstyledComponent = (props: OakHeaderHeroProps) => {
     subHeadingText,
     heroImageSrc,
     authorImageSrc,
+    heroImageAlt,
+    authorImageAlt,
   } = props;
   return (
     <OakBox
@@ -62,7 +66,7 @@ const UnstyledComponent = (props: OakHeaderHeroProps) => {
         >
           <OakFlex
             $alignSelf={"flex-start"}
-            $ph={"inner-padding-m"}
+            $ph={"inner-padding-s"}
             $height={"100%"}
             $flexDirection={"column"}
           >
@@ -97,7 +101,7 @@ const UnstyledComponent = (props: OakHeaderHeroProps) => {
                 $alignItems={"center"}
               >
                 <StyledAutorImage
-                  alt={`${authorName} profile image`}
+                  alt={authorImageAlt}
                   src={authorImageSrc}
                   $zIndex={"in-front"}
                 />
@@ -138,7 +142,7 @@ const UnstyledComponent = (props: OakHeaderHeroProps) => {
                 "all-spacing-20",
               ]}
               $minWidth={["all-spacing-19", "all-spacing-22", "all-spacing-21"]}
-              alt={`${headingTitle} hero image`}
+              alt={heroImageAlt}
               $zIndex={"in-front"}
             />
             <OakFlex

--- a/src/components/organisms/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
+++ b/src/components/organisms/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
@@ -561,7 +561,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
               className="c15 c16"
             >
               <img
-                alt="Rachel Storm profile image"
+                alt="Author image"
                 className="c17"
                 data-nimg="fill"
                 decoding="async"

--- a/src/components/organisms/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
+++ b/src/components/organisms/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
@@ -28,8 +28,8 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 
 .c5 {
   height: 100%;
-  padding-left: 1rem;
-  padding-right: 1rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -616,7 +616,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
           className="c24"
         >
           <img
-            alt="How to plan a lesson: a helpful guide for teachers hero image"
+            alt="Hero image"
             className="c17"
             data-nimg="fill"
             decoding="async"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- Adds alt text prop for header images
- Fixes spacing of header on small screens