### PR TITLE
feat!: rename props in consent ui

### DIFF
--- a/src/components/organisms/OakCookieConsent/OakCookieConsent.stories.tsx
+++ b/src/components/organisms/OakCookieConsent/OakCookieConsent.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import { useArgs } from "@storybook/preview-api";
+import { action } from "@storybook/addon-actions";
 
 import { OakCookieConsentProvider } from "../OakCookieConsentProvider";
 import {
@@ -15,7 +16,7 @@ import { sizeArgTypes } from "@/storybook-helpers/sizeStyleHelpers";
 
 const meta: Meta<
   OakCookieConsentProps &
-    Pick<OakCookieConsentProviderProps, "currentConsents" | "policies">
+    Pick<OakCookieConsentProviderProps, "policyConsents" | "onConsentChange">
 > = {
   component: OakCookieConsent,
   tags: ["autodocs"],
@@ -27,68 +28,58 @@ const meta: Meta<
   args: {
     isFixed: true,
     policyURL: "https://example.com/privacy-policy",
-    policies: [
+    policyConsents: [
       {
-        id: "1",
-        label: "Strictly necessary",
-        description:
+        policyId: "1",
+        policyLabel: "Strictly necessary",
+        policyDescription:
           "Any cookies required for the website to function properly.",
-        strictlyNecessary: true,
-        parties: [],
+        isStrictlyNecessary: true,
+        policyParties: [],
+        consentState: "granted",
       },
       {
-        id: "2",
-        label: "Embedded content",
-        description:
+        policyId: "2",
+        policyLabel: "Embedded content",
+        policyDescription:
           "Any cookies required for video or other embedded learning content to work.",
-        strictlyNecessary: false,
-        parties: [
+        isStrictlyNecessary: false,
+        policyParties: [
           {
             name: "Big Video",
-            policyURL: "https://example.com/party-2-policy",
+            url: "https://example.com/party-2-policy",
           },
         ],
+        consentState: "denied",
       },
       {
-        id: "3",
-        label: "Statistics",
-        description:
+        policyId: "3",
+        policyLabel: "Statistics",
+        policyDescription:
           "Statistics and analytics that allow us to see usage, find bugs and issues, and improve the service.",
-        strictlyNecessary: false,
-        parties: [
+        isStrictlyNecessary: false,
+        policyParties: [
           {
             name: "Bug jar",
-            policyURL: "https://example.com/party-3-policy",
+            url: "https://example.com/party-3-policy",
           },
           {
             name: "Captain Stats",
-            policyURL: "https://example.com/party-4-policy",
+            url: "https://example.com/party-4-policy",
           },
         ],
+        consentState: "pending",
       },
     ],
-    currentConsents: {
-      "1": "granted",
-      "2": "denied",
-    },
+    onConsentChange: action("onConsentChange"),
   },
-  render: ({
-    policies,
-    policyURL,
-    currentConsents,
-    isFixed,
-    innerMaxWidth,
-    zIndex,
-  }) => {
-    const [, updateArgs] = useArgs();
+  render: ({ policyConsents, policyURL, isFixed, innerMaxWidth, zIndex }) => {
+    const [{ onConsentChange }] = useArgs();
 
     return (
       <OakCookieConsentProvider
-        currentConsents={currentConsents}
-        policies={policies}
-        onConsentChange={(consents) => {
-          updateArgs({ currentConsents: consents });
-        }}
+        policyConsents={policyConsents}
+        onConsentChange={onConsentChange}
       >
         <ConsentBannerButton />
         <OakCookieConsent
@@ -115,8 +106,7 @@ function ConsentBannerButton() {
 export default meta;
 
 type Story = StoryObj<
-  OakCookieConsentProps &
-    Pick<OakCookieConsentProviderProps, "currentConsents" | "policies">
+  OakCookieConsentProps & Pick<OakCookieConsentProviderProps, "policyConsents">
 >;
 
 export const Default: Story = {};

--- a/src/components/organisms/OakCookieConsent/OakCookieConsent.tsx
+++ b/src/components/organisms/OakCookieConsent/OakCookieConsent.tsx
@@ -28,14 +28,13 @@ export const OakCookieConsent = ({
   zIndex,
 }: OakCookieConsentProps) => {
   const {
-    policies,
+    policyConsents,
     acceptModalConsents,
     rejectModalConsents,
     confirmModalConsents,
     hideBanner,
     openSettings,
     closeSettings,
-    currentConsents,
     isSettingsModalOpen,
     acceptBannerConsents,
     rejectBannerConsents,
@@ -57,13 +56,12 @@ export const OakCookieConsent = ({
       )}
       <OakCookieSettingsModal
         policyURL={policyURL}
-        policies={policies}
+        policyConsents={policyConsents}
         isOpen={isSettingsModalOpen}
         onClose={closeSettings}
         onReject={rejectModalConsents}
         onConfirm={confirmModalConsents}
         onAccept={acceptModalConsents}
-        initialConsents={currentConsents}
         zIndex={zIndex}
       />
     </>

--- a/src/components/organisms/OakCookieConsentProvider/OakCookieConsentProvider.test.tsx
+++ b/src/components/organisms/OakCookieConsentProvider/OakCookieConsentProvider.test.tsx
@@ -17,18 +17,18 @@ describe(OakCookieConsentProvider, () => {
       });
 
       act(() => {
-        result.current.confirmModalConsents({
-          "1": "granted",
-          "2": "denied",
-          "3": "granted",
-        });
+        result.current.confirmModalConsents([
+          { policyId: "1", consentState: "granted" },
+          { policyId: "2", consentState: "denied" },
+          { policyId: "3", consentState: "granted" },
+        ]);
       });
 
-      expect(onConsentChange).toHaveBeenCalledWith({
-        "1": "granted",
-        "2": "denied",
-        "3": "granted",
-      });
+      expect(onConsentChange).toHaveBeenCalledWith([
+        { policyId: "1", consentState: "granted" },
+        { policyId: "2", consentState: "denied" },
+        { policyId: "3", consentState: "granted" },
+      ]);
     });
   });
 
@@ -43,11 +43,11 @@ describe(OakCookieConsentProvider, () => {
         result.current.acceptModalConsents();
       });
 
-      expect(onConsentChange).toHaveBeenCalledWith({
-        "1": "granted",
-        "2": "granted",
-        "3": "granted",
-      });
+      expect(onConsentChange).toHaveBeenCalledWith([
+        { policyId: "1", consentState: "granted" },
+        { policyId: "2", consentState: "granted" },
+        { policyId: "3", consentState: "granted" },
+      ]);
     });
   });
 
@@ -62,11 +62,11 @@ describe(OakCookieConsentProvider, () => {
         result.current.rejectModalConsents();
       });
 
-      expect(onConsentChange).toHaveBeenCalledWith({
-        "1": "granted",
-        "2": "denied",
-        "3": "denied",
-      });
+      expect(onConsentChange).toHaveBeenCalledWith([
+        { policyId: "1", consentState: "granted" },
+        { policyId: "2", consentState: "denied" },
+        { policyId: "3", consentState: "denied" },
+      ]);
     });
   });
 
