### PR TITLE
Fix/pupil 701/tooltip aria labels

### DIFF
--- a/src/components/atoms/InternalTooltip/InternalTooltip.tsx
+++ b/src/components/atoms/InternalTooltip/InternalTooltip.tsx
@@ -12,6 +12,7 @@ import { parseSpacing } from "@/styles/helpers/parseSpacing";
 export type InternalTooltipProps = OakFlexProps & {
   children?: ReactNode;
   tooltipPosition?: "bottom-left" | "bottom-right" | "top-left" | "top-right";
+  id?: string;
 };
 
 const StyledFlex = styled(OakFlex)`
@@ -70,11 +71,13 @@ export const InternalTooltip = ({
   $background = "black",
   $color = "text-inverted",
   tooltipPosition = "bottom-left",
+  id,
   ...props
 }: InternalTooltipProps) => {
   return (
     <StyledFlex
       role="tooltip"
+      id={id}
       {...props}
       $position="relative"
       $background={$background}

--- a/src/components/molecules/OakTooltip/OakTooltip.test.tsx
+++ b/src/components/molecules/OakTooltip/OakTooltip.test.tsx
@@ -26,7 +26,7 @@ describe(OakTooltip, () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <OakTooltip tooltip="Hello there" isOpen>
+        <OakTooltip tooltip="Hello there" isOpen id="tooltip">
           <div>Trigger!</div>
         </OakTooltip>
       </OakThemeProvider>,
@@ -37,7 +37,7 @@ describe(OakTooltip, () => {
 
   it("renders", () => {
     const { getByRole } = renderWithTheme(
-      <OakTooltip tooltip="Hello there" isOpen>
+      <OakTooltip tooltip="Hello there" isOpen id="tooltip">
         <div>Trigger!</div>
       </OakTooltip>,
     );

--- a/src/components/molecules/OakTooltip/OakTooltip.tsx
+++ b/src/components/molecules/OakTooltip/OakTooltip.tsx
@@ -32,6 +32,7 @@ export type OakTooltipProps = Pick<InternalTooltipProps, "tooltipPosition"> & {
    * @default document.body
    */
   domContainer?: Element;
+  id: string;
 };
 
 /**
@@ -43,6 +44,7 @@ export const OakTooltip = ({
   tooltip,
   isOpen,
   domContainer,
+  id,
   ...props
 }: OakTooltipProps) => {
   const [targetElement, setTargetElement] = useState<Element | null>(null);
@@ -159,6 +161,8 @@ export const OakTooltip = ({
                   tooltipPosition={tooltipPosition}
                   {...props}
                   {...borderRadiusProps}
+                  aria-expanded={isVisible}
+                  id={id}
                 >
                   {tooltip}
                 </InternalTooltip>

--- a/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
+++ b/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
@@ -83,7 +83,9 @@ exports[`OakTooltip matches snapshot 1`] = `
       className="c1"
     >
       <div
+        aria-expanded={true}
         className="c2 c3 c4"
+        id="tooltip"
         role="tooltip"
       >
         Hello there

