### PR TITLE
Fix/pupil 701/tooltip aria labels 2

### DIFF
--- a/src/components/atoms/InternalTooltip/InternalTooltip.test.tsx
+++ b/src/components/atoms/InternalTooltip/InternalTooltip.test.tsx
@@ -13,7 +13,7 @@ describe(InternalTooltip, () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <InternalTooltip>Hello there</InternalTooltip>
+        <InternalTooltip id={"tooltip"}>Hello there</InternalTooltip>
       </OakThemeProvider>,
     ).toJSON();
 
@@ -22,7 +22,7 @@ describe(InternalTooltip, () => {
 
   it("renders children", () => {
     const { getByText } = renderWithTheme(
-      <InternalTooltip>Hello there</InternalTooltip>,
+      <InternalTooltip id={"tooltip"}>Hello there</InternalTooltip>,
     );
 
     expect(getByText("Hello there")).toBeInTheDocument();
@@ -30,13 +30,13 @@ describe(InternalTooltip, () => {
 
   it('positions the arrow based on the "tooltipPosition" prop', () => {
     const { rerender, getByTestId } = renderWithTheme(
-      <InternalTooltip>Hello there</InternalTooltip>,
+      <InternalTooltip id={"tooltip"}>Hello there</InternalTooltip>,
     );
 
     expect(getByTestId("tooltip-arrow")).toHaveStyle("top: -1rem; left: 0rem");
 
     rerender(
-      <InternalTooltip tooltipPosition="bottom-right">
+      <InternalTooltip tooltipPosition="bottom-right" id={"tooltip"}>
         Hello there
       </InternalTooltip>,
     );
@@ -44,7 +44,7 @@ describe(InternalTooltip, () => {
     expect(getByTestId("tooltip-arrow")).toHaveStyle("top: -1rem; right: 0rem");
 
     rerender(
-      <InternalTooltip tooltipPosition="top-right">
+      <InternalTooltip tooltipPosition="top-right" id={"tooltip"}>
         Hello there
       </InternalTooltip>,
     );
@@ -54,7 +54,9 @@ describe(InternalTooltip, () => {
     );
 
     rerender(
-      <InternalTooltip tooltipPosition="top-left">Hello there</InternalTooltip>,
+      <InternalTooltip tooltipPosition="top-left" id={"tooltip"}>
+        Hello there
+      </InternalTooltip>,
     );
 
     expect(getByTestId("tooltip-arrow")).toHaveStyle(

--- a/src/components/atoms/InternalTooltip/InternalTooltip.tsx
+++ b/src/components/atoms/InternalTooltip/InternalTooltip.tsx
@@ -12,6 +12,7 @@ import { parseSpacing } from "@/styles/helpers/parseSpacing";
 export type InternalTooltipProps = OakFlexProps & {
   children?: ReactNode;
   tooltipPosition?: "bottom-left" | "bottom-right" | "top-left" | "top-right";
+  id: string;
 };
 
 const StyledFlex = styled(OakFlex)`
@@ -70,11 +71,14 @@ export const InternalTooltip = ({
   $background = "black",
   $color = "text-inverted",
   tooltipPosition = "bottom-left",
+  id,
   ...props
 }: InternalTooltipProps) => {
   return (
     <StyledFlex
       role="tooltip"
+      id={id}
+      data-rac
       {...props}
       $position="relative"
       $background={$background}

--- a/src/components/atoms/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
+++ b/src/components/atoms/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
@@ -41,6 +41,8 @@ exports[`InternalTooltip matches snapshot 1`] = `
 
 <div
   className="c0 c1 c2"
+  data-rac={true}
+  id="tooltip"
   role="tooltip"
 >
   Hello there

--- a/src/components/molecules/OakTooltip/OakTooltip.test.tsx
+++ b/src/components/molecules/OakTooltip/OakTooltip.test.tsx
@@ -26,7 +26,7 @@ describe(OakTooltip, () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <OakTooltip tooltip="Hello there" isOpen>
+        <OakTooltip tooltip="Hello there" isOpen id="tooltip">
           <div>Trigger!</div>
         </OakTooltip>
       </OakThemeProvider>,
@@ -37,7 +37,7 @@ describe(OakTooltip, () => {
 
   it("renders", () => {
     const { getByRole } = renderWithTheme(
-      <OakTooltip tooltip="Hello there" isOpen>
+      <OakTooltip tooltip="Hello there" isOpen id="tooltip">
         <div>Trigger!</div>
       </OakTooltip>,
     );

--- a/src/components/molecules/OakTooltip/OakTooltip.tsx
+++ b/src/components/molecules/OakTooltip/OakTooltip.tsx
@@ -32,6 +32,7 @@ export type OakTooltipProps = Pick<InternalTooltipProps, "tooltipPosition"> & {
    * @default document.body
    */
   domContainer?: Element;
+  id: string;
 };
 
 /**
@@ -43,6 +44,7 @@ export const OakTooltip = ({
   tooltip,
   isOpen,
   domContainer,
+  id,
   ...props
 }: OakTooltipProps) => {
   const [targetElement, setTargetElement] = useState<Element | null>(null);
@@ -159,6 +161,8 @@ export const OakTooltip = ({
                   tooltipPosition={tooltipPosition}
                   {...props}
                   {...borderRadiusProps}
+                  aria-expanded={isVisible}
+                  id={id}
                 >
                   {tooltip}
                 </InternalTooltip>

--- a/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
+++ b/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
@@ -83,7 +83,10 @@ exports[`OakTooltip matches snapshot 1`] = `
       className="c1"
     >
       <div
+        aria-expanded={true}
         className="c2 c3 c4"
+        data-rac={true}
+        id="tooltip"
         role="tooltip"
       >
         Hello there

--- a/src/components/organisms/pupil/OakHintButton/OakHintButton.test.tsx
+++ b/src/components/organisms/pupil/OakHintButton/OakHintButton.test.tsx
@@ -18,7 +18,10 @@ describe("OakHintButton", () => {
   it("matches snapshot", () => {
     const tree = create(
       <ThemeProvider theme={oakDefaultTheme}>
-        <OakHintButton isOpen={false} />
+        <OakHintButton
+          isOpen={false}
+          buttonProps={{ "aria-describedby": "hint-tooltip" }}
+        />
       </ThemeProvider>,
     ).toJSON();
 

--- a/src/components/organisms/pupil/OakHintButton/OakHintButton.tsx
+++ b/src/components/organisms/pupil/OakHintButton/OakHintButton.tsx
@@ -51,6 +51,8 @@ export const OakHintButton = (props: OakHintButtonProps) => {
       disabled={props.disabled}
       iconBackgroundSize={"all-spacing-8"}
       iconSize={"all-spacing-6"}
+      data-rac
+      aria-describedby="hint-tooltip"
     >
       {!isOpen ? "Need a hint?" : "Close hint"}
     </StyledInternalShadowRoundButton>

--- a/src/components/organisms/pupil/OakHintButton/OakHintButton.tsx
+++ b/src/components/organisms/pupil/OakHintButton/OakHintButton.tsx
@@ -1,7 +1,10 @@
-import React, { MouseEventHandler } from "react";
+import React, { HTMLAttributes, MouseEventHandler } from "react";
 import styled from "styled-components";
 
-import { InternalShadowRoundButton } from "@/components/molecules/InternalShadowRoundButton";
+import {
+  InternalShadowRoundButton,
+  InternalShadowRoundButtonProps,
+} from "@/components/molecules/InternalShadowRoundButton";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 
 export type OakHintButtonProps = {
@@ -9,6 +12,9 @@ export type OakHintButtonProps = {
   onClick?: MouseEventHandler;
   isLoading?: boolean;
   disabled?: boolean;
+  buttonProps?: Partial<
+    InternalShadowRoundButtonProps & HTMLAttributes<Element>
+  >;
 };
 
 const StyledInternalShadowRoundButton = styled(InternalShadowRoundButton)`
@@ -35,7 +41,7 @@ const StyledInternalShadowRoundButton = styled(InternalShadowRoundButton)`
  *  called after a mouseEnter and mouseLeave event has happened
  */
 export const OakHintButton = (props: OakHintButtonProps) => {
-  const { isOpen, disabled } = props;
+  const { isOpen, disabled, buttonProps } = props;
   return (
     <StyledInternalShadowRoundButton
       iconName={isOpen && !disabled ? "lightbulb-yellow" : "lightbulb"}
@@ -52,7 +58,8 @@ export const OakHintButton = (props: OakHintButtonProps) => {
       iconBackgroundSize={"all-spacing-8"}
       iconSize={"all-spacing-6"}
       data-rac
-      aria-describedby="hint-tooltip"
+      // aria-describedby={describedby}
+      {...buttonProps}
     >
       {!isOpen ? "Need a hint?" : "Close hint"}
     </StyledInternalShadowRoundButton>

--- a/src/components/organisms/pupil/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/organisms/pupil/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -172,7 +172,9 @@ exports[`OakHintButton matches snapshot 1`] = `
   className="c0 c1 c2 c3"
 >
   <button
+    aria-describedby="hint-tooltip"
     className="c4 c5"
+    data-rac={true}
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}

--- a/src/components/organisms/pupil/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/organisms/pupil/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -267,7 +267,9 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
           className="c5 c6 c7 c8"
         >
           <button
+            aria-describedby="hint-tooltip"
             className="c9 c10"
+            data-rac={true}
             onClick={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}

--- a/src/components/organisms/pupil/OakQuizHint/OakQuizHint.tsx
+++ b/src/components/organisms/pupil/OakQuizHint/OakQuizHint.tsx
@@ -21,7 +21,11 @@ export const OakQuizHint = ({ hint }: OakQuizHintProps) => {
 
   return (
     <OakTooltip tooltip={hint} isOpen={isOpen} id="hint-tooltip">
-      <OakHintButton isOpen={isOpen} onClick={handleClick} />
+      <OakHintButton
+        isOpen={isOpen}
+        onClick={handleClick}
+        buttonProps={{ "aria-describedby": "hint-tooltip" }}
+      />
     </OakTooltip>
   );
 };

--- a/src/components/organisms/pupil/OakQuizHint/OakQuizHint.tsx
+++ b/src/components/organisms/pupil/OakQuizHint/OakQuizHint.tsx
@@ -20,7 +20,7 @@ export const OakQuizHint = ({ hint }: OakQuizHintProps) => {
   };
 
   return (
-    <OakTooltip tooltip={hint} isOpen={isOpen}>
+    <OakTooltip tooltip={hint} isOpen={isOpen} id="hint-tooltip">
       <OakHintButton isOpen={isOpen} onClick={handleClick} />
     </OakTooltip>
   );

--- a/src/components/organisms/pupil/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/organisms/pupil/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -180,7 +180,9 @@ exports[`OakQuizHint matches snapshot 1`] = `
       className="c0 c1 c2 c3"
     >
       <button
+        aria-describedby="hint-tooltip"
         className="c4 c5"
+        data-rac={true}
         onClick={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}

--- a/src/components/organisms/pupil/Oakinfo/OakInfo.tsx
+++ b/src/components/organisms/pupil/Oakinfo/OakInfo.tsx
@@ -11,7 +11,7 @@ export type OakInfoProps = {
   hint: ReactNode;
   isLoading?: boolean;
   disabled?: boolean;
-} & Omit<OakTooltipProps, "children" | "tooltip">;
+} & Omit<OakTooltipProps, "children" | "tooltip" | "id">;
 
 /**
  * Presents a button which will show a hint when clicked
@@ -24,7 +24,12 @@ export const OakInfo = (props: OakInfoProps) => {
   };
 
   return (
-    <OakTooltip tooltip={props.hint} isOpen={isOpen} {...tooltipProps}>
+    <OakTooltip
+      tooltip={props.hint}
+      isOpen={isOpen}
+      id={"info-tooltip"}
+      {...tooltipProps}
+    >
       <OakInfoButton onClick={handleClick} isOpen={isOpen} />
     </OakTooltip>
   );

--- a/src/components/organisms/pupil/Oakinfo/OakInfo.tsx
+++ b/src/components/organisms/pupil/Oakinfo/OakInfo.tsx
@@ -30,7 +30,11 @@ export const OakInfo = (props: OakInfoProps) => {
       id={"info-tooltip"}
       {...tooltipProps}
     >
-      <OakInfoButton onClick={handleClick} isOpen={isOpen} />
+      <OakInfoButton
+        onClick={handleClick}
+        isOpen={isOpen}
+        buttonProps={{ "aria-describedby": "info-tooltip" }}
+      />
     </OakTooltip>
   );
 };

--- a/src/components/organisms/pupil/Oakinfo/__snapshots__/OakInfo.test.tsx.snap
+++ b/src/components/organisms/pupil/Oakinfo/__snapshots__/OakInfo.test.tsx.snap
@@ -182,7 +182,9 @@ exports[`OakInfo matches snapshot 1`] = `
       className="c0 c1 c2 c3"
     >
       <button
+        aria-describedby="info-tooltip"
         className="c4 c5"
+        data-rac={true}
         onClick={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}

--- a/src/components/organisms/pupil/OakinfoButton/OakInfoButton.test.tsx
+++ b/src/components/organisms/pupil/OakinfoButton/OakInfoButton.test.tsx
@@ -12,7 +12,12 @@ describe(OakInfoButton, () => {
     const handleClick = () => jest.fn();
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <OakInfoButton isOpen={false} isLoading={false} onClick={handleClick} />
+        <OakInfoButton
+          isOpen={false}
+          isLoading={false}
+          onClick={handleClick}
+          buttonProps={{ "aria-describedby": "info-tooltip" }}
+        />
         ,
       </OakThemeProvider>,
     ).toJSON();

--- a/src/components/organisms/pupil/OakinfoButton/OakInfoButton.tsx
+++ b/src/components/organisms/pupil/OakinfoButton/OakInfoButton.tsx
@@ -46,6 +46,8 @@ export const OakInfoButton = (props: OakInfoButtonProps) => {
       iconBackgroundSize={"all-spacing-8"}
       iconSize={"all-spacing-7"}
       onClick={onClick}
+      data-rac
+      aria-describedby="info-tooltip"
     />
   );
 };

--- a/src/components/organisms/pupil/OakinfoButton/OakInfoButton.tsx
+++ b/src/components/organisms/pupil/OakinfoButton/OakInfoButton.tsx
@@ -1,7 +1,10 @@
-import React, { MouseEventHandler } from "react";
+import React, { HTMLAttributes, MouseEventHandler } from "react";
 import styled from "styled-components";
 
-import { InternalShadowRoundButton } from "@/components/molecules/InternalShadowRoundButton";
+import {
+  InternalShadowRoundButton,
+  InternalShadowRoundButtonProps,
+} from "@/components/molecules/InternalShadowRoundButton";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 
 export type OakInfoButtonProps = {
@@ -9,6 +12,9 @@ export type OakInfoButtonProps = {
   isOpen: boolean;
   isLoading?: boolean;
   disabled?: boolean;
+  buttonProps?: Partial<
+    InternalShadowRoundButtonProps & HTMLAttributes<Element>
+  >;
 };
 
 const StyledInternalShadowRoundButton = styled(InternalShadowRoundButton)`
@@ -28,7 +34,7 @@ const StyledInternalShadowRoundButton = styled(InternalShadowRoundButton)`
  *
  */
 export const OakInfoButton = (props: OakInfoButtonProps) => {
-  const { isLoading, disabled, onClick, isOpen } = props;
+  const { isLoading, disabled, onClick, isOpen, buttonProps } = props;
 
   return (
     <StyledInternalShadowRoundButton
@@ -47,7 +53,7 @@ export const OakInfoButton = (props: OakInfoButtonProps) => {
       iconSize={"all-spacing-7"}
       onClick={onClick}
       data-rac
-      aria-describedby="info-tooltip"
+      {...buttonProps}
     />
   );
 };

--- a/src/components/organisms/pupil/OakinfoButton/__snapshots__/OakInfoButton.test.tsx.snap
+++ b/src/components/organisms/pupil/OakinfoButton/__snapshots__/OakInfoButton.test.tsx.snap
@@ -175,7 +175,9 @@ exports[`OakInfoButton matches snapshot 1`] = `
     className="c0 c1 c2 c3"
   >
     <button
+      aria-describedby="info-tooltip"
       className="c4 c5"
+      data-rac={true}
       disabled={false}
       onClick={[Function]}
       onMouseEnter={[Function]}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

When a user opens a tool tip element
I want an aria exapanded attribute to toggle true
So that users with screen readers are aware that the item has successfully been toggled

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

look at the oakinfo [component](https://deploy-preview-188--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-pupil-oakinfo--docs) and
test that the tooltip can be picked up by screen reader 

## ACs

- [ ]  Ensure screen reader can pick up text in info component
- [ ]  When expanded user can navigate to info component using keyboard
