### PR TITLE
fix: allow labels to be react elements so that mathjax component can be passed in as label

### DIFF
--- a/src/components/organisms/pupil/OakQuizMatch/OakQuizMatch.tsx
+++ b/src/components/organisms/pupil/OakQuizMatch/OakQuizMatch.tsx
@@ -31,11 +31,11 @@ type DraggableId = string;
 type DroppableId = string;
 type DraggableItem = {
   id: DraggableId;
-  label: string;
+  label: ReactNode;
 };
 type DroppableItem = {
   id: DroppableId;
-  label: string;
+  label: ReactNode;
 };
 type Matches = Record<DroppableId, DraggableItem>;
 


### PR DESCRIPTION
This PR fixes a type issue. Means that the mathjax component can be passed into the OakQuizMatch component on the label prop.

I don't have anyone else in my team for the next 2 weeks so apologies for asking outside the usual channels 🙂

See this PR if you are interested in output
https://github.com/oaknational/Oak-Web-Application/pull/2348

# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
