### PR TITLE
fix: updated types on OakPupilJourneyContentGuidance

### DIFF
--- a/src/components/organisms/pupil/OakPupilJourneyContentGuidance/OakPupilJourneyContentGuidance.test.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyContentGuidance/OakPupilJourneyContentGuidance.test.tsx
@@ -42,10 +42,10 @@ describe("OakPupilJourneyContentGuidance", () => {
     );
 
     expect(
-      getByText(contentGuidanceDescimination.contentguidanceLabel),
+      getByText(contentGuidanceDescimination.contentguidanceLabel as string),
     ).toBeInTheDocument();
     expect(
-      getByText(contentGuidanceUpsetting.contentguidanceLabel),
+      getByText(contentGuidanceUpsetting.contentguidanceLabel as string),
     ).toBeInTheDocument();
   });
 

--- a/src/components/organisms/pupil/OakPupilJourneyContentGuidance/OakPupilJourneyContentGuidance.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyContentGuidance/OakPupilJourneyContentGuidance.tsx
@@ -9,9 +9,9 @@ import {
 import { OakFlex, OakHeading } from "@/components/atoms";
 
 export type OakPupilContentGuidance = {
-  contentguidanceLabel: string;
-  contentguidanceDescription: string;
-  contentguidanceArea: string;
+  contentguidanceLabel: string | null;
+  contentguidanceDescription: string | null;
+  contentguidanceArea: string | null;
 };
 
 export type OakPupilJourneyContentGuidanceProps = {
@@ -30,15 +30,15 @@ export type OakPupilJourneyContentGuidanceProps = {
   /**
    * An array of objects containing the content guidance label, description and area
    */
-  contentGuidance?: OakPupilContentGuidance[] | undefined;
+  contentGuidance?: OakPupilContentGuidance[] | null;
   /**
    * The level of supervision required for the content
    */
-  supervisionLevel?: string | null | undefined;
+  supervisionLevel?: string | null;
 };
 
 export const removedGuidanceDuplicates = (
-  contentGuidance: OakPupilContentGuidance[] | undefined = [],
+  contentGuidance: OakPupilContentGuidance[] | null = [],
 ) => {
   return Array.from(
     new Set(
@@ -107,7 +107,7 @@ export const OakPupilJourneyContentGuidance = ({
       >
         <OakFlex $flexDirection="column" $rowGap="space-between-m2">
           {removedGuidanceDuplicates(contentGuidance).map(
-            (guidance: string, index: number) => (
+            (guidance, index: number) => (
               <OakHeading
                 key={index}
                 $font={[


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Types didn't quite match the content guidance field on the lesson in OWA.

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
