### PR TITLE
chore: correct missing `OakGlobalStyle` import and add a note to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,11 @@ You can install it using `npm i @oaknational/oak-components` or any other packag
 
 For components to be styled correctly they will need access to a theme, some global styles and the Lexend font.
 
-You can add those to your app using something like:
-
-
-> 🚨 This example is for the [Next.js App router](https://nextjs.org/docs/app) . If you're using the [Pages router](https://nextjs.org/docs/pages/building-your-application) these changes should be made inside your `_document.js` 
-
+If you're using the Next.js App router your root layout should look something like:
 
 ```typescript
 // layout.js 
 import { OakThemeProvider, oakDefaultTheme, OakGlobalStyle } from "@oaknational/oak-components";
-import Head from "next/head";
 import { Lexend } from "next/font/google";
 
 const lexend = Lexend({ subsets: ['latin'] });
@@ -33,9 +28,7 @@ const lexend = Lexend({ subsets: ['latin'] });
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <Head>
-        <OakGlobalStyle />
-      </Head>
+      <OakGlobalStyle />
       <body className={lexend.className}>
         <OakThemeProvider theme={oakDefaultTheme}>{children}</OakThemeProvider>
       </body>
@@ -43,6 +36,8 @@ export default function RootLayout({ children }) {
   );
 }
 ```
+
+To enable SSR of styles and avoid a flicker of unstyled content you'll need to configure your Next.js app to support [styled-components](https://nextjs.org/docs/app/building-your-application/styling/css-in-js#styled-components)
 
 ### TypeScript
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ For components to be styled correctly they will need access to a theme, some glo
 
 You can add those to your app using something like:
 
+
+> 🚨 This example is for the [Next.js App router](https://nextjs.org/docs/app) . If you're using the [Pages router](https://nextjs.org/docs/pages/building-your-application) these changes should be made inside your `_document.js` 
+
+
 ```typescript
-import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
+// layout.js 
+import { OakThemeProvider, oakDefaultTheme, OakGlobalStyle } from "@oaknational/oak-components";
 import Head from "next/head";
 import { Lexend } from "next/font/google";
 
@@ -29,7 +34,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <Head>
-        <OakGlobalStyles />
+        <OakGlobalStyle />
       </Head>
       <body className={lexend.className}>
         <OakThemeProvider theme={oakDefaultTheme}>{children}</OakThemeProvider>


### PR DESCRIPTION
It was not abundantly clear that the example used the App router rather than Pages. We could also add a working example for the Pages router.

# How to review this PR

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports
