### PR TITLE
Fix/pupil 700/list aria roles

### DIFF
--- a/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.tsx
@@ -34,7 +34,6 @@ export const OakPupilJourneyList = ({
       $flexDirection={"column"}
       $width={["100%", "all-spacing-22", "all-spacing-23"]}
       $background={outerBackgroundColor}
-      role="list"
     >
       {titleSlot && (
         <OakFlex
@@ -53,6 +52,7 @@ export const OakPupilJourneyList = ({
         $borderRadius={"border-radius-l"}
         $gap={"space-between-s"}
         $background={backgroundColor}
+        role="list"
       >
         {children}
       </OakFlex>

--- a/src/components/organisms/pupil/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
@@ -62,7 +62,6 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
 
 <div
   className="c0 c1"
-  role="list"
 >
   <div
     className="c2 c3"
@@ -73,6 +72,7 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
   </div>
   <div
     className="c4 c5"
+    role="list"
   >
     <p>
       Hello World

--- a/src/components/organisms/pupil/OakPupilJourneyListItem/OakPupilJourneyListItem.stories.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyListItem/OakPupilJourneyListItem.stories.tsx
@@ -29,6 +29,7 @@ const meta: Meta<typeof OakPupilJourneyListItem> = {
           $gap="space-between-m"
           $background={"bg-decorative4-main"}
           $pa={"inner-padding-xl"}
+          role="list"
         >
           {Story()}
         </OakFlex>

--- a/src/components/organisms/pupil/OakPupilJourneyListItem/OakPupilJourneyListItem.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyListItem/OakPupilJourneyListItem.tsx
@@ -117,74 +117,76 @@ export const OakPupilJourneyListItem = <C extends ElementType = "a">(
 
   const disabledOrUnavailable = disabled || unavailable;
   return (
-    <StyledPupilJourneyItem
-      as={disabledOrUnavailable ? "div" : as ?? "a"}
-      $gap={["space-between-s", "space-between-m2"]}
-      $alignItems="center"
-      $justifyContent={"space-between"}
-      $flexWrap={"wrap"}
-      $background={unavailable ? "bg-neutral" : "bg-primary"}
-      $pa={["inner-padding-l", "inner-padding-xl"]}
-      $borderRadius="border-radius-m"
-      $ba={unavailable ? "border-solid-m" : "border-solid-none"}
-      $borderColor={unavailable ? "border-neutral-lighter" : "transparent"}
-      $disabled={disabledOrUnavailable}
-      $color="text-primary"
-      href={disabledOrUnavailable ? undefined : href}
-      onClick={disabledOrUnavailable ? undefined : onClick}
-      {...rest}
-    >
-      <OakFlex $alignItems={"center"} $gap={["space-between-m2"]}>
-        {" "}
-        <OakFlex>
-          <OakBox
-            $font={["heading-5", "heading-4"]}
-            $color={props.unavailable ? "text-subdued" : "text-primary"}
-            $textDecoration={"none"}
-          >
-            {props.index}
-          </OakBox>
-        </OakFlex>
-        <FlexedOakBox>
-          <StyledLabel
-            $font={["heading-6", "heading-5"]}
-            $color={disabledOrUnavailable ? "text-subdued" : "text-primary"}
-          >
-            {props.title}
-          </StyledLabel>
-        </FlexedOakBox>
-      </OakFlex>
-
-      <OakFlex
-        $alignItems={"center"}
-        $gap={"space-between-xs"}
-        $flexBasis={"auto"}
-        $flexGrow={1}
-        $justifyContent={"flex-end"}
+    <OakBox role="listitem">
+      <StyledPupilJourneyItem
+        as={disabledOrUnavailable ? "div" : as ?? "a"}
+        $gap={["space-between-s", "space-between-m2"]}
+        $alignItems="center"
+        $justifyContent={"space-between"}
+        $flexWrap={"wrap"}
+        $background={unavailable ? "bg-neutral" : "bg-primary"}
+        $pa={["inner-padding-l", "inner-padding-xl"]}
+        $borderRadius="border-radius-m"
+        $ba={unavailable ? "border-solid-m" : "border-solid-none"}
+        $borderColor={unavailable ? "border-neutral-lighter" : "transparent"}
+        $disabled={disabledOrUnavailable}
+        $color="text-primary"
+        href={disabledOrUnavailable ? undefined : href}
+        onClick={disabledOrUnavailable ? undefined : onClick}
+        {...rest}
       >
-        {props.numberOfLessons && !props.unavailable && (
-          <StyledLabel
-            $font={"heading-7"}
-            $color={disabledOrUnavailable ? "text-subdued" : "text-primary"}
-          >
-            {props.numberOfLessons} lessons
-          </StyledLabel>
-        )}
-        {props.unavailable && (
-          <StyledLabel
-            $font={"heading-7"}
-            $color={disabledOrUnavailable ? "text-subdued" : "text-primary"}
-          >
-            Unavailable
-          </StyledLabel>
-        )}
-        {!props.unavailable && (
-          <StyledRoundIcon
-            iconName="chevron-right"
-            $disabled={disabledOrUnavailable}
-          />
-        )}
-      </OakFlex>
-    </StyledPupilJourneyItem>
+        <OakFlex $alignItems={"center"} $gap={["space-between-m2"]}>
+          {" "}
+          <OakFlex>
+            <OakBox
+              $font={["heading-5", "heading-4"]}
+              $color={props.unavailable ? "text-subdued" : "text-primary"}
+              $textDecoration={"none"}
+            >
+              {props.index}
+            </OakBox>
+          </OakFlex>
+          <FlexedOakBox>
+            <StyledLabel
+              $font={["heading-6", "heading-5"]}
+              $color={disabledOrUnavailable ? "text-subdued" : "text-primary"}
+            >
+              {props.title}
+            </StyledLabel>
+          </FlexedOakBox>
+        </OakFlex>
+
+        <OakFlex
+          $alignItems={"center"}
+          $gap={"space-between-xs"}
+          $flexBasis={"auto"}
+          $flexGrow={1}
+          $justifyContent={"flex-end"}
+        >
+          {props.numberOfLessons && !props.unavailable && (
+            <StyledLabel
+              $font={"heading-7"}
+              $color={disabledOrUnavailable ? "text-subdued" : "text-primary"}
+            >
+              {props.numberOfLessons} lessons
+            </StyledLabel>
+          )}
+          {props.unavailable && (
+            <StyledLabel
+              $font={"heading-7"}
+              $color={disabledOrUnavailable ? "text-subdued" : "text-primary"}
+            >
+              Unavailable
+            </StyledLabel>
+          )}
+          {!props.unavailable && (
+            <StyledRoundIcon
+              iconName="chevron-right"
+              $disabled={disabledOrUnavailable}
+            />
+          )}
+        </OakFlex>
+      </StyledPupilJourneyItem>
+    </OakBox>
   );
 };

--- a/src/components/organisms/pupil/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
@@ -3,16 +3,16 @@
 exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 [
   .c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
   padding: 1.25rem;
   color: #222222;
   background: #ffffff;
   border: 0rem solid;
   border-color: transparent;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
-}
-
-.c3 {
   font-family: Lexend,sans-serif;
 }
 
@@ -60,7 +60,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -137,29 +137,29 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c2 {
+.c3 {
   outline: none;
   text-align: initial;
   cursor: pointer;
 }
 
-.c2:focus-visible {
+.c3:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c2:active {
+.c3:active {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c2:active .c11 {
+.c3:active .c11 {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c2:active .c11 {
+.c3:active .c11 {
   background: #222222;
 }
 
-.c2:active .c11 img {
+.c3:active .c11 img {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
 }
@@ -171,7 +171,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c1 {
     padding: 1.5rem;
   }
 }
@@ -231,90 +231,95 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c2 {
     gap: 2rem;
   }
 }
 
 @media (hover:hover) {
-  .c2:hover {
+  .c3:hover {
     background: #dff9de;
   }
 
-  .c2:hover .c11 {
+  .c3:hover .c11 {
     background: #222222;
   }
 
-  .c2:hover .c11 img {
+  .c3:hover .c11 img {
     -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
     filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   }
 }
 
-<a
-    className="c0 c1 c2"
-    title="Lesson 1"
+<div
+    className="c0"
+    role="listitem"
   >
-    <div
-      className="c3 c4"
+    <a
+      className="c1 c2 c3"
+      title="Lesson 1"
     >
-       
       <div
-        className="c3 c5"
+        className="c0 c4"
       >
+         
         <div
-          className="c6"
+          className="c0 c5"
         >
-          1
+          <div
+            className="c6"
+          >
+            1
+          </div>
+        </div>
+        <div
+          className="c0 c7"
+        >
+          <div
+            className="c8"
+          >
+            Lesson 1
+          </div>
         </div>
       </div>
       <div
-        className="c3 c7"
+        className="c0 c9"
       >
         <div
-          className="c8"
+          className="c10 c11 c12"
         >
-          Lesson 1
-        </div>
-      </div>
-    </div>
-    <div
-      className="c3 c9"
-    >
-      <div
-        className="c10 c11 c12"
-      >
-        <div
-          className="c13"
-        >
-          <img
-            alt="chevron-right"
-            className="c14"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            onError={[Function]}
-            onLoad={[Function]}
-            src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
-            style={
-              {
-                "bottom": 0,
-                "color": "transparent",
-                "height": "100%",
-                "left": 0,
-                "objectFit": undefined,
-                "objectPosition": undefined,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "width": "100%",
+          <div
+            className="c13"
+          >
+            <img
+              alt="chevron-right"
+              className="c14"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+              style={
+                {
+                  "bottom": 0,
+                  "color": "transparent",
+                  "height": "100%",
+                  "left": 0,
+                  "objectFit": undefined,
+                  "objectPosition": undefined,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
               }
-            }
-          />
+            />
+          </div>
         </div>
       </div>
-    </div>
-  </a>,
+    </a>
+  </div>,
   ",",
 ]
 `;


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Give pupilJourneyLists & pupilJourneyListItems an appropriate aria role so that users of screen readers know that the items are a list

## Link to the design doc

## A link to the component in the deployment preview

[component](https://deploy-preview-187--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-pupil-oakpupiljourneylist--docs)
## Testing instructions

go to storybook, observe the accessibility violations are zero for both components

## ACs
- [x]  correct roles applied
- [x]  works correctly with the screen reader
