### PR TITLE
chore: refactor id on OakTooltip

### DIFF
--- a/src/components/atoms/InternalTooltip/InternalTooltip.tsx
+++ b/src/components/atoms/InternalTooltip/InternalTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { HTMLAttributes, ReactNode } from "react";
 import styled, { css } from "styled-components";
 
 import { OakFlex, OakFlexProps } from "../OakFlex";
@@ -9,11 +9,11 @@ import { ColorStyleProps } from "@/styles/utils/colorStyle";
 import { responsiveStyle } from "@/styles/utils/responsiveStyle";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
 
-export type InternalTooltipProps = OakFlexProps & {
-  children?: ReactNode;
-  tooltipPosition?: "bottom-left" | "bottom-right" | "top-left" | "top-right";
-  id: string;
-};
+export type InternalTooltipProps = OakFlexProps &
+  HTMLAttributes<Element> & {
+    children?: ReactNode;
+    tooltipPosition?: "bottom-left" | "bottom-right" | "top-left" | "top-right";
+  };
 
 const StyledFlex = styled(OakFlex)`
   width: max-content;
@@ -71,19 +71,17 @@ export const InternalTooltip = ({
   $background = "black",
   $color = "text-inverted",
   tooltipPosition = "bottom-left",
-  id,
   ...props
 }: InternalTooltipProps) => {
   return (
     <StyledFlex
       role="tooltip"
-      id={id}
       data-rac
-      {...props}
       $position="relative"
       $background={$background}
       $color={$color}
       $maxWidth={["all-spacing-20", "all-spacing-22"]}
+      {...props}
     >
       {children}
       <StyledSvg

--- a/src/components/molecules/OakTooltip/OakTooltip.tsx
+++ b/src/components/molecules/OakTooltip/OakTooltip.tsx
@@ -13,7 +13,7 @@ import {
 import { OakBox, OakBoxProps } from "@/components/atoms";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
 
-export type OakTooltipProps = Pick<InternalTooltipProps, "tooltipPosition"> & {
+export type OakTooltipProps = InternalTooltipProps & {
   /**
    * The target element that triggers the tooltip
    */
@@ -32,7 +32,6 @@ export type OakTooltipProps = Pick<InternalTooltipProps, "tooltipPosition"> & {
    * @default document.body
    */
   domContainer?: Element;
-  id: string;
 };
 
 /**
@@ -44,7 +43,6 @@ export const OakTooltip = ({
   tooltip,
   isOpen,
   domContainer,
-  id,
   ...props
 }: OakTooltipProps) => {
   const [targetElement, setTargetElement] = useState<Element | null>(null);
@@ -159,10 +157,9 @@ export const OakTooltip = ({
                   $ph="inner-padding-xl"
                   $font="heading-light-7"
                   tooltipPosition={tooltipPosition}
-                  {...props}
-                  {...borderRadiusProps}
                   aria-expanded={isVisible}
-                  id={id}
+                  {...borderRadiusProps}
+                  {...props}
                 >
                   {tooltip}
                 </InternalTooltip>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  [x] Missing exports for Oak components
  [x] Accidental export of Internal components
  [x] Snapshots of unexpected components have been modified
  [x] Circular dependencies
  [x] Code duplication (via not using base components)
  [x] Non-functional storybook for this or related components
  [x] Sensitve files changed eg. atoms, or style tokens
  [x] Relative imports
  [x] Default exports

# Add your PR description below

Refactored this slightly, Kyle had an issue when he upgraded Oak-components in OWA. Which led me to believe id should be optional. I also decided to allow any html attributes to be passed as props to the InternalTooltip.

## Testing instructions

OakTooltip and InternalTooltip should be tested, but their functionality is extremely unlikely to be effected as this is just a refactor of props and the snapshots remained the same.