@@ -81,11 +81,11 @@ describe(OakCookieConsentProvider, () => {
         result.current.acceptBannerConsents();
       });
 
-      expect(onConsentChange).toHaveBeenCalledWith({
-        "1": "granted",
-        "2": "granted",
-        "3": "granted",
-      });
+      expect(onConsentChange).toHaveBeenCalledWith([
+        { policyId: "1", consentState: "granted" },
+        { policyId: "2", consentState: "granted" },
+        { policyId: "3", consentState: "granted" },
+      ]);
     });
   });
 
@@ -100,11 +100,11 @@ describe(OakCookieConsentProvider, () => {
         result.current.rejectBannerConsents();
       });
 
-      expect(onConsentChange).toHaveBeenCalledWith({
-        "1": "granted",
-        "2": "denied",
-        "3": "denied",
-      });
+      expect(onConsentChange).toHaveBeenCalledWith([
+        { policyId: "1", consentState: "granted" },
+        { policyId: "2", consentState: "denied" },
+        { policyId: "3", consentState: "denied" },
+      ]);
     });
   });
 });
@@ -115,56 +115,54 @@ function wrapper(
   return <OakCookieConsentProvider {...createProps()} {...props} />;
 }
 
-const policies: OakCookieConsentContextType["policies"] = [
+const policyConsents: OakCookieConsentContextType["policyConsents"] = [
   {
-    id: "1",
-    label: "Strictly necessary",
-    description: "Any cookies required for the website to function properly.",
-    strictlyNecessary: true,
-    parties: [],
+    policyId: "1",
+    policyLabel: "Strictly necessary",
+    policyDescription:
+      "Any cookies required for the website to function properly.",
+    isStrictlyNecessary: true,
+    policyParties: [],
+    consentState: "granted",
   },
   {
-    id: "2",
-    label: "Embedded content",
-    description:
+    policyId: "2",
+    policyLabel: "Embedded content",
+    policyDescription:
       "Any cookies required for video or other embedded learning content to work.",
-    strictlyNecessary: false,
-    parties: [
+    isStrictlyNecessary: false,
+    policyParties: [
       {
         name: "Big Video",
-        policyURL: "https://example.com/party-2-policy",
+        url: "https://example.com/party-2-policy",
       },
     ],
+    consentState: "denied",
   },
   {
-    id: "3",
-    label: "Statistics",
-    description:
+    policyId: "3",
+    policyLabel: "Statistics",
+    policyDescription:
       "Statistics and analytics that allow us to see usage, find bugs and issues, and improve the service.",
-    strictlyNecessary: false,
-    parties: [
+    isStrictlyNecessary: false,
+    policyParties: [
       {
         name: "Bug jar",
-        policyURL: "https://example.com/party-3-policy",
+        url: "https://example.com/party-3-policy",
       },
       {
         name: "Captain Stats",
-        policyURL: "https://example.com/party-4-policy",
+        url: "https://example.com/party-4-policy",
       },
     ],
+    consentState: "pending",
   },
 ];
-
-const consents: OakCookieConsentContextType["currentConsents"] = {
-  "1": "granted",
-  "2": "denied",
-};
 
 export function createProps(): OakCookieConsentProviderProps {
   return {
     children: null,
-    policies,
-    currentConsents: consents,
+    policyConsents,
     onConsentChange: jest.fn(),
   };
 }

--- a/src/components/organisms/OakCookieSettingsModal/OakCookieSettingsModal.stories.tsx
+++ b/src/components/organisms/OakCookieSettingsModal/OakCookieSettingsModal.stories.tsx
@@ -13,50 +13,49 @@ const meta: Meta<typeof OakCookieSettingsModal> = {
   args: {
     isOpen: false,
     policyURL: "https://example.com/privacy-policy",
-    policies: [
+    policyConsents: [
       {
-        id: "1",
-        label: "Strictly necessary",
-        description:
+        policyId: "1",
+        policyLabel: "Strictly necessary",
+        policyDescription:
           "Any cookies required for the website to function properly.",
-        strictlyNecessary: true,
-        parties: [],
+        isStrictlyNecessary: true,
+        policyParties: [],
+        consentState: "granted",
       },
       {
-        id: "2",
-        label: "Embedded content",
-        description:
+        policyId: "2",
+        policyLabel: "Embedded content",
+        policyDescription:
           "Any cookies required for video or other embedded learning content to work.",
-        strictlyNecessary: false,
-        parties: [
+        isStrictlyNecessary: false,
+        policyParties: [
           {
             name: "Big Video",
-            policyURL: "https://example.com/party-2-policy",
+            url: "https://example.com/party-2-policy",
           },
         ],
+        consentState: "denied",
       },
       {
-        id: "3",
-        label: "Statistics",
-        description:
+        policyId: "3",
+        policyLabel: "Statistics",
+        policyDescription:
           "Statistics and analytics that allow us to see usage, find bugs and issues, and improve the service.",
-        strictlyNecessary: false,
-        parties: [
+        isStrictlyNecessary: false,
+        policyParties: [
           {
             name: "Bug jar",
-            policyURL: "https://example.com/party-3-policy",
+            url: "https://example.com/party-3-policy",
           },
           {
             name: "Captain Stats",
-            policyURL: "https://example.com/party-4-policy",
+            url: "https://example.com/party-4-policy",
           },
         ],
+        consentState: "pending",
       },
     ],
-    initialConsents: {
-      "1": "granted",
-      "2": "denied",
-    },
   },
   render: (args) => {
     const [, updateArgs] = useArgs();

--- a/src/components/organisms/OakCookieSettingsModal/OakCookieSettingsModal.test.tsx
+++ b/src/components/organisms/OakCookieSettingsModal/OakCookieSettingsModal.test.tsx
@@ -55,11 +55,11 @@ describe(OakCookieSettingsModal, () => {
       fireEvent.click(getByText("Confirm my choices"));
     });
 
-    expect(props.onConfirm).toHaveBeenCalledWith({
-      "1": "granted",
-      "2": "granted",
-      "3": "denied",
-    });
+    expect(props.onConfirm).toHaveBeenCalledWith([
+      { policyId: "1", consentState: "granted" },
+      { policyId: "2", consentState: "granted" },
+      { policyId: "3", consentState: "denied" },
+    ]);
   });
 });
 
@@ -69,50 +69,50 @@ export function createProps(
   return {
     isOpen: false,
     policyURL: "https://example.com/privacy-policy",
-    policies: [
+    policyConsents: [
       {
-        id: "1",
-        label: "Strictly necessary",
-        description:
+        policyId: "1",
+        policyLabel: "Strictly necessary",
+        policyDescription:
           "Any cookies required for the website to function properly.",
-        strictlyNecessary: true,
-        parties: [],
+        isStrictlyNecessary: true,
+        policyParties: [],
+        consentState: "granted",
       },
       {
-        id: "2",
-        label: "Embedded content",
-        description:
+        policyId: "2",
+        policyLabel: "Embedded content",
+        policyDescription:
           "Any cookies required for video or other embedded learning content to work.",
-        strictlyNecessary: false,
-        parties: [
+        isStrictlyNecessary: false,
+        policyParties: [
           {
             name: "Big Video",
-            policyURL: "https://example.com/party-2-policy",
+            url: "https://example.com/party-2-policy",
           },
         ],
+        consentState: "denied",
       },
       {
-        id: "3",
-        label: "Statistics",
-        description:
+        policyId: "3",
+        policyLabel: "Statistics",
+        policyDescription:
           "Statistics and analytics that allow us to see usage, find bugs and issues, and improve the service.",
-        strictlyNecessary: false,
-        parties: [
+        isStrictlyNecessary: false,
+        policyParties: [
           {
             name: "Bug jar",
-            policyURL: "https://example.com/party-3-policy",
+            url: "https://example.com/party-3-policy",
           },
           {
             name: "Captain Stats",
-            policyURL: "https://example.com/party-4-policy",
+            url: "https://example.com/party-4-policy",
           },
         ],
+        consentState: "pending",
       },
     ],
-    initialConsents: {
-      "1": "granted",
-      "2": "denied",
-    },
+
     onClose: jest.fn(),
     onReject: jest.fn(),
     onConfirm: jest.fn(),


### PR DESCRIPTION
BREAKING CHANGE: this brings the prop names inline with those in oak-consent-client making integration easier.

This will make it much cleaner to integrate the UI with the client. Since these components are highly unlikely to be used with anything but oak-consent-client, it makes sense that they have things named consistently and APIs that match.

This change means that an integrating component will now look something like:

```typescript
const { state, logConsents } = useOakConsent();

return (
  <OakCookieConsentProvider
    policyConsents={state.policyConsents}
    onConsentChange={logConsents}
  >
    <OakCookieConsent
      policyURL="/cookie-policy"
      isFixed
    />
  </OakCookieConsentProvider>
);
```
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

## A link to the component in the deployment preview

https://deploy-preview-205--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-oakcookieconsent--default

## Testing instructions

This should behave exactly as before with the only difference being the shape of the props passed in.

