### PR TITLE
fix: `OakCookieSettingsModal` being stacked behind `OakCookieBanner`

### DIFF
--- a/src/components/molecules/OakModal/OakModal.tsx
+++ b/src/components/molecules/OakModal/OakModal.tsx
@@ -42,6 +42,14 @@ export type OakModalProps = {
    * @default document.body
    */
   domContainer?: Element;
+  /**
+   * Optional z-index override.
+   *
+   * Defaults to token: `modal-dialog`
+   *
+   * NB *The modal is rendered inside a portal so it will not respect the stacking context of its parent component*.
+   */
+  zIndex?: number;
 } & Pick<
   HTMLAttributes<Element>,
   "aria-label" | "aria-description" | "aria-labelledby" | "aria-describedby"
@@ -83,6 +91,7 @@ export const OakModal = ({
   domContainer,
   isOpen,
   onClose,
+  zIndex,
   ...rest
 }: OakModalProps) => {
   const [canaryElement, setCanaryElement] = useState<HTMLDivElement | null>(
@@ -121,6 +130,8 @@ export const OakModal = ({
     return null;
   }
 
+  const finalZIndex = typeof zIndex === "number" ? zIndex : "modal-dialog";
+
   return createPortal(
     <Transition
       in={isOpen}
@@ -137,7 +148,7 @@ export const OakModal = ({
           <FadeOutBox
             $position="fixed"
             $inset="all-spacing-0"
-            $zIndex="modal-dialog"
+            $zIndex={finalZIndex}
             $background="black"
             $opacity="semi-transparent"
             $state={state}
@@ -151,7 +162,7 @@ export const OakModal = ({
             $top="all-spacing-0"
             $bottom="all-spacing-0"
             $width={["all-spacing-22"]}
-            $zIndex="modal-dialog"
+            $zIndex={finalZIndex}
             $flexDirection="column"
             $transition="standard-ease"
             $color="text-primary"

--- a/src/components/organisms/OakCookieBanner/OakCookieBanner.tsx
+++ b/src/components/organisms/OakCookieBanner/OakCookieBanner.tsx
@@ -48,6 +48,8 @@ export type OakCookieBannerProps = {
   isFixed?: boolean;
   /**
    * Optional z-index override of the banner.
+   *
+   * Defaults to token: `in-front`
    */
   zIndex?: number;
 };
@@ -74,7 +76,9 @@ export const OakCookieBanner = ({
       $bottom={isFixed ? "all-spacing-0" : undefined}
       $right={isFixed ? "all-spacing-0" : undefined}
       $left={isFixed ? "all-spacing-0" : undefined}
-      $zIndex={zIndex ? zIndex : isFixed ? "always-on-top" : undefined}
+      $zIndex={
+        typeof zIndex === "number" ? zIndex : isFixed ? "in-front" : undefined
+      }
       $color="text-primary"
       data-testid="cookie-banner"
     >

--- a/src/components/organisms/OakCookieConsent/OakCookieConsent.stories.tsx
+++ b/src/components/organisms/OakCookieConsent/OakCookieConsent.stories.tsx
@@ -22,6 +22,7 @@ const meta: Meta<
   title: "components/organisms/OakCookieConsent",
   argTypes: {
     innerMaxWidth: sizeArgTypes["$maxWidth"],
+    zIndex: { control: "number" },
   },
   args: {
     isFixed: true,
@@ -77,6 +78,7 @@ const meta: Meta<
     currentConsents,
     isFixed,
     innerMaxWidth,
+    zIndex,
   }) => {
     const [, updateArgs] = useArgs();
 
@@ -93,6 +95,7 @@ const meta: Meta<
           policyURL={policyURL}
           isFixed={isFixed}
           innerMaxWidth={innerMaxWidth}
+          zIndex={zIndex}
         />
       </OakCookieConsentProvider>
     );

--- a/src/components/organisms/OakCookieConsent/OakCookieConsent.tsx
+++ b/src/components/organisms/OakCookieConsent/OakCookieConsent.tsx
@@ -11,7 +11,12 @@ export type OakCookieConsentProps = Pick<
   OakCookieSettingsModalProps,
   "policyURL"
 > &
-  Pick<OakCookieBannerProps, "isFixed" | "innerMaxWidth" | "zIndex">;
+  Pick<OakCookieBannerProps, "isFixed" | "innerMaxWidth"> & {
+    /**
+     * Optional stacking context for the entire consent UI
+     */
+    zIndex?: number;
+  };
 
 /**
  * Connects `OakCookieBanner` and `OakCookieSettingsModal` to `OakCookieConsentProvider`.
@@ -59,6 +64,7 @@ export const OakCookieConsent = ({
         onConfirm={confirmModalConsents}
         onAccept={acceptModalConsents}
         initialConsents={currentConsents}
+        zIndex={zIndex}
       />
     </>
   );

--- a/src/components/organisms/OakCookieSettingsModal/OakCookieSettingsModal.tsx
+++ b/src/components/organisms/OakCookieSettingsModal/OakCookieSettingsModal.tsx
@@ -48,7 +48,7 @@ type Consents = {
 
 export type OakCookieSettingsModalProps = Pick<
   OakModalProps,
-  "isOpen" | "onClose"
+  "isOpen" | "onClose" | "zIndex"
 > & {
   /**
    * Triggered when the user rejects all non-essential cookies.
@@ -89,6 +89,7 @@ export const OakCookieSettingsModal = ({
   policyURL,
   policies,
   initialConsents,
+  zIndex,
 }: OakCookieSettingsModalProps) => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -110,6 +111,7 @@ export const OakCookieSettingsModal = ({
     <OakModal
       isOpen={isOpen}
       onClose={onClose}
+      zIndex={zIndex}
       footerSlot={
         <OakModalFooter>
           <OakSecondaryButton onClick={onReject} width="100%">

--- a/src/styles/helpers/parseZindex.test.tsx
+++ b/src/styles/helpers/parseZindex.test.tsx
@@ -14,7 +14,6 @@ describe("parseZindex", () => {
   it.each([
     ["in-front", 1],
     ["mobile-filters", 2],
-    ["always-on-top", 9999],
   ])("should correctly handle props", (value, expected) => {
     expect(parseZIndex(value as OakZIndexToken)).toBe(expected);
   });

--- a/src/styles/theme/zIndex.ts
+++ b/src/styles/theme/zIndex.ts
@@ -6,7 +6,6 @@ export const oakZIndexTokens = {
   "fixed-header": 100,
   "modal-close-button": 150,
   "modal-dialog": 300,
-  "always-on-top": 9999,
 };
 
 export type OakZIndexToken = keyof typeof oakZIndexTokens | null;


### PR DESCRIPTION
the z-index of 99999 caused that the banner to be rendered on top of the settings modal. This commit restores the original values while adding an option to set a stacking context for the entire `OakCookieConsent` component.

This ensures that the entire component can be stacked according to the needs of the host app while keeping the internal stacking order encapsulated.


**before**
<img width="1500" alt="Screenshot 2024-06-20 at 11 10 19" src="https://github.com/oaknational/oak-components/assets/122096/0e53db4d-0254-483d-8a45-fe6152ba6c55">

**after**

https://github.com/oaknational/oak-components/assets/122096/610007d8-2578-4580-a41e-57e575df9ef3



# How to review this PR

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

## A link to the component in the deployment preview

https://deploy-preview-204--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-oakcookieconsent--default

## ACs

The settings modal should always stack above the banner when present.
