### PR TITLE
[ENG-813] Consent banner stacked in front of modals

### DIFF
--- a/src/components/molecules/OakModal/OakModal.tsx
+++ b/src/components/molecules/OakModal/OakModal.tsx
@@ -47,6 +47,9 @@ export type OakModalProps = {
    *
    * Defaults to token: `modal-dialog`
    *
+   * 🚨 This prop is intended for use by consumers that do not use
+   * the internal system of z-index tokens.
+   *
    * NB *The modal is rendered inside a portal so it will not respect the stacking context of its parent component*.
    */
   zIndex?: number;

--- a/src/components/organisms/OakCookieBanner/OakCookieBanner.tsx
+++ b/src/components/organisms/OakCookieBanner/OakCookieBanner.tsx
@@ -49,7 +49,10 @@ export type OakCookieBannerProps = {
   /**
    * Optional z-index override of the banner.
    *
-   * Defaults to token: `in-front`
+   * Defaults to token: `banner`
+   *
+   * 🚨 This prop is intended for use by consumers that do not use
+   * the internal system of z-index tokens.
    */
   zIndex?: number;
 };
@@ -67,6 +70,15 @@ export const OakCookieBanner = ({
   isFixed = false,
   zIndex,
 }: OakCookieBannerProps) => {
+  const finalZIndex = (() => {
+    if (typeof zIndex === "number") {
+      return zIndex;
+    }
+    if (isFixed) {
+      return "banner";
+    }
+  })();
+
   return (
     <OakBox
       $background="bg-neutral"
@@ -76,9 +88,7 @@ export const OakCookieBanner = ({
       $bottom={isFixed ? "all-spacing-0" : undefined}
       $right={isFixed ? "all-spacing-0" : undefined}
       $left={isFixed ? "all-spacing-0" : undefined}
-      $zIndex={
-        typeof zIndex === "number" ? zIndex : isFixed ? "in-front" : undefined
-      }
+      $zIndex={finalZIndex}
       $color="text-primary"
       data-testid="cookie-banner"
     >

--- a/src/components/organisms/OakCookieConsent/OakCookieConsent.tsx
+++ b/src/components/organisms/OakCookieConsent/OakCookieConsent.tsx
@@ -14,6 +14,9 @@ export type OakCookieConsentProps = Pick<
   Pick<OakCookieBannerProps, "isFixed" | "innerMaxWidth"> & {
     /**
      * Optional stacking context for the entire consent UI
+     *
+     * 🚨 This prop is intended for use by consumers that do not use
+     * the internal system of z-index tokens.
      */
     zIndex?: number;
   };

--- a/src/styles/theme/zIndex.ts
+++ b/src/styles/theme/zIndex.ts
@@ -1,11 +1,18 @@
+// For help with defining z-index values, refer to this article:
+// https://www.smashingmagazine.com/2021/02/css-z-index-large-projects/#a-new-solution
+const behind = -1;
+const modalDialog = 300;
+const banner = behind + modalDialog;
+
 export const oakZIndexTokens = {
-  behind: -1,
+  behind,
   neutral: 0,
   "in-front": 1,
   "mobile-filters": 2,
   "fixed-header": 100,
   "modal-close-button": 150,
-  "modal-dialog": 300,
-};
+  "modal-dialog": modalDialog,
+  banner,
+} as const;
 
 export type OakZIndexToken = keyof typeof oakZIndexTokens | null;


### PR DESCRIPTION
# How to review this PR

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

We need to ensure that the cookie banner is rendered above all the content on the page but still allow the app to function while it is visible . We discovered that modals were being rendered below the banner owing to the z-index being overridden and the default `in-front` being insufficient to stack it above.

I looked at introducing some sort of React context->provider layer manager thingy to create portals and manage z-indices. But that is a lot of maintenance and would require future developers to have knowledge of its purpose when creating new components that need to stack.

So a simple but tidy thing we can do is add a constant that ensures the consent banner (and other future banners) will be stacked behind all modals. This constant should communicate its intent to future developers while making it hard to regress and/or miss 

## Testing instructions

There isn't much to test here since the issue only presents itself in OWA currently — there will be a PR there where the fix can be verified