--- a/src/components/organisms/pupil/OakHintButton/OakHintButton.tsx
+++ b/src/components/organisms/pupil/OakHintButton/OakHintButton.tsx
@@ -51,6 +51,7 @@ export const OakHintButton = (props: OakHintButtonProps) => {
       disabled={props.disabled}
       iconBackgroundSize={"all-spacing-8"}
       iconSize={"all-spacing-6"}
+      aria-controls="info-tooltip"
     >
       {!isOpen ? "Need a hint?" : "Close hint"}
     </StyledInternalShadowRoundButton>

--- a/src/components/organisms/pupil/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/organisms/pupil/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -172,6 +172,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   className="c0 c1 c2 c3"
 >
   <button
+    aria-controls="info-tooltip"
     className="c4 c5"
     onClick={[Function]}
     onMouseEnter={[Function]}

--- a/src/components/organisms/pupil/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/organisms/pupil/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -267,6 +267,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
           className="c5 c6 c7 c8"
         >
           <button
+            aria-controls="info-tooltip"
             className="c9 c10"
             onClick={[Function]}
             onMouseEnter={[Function]}

--- a/src/components/organisms/pupil/OakQuizHint/OakQuizHint.tsx
+++ b/src/components/organisms/pupil/OakQuizHint/OakQuizHint.tsx
@@ -20,7 +20,7 @@ export const OakQuizHint = ({ hint }: OakQuizHintProps) => {
   };
 
   return (
-    <OakTooltip tooltip={hint} isOpen={isOpen}>
+    <OakTooltip tooltip={hint} isOpen={isOpen} id="hint-tooltip">
       <OakHintButton isOpen={isOpen} onClick={handleClick} />
     </OakTooltip>
   );

--- a/src/components/organisms/pupil/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/organisms/pupil/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -180,6 +180,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
       className="c0 c1 c2 c3"
     >
       <button
+        aria-controls="info-tooltip"
         className="c4 c5"
         onClick={[Function]}
         onMouseEnter={[Function]}

--- a/src/components/organisms/pupil/Oakinfo/OakInfo.tsx
+++ b/src/components/organisms/pupil/Oakinfo/OakInfo.tsx
@@ -11,7 +11,7 @@ export type OakInfoProps = {
   hint: ReactNode;
   isLoading?: boolean;
   disabled?: boolean;
-} & Omit<OakTooltipProps, "children" | "tooltip">;
+} & Omit<OakTooltipProps, "children" | "tooltip" | "id">;
 
 /**
  * Presents a button which will show a hint when clicked
@@ -24,7 +24,12 @@ export const OakInfo = (props: OakInfoProps) => {
   };
 
   return (
-    <OakTooltip tooltip={props.hint} isOpen={isOpen} {...tooltipProps}>
+    <OakTooltip
+      tooltip={props.hint}
+      isOpen={isOpen}
+      id={"info-tooltip"}
+      {...tooltipProps}
+    >
       <OakInfoButton onClick={handleClick} isOpen={isOpen} />
     </OakTooltip>
   );

--- a/src/components/organisms/pupil/Oakinfo/OakInfo.tsx
+++ b/src/components/organisms/pupil/Oakinfo/OakInfo.tsx
@@ -3,6 +3,7 @@ import React, { MouseEventHandler, ReactNode, useState } from "react";
 import { OakInfoButton } from "../OakinfoButton";
 
 import { OakTooltip, OakTooltipProps } from "@/components/molecules";
+import { OakScreenReader } from "@/components/atoms/OakScreenReader";
 
 export type OakInfoProps = {
   /**
@@ -30,7 +31,10 @@ export const OakInfo = (props: OakInfoProps) => {
       id={"info-tooltip"}
       {...tooltipProps}
     >
-      <OakInfoButton onClick={handleClick} isOpen={isOpen} />
+      <>
+        <OakInfoButton onClick={handleClick} isOpen={isOpen} />
+        <OakScreenReader>{props.hint}</OakScreenReader>
+      </>
     </OakTooltip>
   );
 };

--- a/src/components/organisms/pupil/Oakinfo/__snapshots__/OakInfo.test.tsx.snap
+++ b/src/components/organisms/pupil/Oakinfo/__snapshots__/OakInfo.test.tsx.snap
@@ -120,6 +120,19 @@ exports[`OakInfo matches snapshot 1`] = `
   cursor: default;
 }
 
+.c14 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .c5 {
   display: inline-block;
   position: relative;
@@ -233,6 +246,11 @@ exports[`OakInfo matches snapshot 1`] = `
         </div>
       </button>
     </div>
+    <span
+      className="c14"
+    >
+      The answer is right in front of your eyes
+    </span>
   </div>,
   ",",
 ]

--- a/src/components/organisms/pupil/Oakinfo/__snapshots__/OakInfo.test.tsx.snap
+++ b/src/components/organisms/pupil/Oakinfo/__snapshots__/OakInfo.test.tsx.snap
@@ -182,6 +182,7 @@ exports[`OakInfo matches snapshot 1`] = `
       className="c0 c1 c2 c3"
     >
       <button
+        aria-controls="info-tooltip"
         className="c4 c5"
         onClick={[Function]}
         onMouseEnter={[Function]}

--- a/src/components/organisms/pupil/OakinfoButton/OakInfoButton.tsx
+++ b/src/components/organisms/pupil/OakinfoButton/OakInfoButton.tsx
@@ -46,6 +46,7 @@ export const OakInfoButton = (props: OakInfoButtonProps) => {
       iconBackgroundSize={"all-spacing-8"}
       iconSize={"all-spacing-7"}
       onClick={onClick}
+      aria-controls="info-tooltip"
     />
   );
 };

--- a/src/components/organisms/pupil/OakinfoButton/__snapshots__/OakInfoButton.test.tsx.snap
+++ b/src/components/organisms/pupil/OakinfoButton/__snapshots__/OakInfoButton.test.tsx.snap
@@ -175,6 +175,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
     className="c0 c1 c2 c3"
   >
     <button
+      aria-controls="info-tooltip"
       className="c4 c5"
       disabled={false}
       onClick={[Function]}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

When a user opens a tool tip element
I want an aria exapanded attribute to toggle true
So that users with screen readers are aware that the item has successfully been toggled

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

look at the oakinfo [component](https://deploy-preview-188--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-pupil-oakinfo--docs) and
test that the tooltip can be picked up by screen reader 

## ACs

- [ ]  Ensure screen reader can pick up text in info component
- [ ]  When expanded user can navigate to info component using keyboard