### PR TITLE
feat: prop for passing cms image

### DIFF
--- a/src/components/organisms/OakHeaderHero/OakHeaderHero.tsx
+++ b/src/components/organisms/OakHeaderHero/OakHeaderHero.tsx
@@ -21,6 +21,7 @@ export type OakHeaderHeroProps = {
   heroImageAlt: string;
   authorImageAlt: string;
   breadcrumbs: ReactElement;
+  cmsImage?: ReactElement;
   children?: ReactNode;
 };
 
@@ -46,6 +47,7 @@ const UnstyledComponent = (props: OakHeaderHeroProps) => {
     authorImageSrc,
     heroImageAlt,
     authorImageAlt,
+    cmsImage,
   } = props;
   return (
     <OakBox
@@ -129,19 +131,27 @@ const UnstyledComponent = (props: OakHeaderHeroProps) => {
               "space-between-none",
             ]}
           >
-            <OakImage
-              $transform={"rotate(-2.025deg)"}
-              src={heroImageSrc}
-              width={100}
-              $minHeight={[
-                "all-spacing-19",
-                "all-spacing-20",
-                "all-spacing-20",
-              ]}
-              $minWidth={["all-spacing-19", "all-spacing-22", "all-spacing-21"]}
-              alt={heroImageAlt}
-              $zIndex={"in-front"}
-            />
+            {cmsImage ? (
+              cmsImage
+            ) : (
+              <OakImage
+                $transform={"rotate(-2.025deg)"}
+                src={heroImageSrc}
+                width={100}
+                $minHeight={[
+                  "all-spacing-19",
+                  "all-spacing-20",
+                  "all-spacing-20",
+                ]}
+                $minWidth={[
+                  "all-spacing-19",
+                  "all-spacing-22",
+                  "all-spacing-21",
+                ]}
+                alt={heroImageAlt}
+                $zIndex={"in-front"}
+              />
+            )}
             <OakFlex
               $position={"absolute"}
               $top={"all-spacing-0"}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Adds an option prop from cms image 

Domain for images is sanity -  https://www.notion.so/oaknationalacademy/Refactor-plan-a-lesson-page-images-79e3956b5dea40139f0b8e1ec9792c79

## A link to the component in the deployment preview

https://deploy-preview-220--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-oakheaderhero--docs

## Testing instructions

Should behave the same

## ACs
