### PR TITLE
fix: remove styled prop and change to styled component

### DIFF
--- a/src/components/molecules/OakModalCenter/OakModalCenter.tsx
+++ b/src/components/molecules/OakModalCenter/OakModalCenter.tsx
@@ -64,6 +64,10 @@ const FocusOnBox = styled(FocusOn)`
   ${oakBoxCss}
 `;
 
+const BlurredOakBox = styled(OakBox)`
+  backdrop-filter: blur(3px);
+`;
+
 const FadeInFlex = styled(OakFlex)<{ $state: TransitionStatus }>`
   opacity: ${({ $state }) => {
     switch ($state) {
@@ -167,15 +171,11 @@ export const OakModalCenter = ({
           $alignItems="center"
           $zIndex="modal-dialog"
         >
-          <OakBox
+          <BlurredOakBox
             $position="fixed"
             $inset="all-spacing-0"
             $zIndex="behind"
             $background="blackSemiTransparent"
-            style={{
-              backdropFilter: `blur(3px)`,
-              WebkitBackdropFilter: `blur(3px)`,
-            }}
             data-testid="backdrop"
             {...backdropFlexProps}
           />

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
@@ -16,14 +16,14 @@ exports[`OakModalCenter matches snapshot 1`] = `
   z-index: -1;
 }
 
-.c4 {
+.c5 {
   width: 100%;
   max-width: 60rem;
   padding: 1.25rem;
   font-family: Lexend,sans-serif;
 }
 
-.c6 {
+.c7 {
   position: relative;
   width: 100%;
   background: #ffffff;
@@ -33,20 +33,20 @@ exports[`OakModalCenter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c8 {
+.c9 {
   position: relative;
   min-height: 3.5rem;
   font-family: Lexend,sans-serif;
 }
 
-.c9 {
+.c10 {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
   font-family: Lexend,sans-serif;
 }
 
-.c10 {
+.c11 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -54,11 +54,11 @@ exports[`OakModalCenter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c15 {
+.c16 {
   font-family: Lexend,sans-serif;
 }
 
-.c17 {
+.c18 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -69,7 +69,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c18 {
+.c19 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -78,7 +78,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c19 {
+.c20 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -87,7 +87,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c22 {
+.c23 {
   overflow: auto;
   padding-left: 3.5rem;
   padding-right: 3.5rem;
@@ -112,7 +112,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -122,14 +122,14 @@ exports[`OakModalCenter matches snapshot 1`] = `
   flex-direction: column;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c16 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -148,7 +148,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   gap: 0rem;
 }
 
-.c21 {
+.c22 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -159,13 +159,13 @@ exports[`OakModalCenter matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c20 {
+.c21 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c13 {
+.c14 {
   background: none;
   color: inherit;
   border: none;
@@ -179,62 +179,67 @@ exports[`OakModalCenter matches snapshot 1`] = `
   color: transparent;
 }
 
-.c13:disabled {
+.c14:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c14 {
+.c15 {
   display: inline-block;
   position: relative;
 }
 
-.c14:hover {
+.c15:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: transparent;
 }
 
-.c14:hover:not(:active) [data-icon-for="button"] img {
+.c15:hover:not(:active) [data-icon-for="button"] img {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
 }
 
-.c14:active {
+.c15:active {
   color: transparent;
 }
 
-.c14:disabled {
+.c15:disabled {
   color: transparent;
 }
 
-.c12 > :first-child:focus-visible .shadow {
+.c13 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c12 > :first-child:hover .shadow {
+.c13 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c12 > :first-child:active .shadow {
+.c13 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c12 > :first-child:disabled .icon-container {
+.c13 > :first-child:disabled .icon-container {
   background: transparent;
 }
 
-.c12 > :first-child:hover .icon-container {
+.c13 > :first-child:hover .icon-container {
   background: #222222;
 }
 
-.c12 > :first-child:active .icon-container {
+.c13 > :first-child:active .icon-container {
   background: transparent;
 }
 
-.c5 {
+.c6 {
   width: 100%;
   font-family: Lexend,sans-serif;
+}
+
+.c4 {
+  -webkit-backdrop-filter: blur(3px);
+  backdrop-filter: blur(3px);
 }
 
 .c2 {
@@ -247,17 +252,11 @@ exports[`OakModalCenter matches snapshot 1`] = `
   className="c0 c1 c2"
 >
   <div
-    className="c3"
+    className="c3 c4"
     data-testid="backdrop"
-    style={
-      {
-        "WebkitBackdropFilter": "blur(3px)",
-        "backdropFilter": "blur(3px)",
-      }
-    }
   />
   <div
-    className="c4 c1"
+    className="c5 c1"
   >
     <div
       data-focus-guard={true}
@@ -275,7 +274,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
       tabIndex={-1}
     />
     <div
-      className="c5"
+      className="c6"
       data-focus-lock-disabled="disabled"
       onBlur={[Function]}
       onFocus={[Function]}
@@ -284,7 +283,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
       onWheelCapture={[Function]}
     >
       <div
-        className="c6 c7"
+        className="c7 c8"
         role="alertdialog"
         style={
           {
@@ -293,38 +292,38 @@ exports[`OakModalCenter matches snapshot 1`] = `
         }
       >
         <div
-          className="c8"
+          className="c9"
         >
           <div
-            className="c9"
+            className="c10"
           >
             <div
-              className="c10 c11 c12"
+              className="c11 c12 c13"
             >
               <button
                 aria-label="Close Modal"
-                className="c13 c14"
+                className="c14 c15"
                 data-testid="close-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
               >
                 <div
-                  className="c15 c16"
+                  className="c16 c17"
                 >
                   <div
-                    className="c17 c1 icon-container"
+                    className="c18 c1 icon-container"
                   >
                     <div
-                      className="c18 shadow"
+                      className="c19 shadow"
                     />
                     <div
-                      className="c19"
+                      className="c20"
                       data-icon-for="button"
                     >
                       <img
                         alt="cross"
-                        className="c20"
+                        className="c21"
                         data-nimg="fill"
                         decoding="async"
                         loading="lazy"
@@ -349,7 +348,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
                     </div>
                   </div>
                   <span
-                    className="c21"
+                    className="c22"
                   />
                 </div>
               </button>
@@ -365,7 +364,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
           }
         >
           <div
-            className="c22 c7"
+            className="c23 c8"
             data-testid="modal-main-content"
           >
             Modal content


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Remove styled prop and change to styled component

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
