### PR TITLE
fix: set cookie consent banner to 9999 z-index if fixed

### DIFF
--- a/src/components/organisms/OakCookieBanner/OakCookieBanner.tsx
+++ b/src/components/organisms/OakCookieBanner/OakCookieBanner.tsx
@@ -69,7 +69,7 @@ export const OakCookieBanner = ({
       $bottom={isFixed ? "all-spacing-0" : undefined}
       $right={isFixed ? "all-spacing-0" : undefined}
       $left={isFixed ? "all-spacing-0" : undefined}
-      $zIndex={isFixed ? "in-front" : undefined}
+      $zIndex={isFixed ? "always-on-top" : undefined}
       $color="text-primary"
       data-testid="cookie-banner"
     >

--- a/src/components/organisms/OakCookieBanner/OakCookieBanner.tsx
+++ b/src/components/organisms/OakCookieBanner/OakCookieBanner.tsx
@@ -46,6 +46,10 @@ export type OakCookieBannerProps = {
    * @default false
    */
   isFixed?: boolean;
+  /**
+   * Optional z-index override of the banner.
+   */
+  zIndex?: number;
 };
 
 /**
@@ -59,6 +63,7 @@ export const OakCookieBanner = ({
   onAccept,
   onReject,
   isFixed = false,
+  zIndex,
 }: OakCookieBannerProps) => {
   return (
     <OakBox
@@ -69,7 +74,7 @@ export const OakCookieBanner = ({
       $bottom={isFixed ? "all-spacing-0" : undefined}
       $right={isFixed ? "all-spacing-0" : undefined}
       $left={isFixed ? "all-spacing-0" : undefined}
-      $zIndex={isFixed ? "always-on-top" : undefined}
+      $zIndex={zIndex ? zIndex : isFixed ? "always-on-top" : undefined}
       $color="text-primary"
       data-testid="cookie-banner"
     >

--- a/src/components/organisms/OakCookieConsent/OakCookieConsent.tsx
+++ b/src/components/organisms/OakCookieConsent/OakCookieConsent.tsx
@@ -11,7 +11,7 @@ export type OakCookieConsentProps = Pick<
   OakCookieSettingsModalProps,
   "policyURL"
 > &
-  Pick<OakCookieBannerProps, "isFixed" | "innerMaxWidth">;
+  Pick<OakCookieBannerProps, "isFixed" | "innerMaxWidth" | "zIndex">;
 
 /**
  * Connects `OakCookieBanner` and `OakCookieSettingsModal` to `OakCookieConsentProvider`.
@@ -20,6 +20,7 @@ export const OakCookieConsent = ({
   policyURL,
   isFixed,
   innerMaxWidth,
+  zIndex,
 }: OakCookieConsentProps) => {
   const {
     policies,
@@ -46,6 +47,7 @@ export const OakCookieConsent = ({
           state={bannerState}
           isFixed={isFixed}
           innerMaxWidth={innerMaxWidth}
+          zIndex={zIndex}
         />
       )}
       <OakCookieSettingsModal

--- a/src/styles/helpers/parseZIndex.ts
+++ b/src/styles/helpers/parseZIndex.ts
@@ -1,8 +1,11 @@
 import { OakZIndexToken, oakZIndexTokens } from "@/styles/theme/zIndex";
 
-export const parseZIndex = (value?: OakZIndexToken) => {
+export const parseZIndex = (value?: OakZIndexToken | number) => {
   if (value === undefined || value === null) {
     return undefined;
+  }
+  if (typeof value === "number") {
+    return value;
   }
   return oakZIndexTokens[value];
 };

--- a/src/styles/helpers/parseZindex.test.tsx
+++ b/src/styles/helpers/parseZindex.test.tsx
@@ -10,6 +10,7 @@ describe("parseZindex", () => {
   it.each([
     ["in-front", 1],
     ["mobile-filters", 2],
+    ["always-on-top", 9999],
   ])("should correctly handle props", (value, expected) => {
     expect(parseZIndex(value as OakZIndexToken)).toBe(expected);
   });

--- a/src/styles/helpers/parseZindex.test.tsx
+++ b/src/styles/helpers/parseZindex.test.tsx
@@ -7,6 +7,10 @@ describe("parseZindex", () => {
     expect(parseZIndex()).toBeUndefined();
   });
 
+  it("should return the value if it is a number", () => {
+    expect(parseZIndex(123)).toBe(123);
+  });
+
   it.each([
     ["in-front", 1],
     ["mobile-filters", 2],

--- a/src/styles/theme/zIndex.ts
+++ b/src/styles/theme/zIndex.ts
@@ -6,6 +6,7 @@ export const oakZIndexTokens = {
   "fixed-header": 100,
   "modal-close-button": 150,
   "modal-dialog": 300,
+  "always-on-top": 9999,
 };
 
 export type OakZIndexToken = keyof typeof oakZIndexTokens | null;

--- a/src/styles/utils/zIndexStyle.ts
+++ b/src/styles/utils/zIndexStyle.ts
@@ -13,7 +13,7 @@ export type ZIndexStyleProps = {
    *
    * Accepts a z-index token or a responsive array of z-index tokens.
    */
-  $zIndex?: ResponsiveValues<OakZIndexToken>;
+  $zIndex?: ResponsiveValues<OakZIndexToken | number>;
 };
 
 export const zIndexStyle = css<ZIndexStyleProps>`


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

- If the `OakCookieConsent` component is fixed in the viewport, make sure it appears in front of any other elements (by setting it's zIndex to 9999).
- Allow for `zIndex` to be overridden with a custom value.

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

1. Run storybook locally and navigate to organisms > OakCookieBanner.
2. Inspect the `cookie-banner` element in the default story.
3. If `isFixed` is false and you set a custom `zIndex` it should set that as the z-index value.
4. If you set `isFixed` to true, the z-index should be set to 9999 (unless overridden by the zIndex prop).

## ACs
