### PR TITLE
feat: oak-secondary-button-as-radio

### DIFF
--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.stories.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.stories.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakButtonAsRadioGroup } from "@/components/molecules/OakButtonAsRadioGroup";
+import { colorArgTypes } from "@/storybook-helpers/colorStyleHelpers";
+import { typographyArgTypes } from "@/storybook-helpers/typographyStyleHelpers";
+import { flexArgTypes } from "@/storybook-helpers/flexStyleHelpers";
+import { OakSecondaryButtonAsRadio } from "@/components/molecules/OakSecondaryButtonAsRadio";
+
+const meta: Meta<typeof OakButtonAsRadioGroup> = {
+  component: OakButtonAsRadioGroup,
+  tags: ["autodocs"],
+  title: "components/molecules/OakButtonAsRadioGroup",
+  argTypes: {
+    ...flexArgTypes,
+    ...colorArgTypes,
+    ...typographyArgTypes,
+    disabled: { boolean: true },
+  },
+  parameters: {
+    controls: {
+      include: [
+        "disabled",
+        "$flexDirection",
+        "$gap",
+        "$alignItems",
+        "$font",
+        ...Object.keys(colorArgTypes),
+      ],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof OakButtonAsRadioGroup>;
+
+export const Default: Story = {
+  render: (args) => {
+    return (
+      <OakButtonAsRadioGroup {...args}>
+        <OakSecondaryButtonAsRadio value="1">
+          Option 1
+        </OakSecondaryButtonAsRadio>
+        <OakSecondaryButtonAsRadio value="2">
+          Option 2
+        </OakSecondaryButtonAsRadio>
+        <OakSecondaryButtonAsRadio value="3">
+          Option 3
+        </OakSecondaryButtonAsRadio>
+      </OakButtonAsRadioGroup>
+    );
+  },
+  args: {
+    name: "test",
+  },
+};

--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.stories.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.stories.tsx
@@ -15,11 +15,15 @@ const meta: Meta<typeof OakButtonAsRadioGroup> = {
     ...flexArgTypes,
     ...colorArgTypes,
     ...typographyArgTypes,
-    disabled: { boolean: true },
+    defaultValue: { control: "select", options: ["1", "2", "3"] },
+    label: { control: "text" },
+    name: { control: "text" },
+    ariaLabel: { control: "text" },
+    ariaLabelledby: { control: "text" },
   },
   parameters: {
     controls: {
-      include: [],
+      include: ["defaultValue", "ariaLabel", "ariaLabelledby", "label", "name"],
     },
   },
 };
@@ -45,7 +49,6 @@ export const Default: Story = {
   },
   args: {
     name: "test",
-    defaultValue: "1",
     ariaLabel: "test options",
   },
 };

--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.stories.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.stories.tsx
@@ -52,5 +52,6 @@ export const Default: Story = {
   },
   args: {
     name: "test",
+    defaultValue: "1",
   },
 };

--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.stories.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.stories.tsx
@@ -19,14 +19,7 @@ const meta: Meta<typeof OakButtonAsRadioGroup> = {
   },
   parameters: {
     controls: {
-      include: [
-        "disabled",
-        "$flexDirection",
-        "$gap",
-        "$alignItems",
-        "$font",
-        ...Object.keys(colorArgTypes),
-      ],
+      include: [],
     },
   },
 };
@@ -53,5 +46,6 @@ export const Default: Story = {
   args: {
     name: "test",
     defaultValue: "1",
+    ariaLabel: "test options",
   },
 };

--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.test.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { create } from "react-test-renderer";
+import { render, waitFor } from "@testing-library/react";
 
 import { OakButtonAsRadioGroup } from "./OakButtonAsRadioGroup";
 
@@ -8,7 +9,7 @@ import { OakThemeProvider } from "@/components/atoms";
 import { oakDefaultTheme } from "@/styles/theme";
 import { OakSecondaryButtonAsRadio } from "@/components/molecules/OakSecondaryButtonAsRadio";
 
-describe("OakSecondaryButtonAsRadio", () => {
+describe("OakButtonAsRadioGroup", () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
@@ -20,5 +21,72 @@ describe("OakSecondaryButtonAsRadio", () => {
       </OakThemeProvider>,
     ).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it("will not render without a label of some kind", () => {
+    jest.spyOn(console, "error").mockImplementation(() => jest.fn());
+    expect(() =>
+      render(
+        <OakThemeProvider theme={oakDefaultTheme}>
+          <OakButtonAsRadioGroup name={"test"}>
+            <OakSecondaryButtonAsRadio value="1">
+              Display Value
+            </OakSecondaryButtonAsRadio>
+          </OakButtonAsRadioGroup>
+        </OakThemeProvider>,
+      ),
+    ).toThrow(
+      "OakButtonAsRadioGroup: At least one of label, ariaLabel or ariaLabelledby is required",
+    );
+    jest.restoreAllMocks();
+  });
+
+  it("calls the onChange callback passing the selected value when a radio button is clicked", async () => {
+    const onChange = jest.fn();
+    const { getByRole } = render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakButtonAsRadioGroup
+          name={"test"}
+          ariaLabel="test"
+          onChange={onChange}
+        >
+          <OakSecondaryButtonAsRadio value="1">
+            Display Value
+          </OakSecondaryButtonAsRadio>
+        </OakButtonAsRadioGroup>
+      </OakThemeProvider>,
+    );
+
+    const button = getByRole("radio");
+    button.click();
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith("1");
+    });
+  });
+
+  it("sets the default value when defaultValue is provided", async () => {
+    const onChange = jest.fn();
+    const { getByText } = render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakButtonAsRadioGroup
+          name={"test"}
+          ariaLabel="test"
+          onChange={onChange}
+          defaultValue="2"
+        >
+          <OakSecondaryButtonAsRadio value="1">
+            Value 1
+          </OakSecondaryButtonAsRadio>
+          <OakSecondaryButtonAsRadio value="2">
+            Value 2
+          </OakSecondaryButtonAsRadio>
+        </OakButtonAsRadioGroup>
+      </OakThemeProvider>,
+    );
+
+    const buttonSpan = getByText("Value 2");
+    const button = buttonSpan.closest('[role="radio"]');
+    expect(button).toHaveAttribute("aria-checked", "true");
   });
 });

--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.test.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.test.tsx
@@ -12,7 +12,7 @@ describe("OakSecondaryButtonAsRadio", () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <OakButtonAsRadioGroup name={"test"}>
+        <OakButtonAsRadioGroup name={"test"} ariaLabel="test">
           <OakSecondaryButtonAsRadio value="1">
             Display Value
           </OakSecondaryButtonAsRadio>

--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.test.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+
+import { OakButtonAsRadioGroup } from "./OakButtonAsRadioGroup";
+
+import { OakThemeProvider } from "@/components/atoms";
+import { oakDefaultTheme } from "@/styles/theme";
+import { OakSecondaryButtonAsRadio } from "@/components/molecules/OakSecondaryButtonAsRadio";
+
+describe("OakSecondaryButtonAsRadio", () => {
+  it("matches snapshot", () => {
+    const tree = create(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakButtonAsRadioGroup name={"test"}>
+          <OakSecondaryButtonAsRadio value="1">
+            Display Value
+          </OakSecondaryButtonAsRadio>
+        </OakButtonAsRadioGroup>
+      </OakThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.tsx
@@ -41,13 +41,15 @@ export type OakButtonAsRadioGroupProps = {
 
 /**
  *
- * OakButtonAsRadioGroup allow users to select a single item from a list of mutually exclusive options (buttons) .
- * OakButtonAsRadioGroup consists of a set of OakButtonsAsRadios. Each radio includes a label and a visual selection indicator. A single radio button within the group can be selected at a time. Users may click or touch a radio button to select it, or use the Tab key to navigate to the group, the arrow keys to navigate within the group, and the Space key to select an option.
+ * A react context supporting a list of mutually exclusive options rendered as buttons.
+ *
  * ## Usage
  *
- * use the callback onChange to get the value of the selected radio button.
+ * the nested items should be OakSecondaryButtonAsRadio or implement the same logic.
+ * use the callback onChange to get the value of the clicked button.
  *
  */
+
 export const OakButtonAsRadioGroup = (props: OakButtonAsRadioGroupProps) => {
   const {
     name,

--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.tsx
@@ -19,6 +19,8 @@ export const RadioContext = createContext<RadioContextType>({
 
 export type OakButtonAsRadioGroupProps = {
   label?: string;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
   name: string;
   disabled?: boolean;
   children: React.ReactNode;
@@ -51,6 +53,8 @@ export const OakButtonAsRadioGroup = (props: OakButtonAsRadioGroupProps) => {
     name,
     children,
     label,
+    ariaLabel,
+    ariaLabelledby,
     onChange,
     $font = "body-1-bold",
     $gap = "space-between-s",
@@ -62,6 +66,12 @@ export const OakButtonAsRadioGroup = (props: OakButtonAsRadioGroupProps) => {
 
   const [currentValue, setValue] = useState(defaultValue);
 
+  if (!label && !ariaLabel && !ariaLabelledby) {
+    throw new Error(
+      "OakButtonAsRadioGroup: At least one of label, ariaLabel or ariaLabelledby is required",
+    );
+  }
+
   const handleValueUpdated = (newValue: string) => {
     if (value === undefined) {
       setValue(newValue);
@@ -72,7 +82,13 @@ export const OakButtonAsRadioGroup = (props: OakButtonAsRadioGroupProps) => {
   };
 
   return (
-    <OakFlex role="radiogroup" $gap={$gap} {...rest}>
+    <OakFlex
+      role="radiogroup"
+      $gap={$gap}
+      {...rest}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
+    >
       {label && <OakLabel $font={$font}>{label}</OakLabel>}
       <RadioContext.Provider
         value={{

--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.tsx
@@ -1,0 +1,89 @@
+import React, { createContext, useState } from "react";
+
+import { TypographyStyleProps } from "@/styles/utils/typographyStyle";
+import { ColorStyleProps } from "@/styles/utils/colorStyle";
+import { OakFlex, OakLabel } from "@/components/atoms";
+import { FlexStyleProps } from "@/styles/utils/flexStyle";
+
+type RadioContextType = {
+  currentValue: string;
+  name: string;
+  disabled?: boolean;
+  onValueUpdated?: (value: string) => void;
+};
+
+export const RadioContext = createContext<RadioContextType>({
+  currentValue: "default",
+  name: "default",
+});
+
+export type OakButtonAsRadioGroupProps = {
+  label?: string;
+  name: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+  onChange?: (value: string) => void;
+  /**
+   * Sets the value of the radio group
+   * for use as a controlled component
+   */
+  value?: string;
+  /**
+   * Sets the initial value of the radio group
+   * for use as an uncontrolled component
+   */
+  defaultValue?: string;
+} & Pick<TypographyStyleProps, "$font"> &
+  ColorStyleProps &
+  Pick<FlexStyleProps, "$flexDirection" | "$alignItems" | "$gap">;
+
+/**
+ *
+ * OakButtonAsRadioGroup allow users to select a single item from a list of mutually exclusive options (buttons) .
+ * OakButtonAsRadioGroup consists of a set of OakButtonsAsRadios. Each radio includes a label and a visual selection indicator. A single radio button within the group can be selected at a time. Users may click or touch a radio button to select it, or use the Tab key to navigate to the group, the arrow keys to navigate within the group, and the Space key to select an option.
+ * ## Usage
+ *
+ * use the callback onChange to get the value of the selected radio button.
+ *
+ */
+export const OakButtonAsRadioGroup = (props: OakButtonAsRadioGroupProps) => {
+  const {
+    name,
+    children,
+    label,
+    onChange,
+    $font = "body-1-bold",
+    $gap = "space-between-s",
+    disabled,
+    value,
+    defaultValue = "",
+    ...rest
+  } = props;
+
+  const [currentValue, setValue] = useState(defaultValue);
+
+  const handleValueUpdated = (newValue: string) => {
+    if (value === undefined) {
+      setValue(newValue);
+    }
+    if (onChange) {
+      onChange(newValue);
+    }
+  };
+
+  return (
+    <OakFlex role="radiogroup" $gap={$gap} {...rest}>
+      {label && <OakLabel $font={$font}>{label}</OakLabel>}
+      <RadioContext.Provider
+        value={{
+          currentValue: value ?? currentValue,
+          name,
+          disabled: disabled,
+          onValueUpdated: handleValueUpdated,
+        }}
+      >
+        {children}
+      </RadioContext.Provider>
+    </OakFlex>
+  );
+};

--- a/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
+exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
 .c0 {
   font-family: Lexend,sans-serif;
 }

--- a/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
@@ -155,6 +155,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
       className="c4 yellow-shadow"
     />
     <button
+      aria-checked={false}
       className="c5 c6 internal-button"
       onClick={[Function]}
       onMouseEnter={[Function]}

--- a/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
@@ -141,6 +141,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
 }
 
 <div
+  aria-label="test"
   className="c0 c1"
   role="radiogroup"
 >

--- a/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c4 {
+  position: absolute;
+  top: 0rem;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 1rem;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.c8 {
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  text-align: left;
+}
+
+.c5 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  color: #222222;
+  background: #ffffff;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.25rem;
+}
+
+.c5:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: inline-block;
+}
+
+.c6:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #222222;
+  background: #f2f2f2;
+  border-color: #222222;
+}
+
+.c6:active {
+  background: #ffffff;
+  border-color: #222222;
+  color: #222222;
+}
+
+.c6:disabled {
+  background: #e4e4e4;
+  border-color: #808080;
+  color: #808080;
+}
+
+.c3 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c3 .yellow-shadow:has(+ .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
+}
+
+.c3 .yellow-shadow:has(+ .internal-button:hover),
+.c3 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+.c3 .grey-shadow:has(+ * + .internal-button:hover) {
+  box-shadow: none;
+}
+
+.c3 .grey-shadow:has(+ * + .internal-button:active) {
+  box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
+}
+
+.c3 .yellow-shadow:has(+ .internal-button:active) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+<div
+  className="c0 c1"
+  role="radiogroup"
+>
+  <div
+    className="c2 c3"
+  >
+    <div
+      className="c4 grey-shadow"
+    />
+    <div
+      className="c4 yellow-shadow"
+    />
+    <button
+      className="c5 c6 internal-button"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      role="radio"
+    >
+      <div
+        className="c0 c7"
+      >
+        <span
+          className="c8"
+        >
+          Display Value
+        </span>
+      </div>
+    </button>
+  </div>
+</div>
+`;

--- a/src/components/molecules/OakButtonAsRadioGroup/index.ts
+++ b/src/components/molecules/OakButtonAsRadioGroup/index.ts
@@ -1,0 +1,1 @@
+export { OakButtonAsRadioGroup } from "./OakButtonAsRadioGroup";

--- a/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.stories.tsx
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.stories.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { StoryObj, Meta } from "@storybook/react";
+
+import { OakSecondaryButtonAsRadio } from "./OakSecondaryButtonAsRadio";
+
+const meta: Meta<typeof OakSecondaryButtonAsRadio> = {
+  component: OakSecondaryButtonAsRadio,
+  tags: ["autodocs"],
+  argTypes: {},
+  parameters: {
+    controls: {
+      include: ["type"],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OakSecondaryButtonAsRadio>;
+
+export const Default: Story = {
+  render: () => (
+    <OakSecondaryButtonAsRadio value="option-1">
+      Option 1
+    </OakSecondaryButtonAsRadio>
+  ),
+};

--- a/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.test.tsx
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+
+import { OakSecondaryButtonAsRadio } from "./OakSecondaryButtonAsRadio";
+
+import { OakThemeProvider } from "@/components/atoms";
+import { oakDefaultTheme } from "@/styles/theme";
+
+describe("OakSecondaryButtonAsRadio", () => {
+  it("matches snapshot", () => {
+    const tree = create(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakSecondaryButtonAsRadio value="1">
+          Display Value
+        </OakSecondaryButtonAsRadio>
+      </OakThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.tsx
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.tsx
@@ -36,6 +36,7 @@ export const OakSecondaryButtonAsRadio = ({
   ) : (
     <OakSecondaryButton
       role="radio"
+      aria-checked={checked}
       onClick={() => onValueUpdated && onValueUpdated(value)}
     >
       {children}

--- a/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.tsx
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.tsx
@@ -1,0 +1,45 @@
+import React, { useContext } from "react";
+
+import { OakSecondaryButton } from "@/components/molecules/OakSecondaryButton";
+import { RadioContext } from "@/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup";
+import { InternalShadowRectButton } from "@/components/molecules/InternalShadowRectButton";
+
+export type OakSecondaryButtonAsRadioProps = {
+  children?: React.ReactNode;
+  value: string;
+};
+
+export const OakSecondaryButtonAsRadio = ({
+  children,
+  value,
+}: OakSecondaryButtonAsRadioProps) => {
+  const radioContext = useContext(RadioContext);
+  const { currentValue, onValueUpdated } = radioContext;
+  const checked = currentValue === value;
+
+  return checked ? (
+    <InternalShadowRectButton
+      role="radio"
+      defaultBorderColor="bg-btn-primary"
+      defaultBackground="bg-btn-primary"
+      defaultTextColor="text-inverted"
+      hoverBackground="bg-btn-primary-hover"
+      hoverBorderColor="bg-btn-primary-hover"
+      hoverTextColor="text-inverted"
+      disabledBackground="bg-btn-primary"
+      disabledBorderColor="bg-btn-primary"
+      disabledTextColor="text-inverted"
+      disabled
+      aria-checked={checked}
+    >
+      {children}
+    </InternalShadowRectButton>
+  ) : (
+    <OakSecondaryButton
+      role="radio"
+      onClick={() => onValueUpdated && onValueUpdated(value)}
+    >
+      {children}
+    </OakSecondaryButton>
+  );
+};

--- a/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.tsx
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.tsx
@@ -9,6 +9,18 @@ export type OakSecondaryButtonAsRadioProps = {
   value: string;
 };
 
+/**
+ *
+ * To be used as a child of OakButtonAsRadioGroup.
+ * Highlights when the value matches the current value of the group.
+ * Changes the current value of the group when clicked.
+ *
+ * ## Usage
+ *
+ * See OakButtonAsRadioGroup.
+ *
+ */
+
 export const OakSecondaryButtonAsRadio = ({
   children,
   value,

--- a/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.tsx
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/OakSecondaryButtonAsRadio.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 
 import { OakSecondaryButton } from "@/components/molecules/OakSecondaryButton";
 import { RadioContext } from "@/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup";
-import { InternalShadowRectButton } from "@/components/molecules/InternalShadowRectButton";
+import { OakPrimaryButton } from "@/components/molecules/OakPrimaryButton";
 
 export type OakSecondaryButtonAsRadioProps = {
   children?: React.ReactNode;
@@ -18,22 +18,9 @@ export const OakSecondaryButtonAsRadio = ({
   const checked = currentValue === value;
 
   return checked ? (
-    <InternalShadowRectButton
-      role="radio"
-      defaultBorderColor="bg-btn-primary"
-      defaultBackground="bg-btn-primary"
-      defaultTextColor="text-inverted"
-      hoverBackground="bg-btn-primary-hover"
-      hoverBorderColor="bg-btn-primary-hover"
-      hoverTextColor="text-inverted"
-      disabledBackground="bg-btn-primary"
-      disabledBorderColor="bg-btn-primary"
-      disabledTextColor="text-inverted"
-      disabled
-      aria-checked={checked}
-    >
+    <OakPrimaryButton role="radio" aria-checked={checked}>
       {children}
-    </InternalShadowRectButton>
+    </OakPrimaryButton>
   ) : (
     <OakSecondaryButton
       role="radio"

--- a/src/components/molecules/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
@@ -142,6 +142,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
     className="c2 yellow-shadow"
   />
   <button
+    aria-checked={false}
     className="c3 c4 internal-button"
     onClick={[Function]}
     onMouseEnter={[Function]}

--- a/src/components/molecules/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
@@ -1,0 +1,162 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c2 {
+  position: absolute;
+  top: 0rem;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c5 {
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.c7 {
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  text-align: left;
+}
+
+.c3 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  color: #222222;
+  background: #ffffff;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.25rem;
+}
+
+.c3:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: inline-block;
+}
+
+.c4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #222222;
+  background: #f2f2f2;
+  border-color: #222222;
+}
+
+.c4:active {
+  background: #ffffff;
+  border-color: #222222;
+  color: #222222;
+}
+
+.c4:disabled {
+  background: #e4e4e4;
+  border-color: #808080;
+  color: #808080;
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:hover),
+.c1 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:hover) {
+  box-shadow: none;
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:active) {
+  box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:active) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+<div
+  className="c0 c1"
+>
+  <div
+    className="c2 grey-shadow"
+  />
+  <div
+    className="c2 yellow-shadow"
+  />
+  <button
+    className="c3 c4 internal-button"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    role="radio"
+  >
+    <div
+      className="c5 c6"
+    >
+      <span
+        className="c7"
+      >
+        Display Value
+      </span>
+    </div>
+  </button>
+</div>
+`;

--- a/src/components/molecules/OakSecondaryButtonAsRadio/index.ts
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakSecondaryButtonAsRadio";

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -28,3 +28,5 @@ export * from "./OakAccordion";
 export * from "./OakModal";
 export * from "./OakModalCenter";
 export * from "./OakCardWithHandDrawnBorder";
+export * from "./OakSecondaryButtonAsRadio";
+export * from "./OakButtonAsRadioGroup";

--- a/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.stories.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.stories.tsx
@@ -8,6 +8,10 @@ import { OakPupilJourneyList } from "./OakPupilJourneyList";
 
 import { OakPupilJourneyListItem } from "@/components/organisms/pupil/OakPupilJourneyListItem";
 import { OakPupilJourneyHeader } from "@/components/organisms/pupil/OakPupilJourneyHeader";
+import {
+  OakButtonAsRadioGroup,
+  OakSecondaryButtonAsRadio,
+} from "@/components/molecules";
 
 const meta: Meta<typeof OakPupilJourneyList> = {
   component: OakPupilJourneyList,
@@ -65,6 +69,44 @@ export const NoTitle: Story = {
           numberOfLessons={10}
           listItems={["test 1", "test 2", "test 3"]}
         />
+      }
+    >
+      <OakPupilJourneyListItem title="Lesson 1" index={1} href="#" />
+      <OakPupilJourneyListItem title="Lesson 2" index={2} href="#" />
+      <OakPupilJourneyListItem title="Lesson 3" index={3} href="#" />
+    </OakPupilJourneyList>
+  ),
+
+  args: {
+    phase: "primary",
+  },
+};
+
+export const WithFilter: Story = {
+  render: (args) => (
+    <OakPupilJourneyList
+      {...args}
+      titleSlot={
+        <OakPupilJourneyHeader
+          title="Primary Lessons"
+          iconName="subject-maths"
+          breadcrumbs={["first", "second", "third"]}
+        />
+      }
+      counterSlot={
+        <OakPupilJourneyListCounter
+          count={10}
+          countHeader="New lessons"
+          tag={"h2"}
+        />
+      }
+      filterSlot={
+        <OakButtonAsRadioGroup ariaLabelledby="test" name="test">
+          <OakSecondaryButtonAsRadio value="all">All</OakSecondaryButtonAsRadio>
+          <OakSecondaryButtonAsRadio value="1">
+            Option 1
+          </OakSecondaryButtonAsRadio>
+        </OakButtonAsRadioGroup>
       }
     >
       <OakPupilJourneyListItem title="Lesson 1" index={1} href="#" />

--- a/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.tsx
@@ -7,7 +7,43 @@ export type OakPupilJourneyListProps = {
   children: React.ReactNode;
   phase: "primary" | "secondary";
   titleSlot?: React.ReactNode;
+  filterSlot?: React.ReactNode;
   counterSlot: React.ReactNode;
+};
+
+const Slots = ({
+  titleSlot,
+  filterSlot,
+  counterSlot,
+}: Pick<
+  OakPupilJourneyListProps,
+  "titleSlot" | "filterSlot" | "counterSlot"
+>) => {
+  if (titleSlot) {
+    return (
+      <OakFlex
+        $flexDirection={"column"}
+        $gap={["space-between-m", "space-between-m2", "space-between-m2"]}
+      >
+        {titleSlot}
+        <OakHandDrawnHR hrColor={"white"} $height={"all-spacing-1"} />
+        <OakFlex $flexDirection={"column"} $gap={"space-between-m"}>
+          {filterSlot && (
+            <OakFlex $background={"red50"} $justifyContent={"end"}>
+              {filterSlot}
+            </OakFlex>
+          )}
+          <OakFlex $background={"red50"}>{counterSlot}</OakFlex>
+        </OakFlex>
+      </OakFlex>
+    );
+  } else {
+    return (
+      <OakFlex $pt={"inner-padding-xl"} $background={"red50"}>
+        {counterSlot}
+      </OakFlex>
+    );
+  }
 };
 
 /**
@@ -22,6 +58,7 @@ export const OakPupilJourneyList = ({
   phase,
   titleSlot,
   counterSlot,
+  filterSlot,
 }: OakPupilJourneyListProps) => {
   const outerBackgroundColor =
     phase === "primary"
@@ -29,23 +66,19 @@ export const OakPupilJourneyList = ({
       : "bg-decorative3-very-subdued";
   const backgroundColor =
     phase === "primary" ? "bg-decorative4-subdued" : "bg-decorative3-subdued";
+
   return (
     <OakFlex
       $flexDirection={"column"}
       $width={["100%", "all-spacing-22", "all-spacing-23"]}
       $background={outerBackgroundColor}
+      $gap={"space-between-m"}
     >
-      {titleSlot && (
-        <OakFlex
-          $flexDirection={"column"}
-          $gap={["space-between-m", "space-between-m2", "space-between-m2"]}
-        >
-          {titleSlot}
-          <OakHandDrawnHR hrColor={"white"} $height={"all-spacing-1"} />
-        </OakFlex>
-      )}
-      <OakFlex $mv={"space-between-m"}>{counterSlot}</OakFlex>
-
+      <Slots
+        titleSlot={titleSlot}
+        filterSlot={filterSlot}
+        counterSlot={counterSlot}
+      />
       <OakFlex
         $flexDirection={"column"}
         $pa={"inner-padding-m"}

--- a/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.tsx
@@ -29,20 +29,14 @@ const Slots = ({
         <OakHandDrawnHR hrColor={"white"} $height={"all-spacing-1"} />
         <OakFlex $flexDirection={"column"} $gap={"space-between-m"}>
           {filterSlot && (
-            <OakFlex $background={"red50"} $justifyContent={"end"}>
-              {filterSlot}
-            </OakFlex>
+            <OakFlex $justifyContent={"end"}>{filterSlot}</OakFlex>
           )}
-          <OakFlex $background={"red50"}>{counterSlot}</OakFlex>
+          <OakFlex>{counterSlot}</OakFlex>
         </OakFlex>
       </OakFlex>
     );
   } else {
-    return (
-      <OakFlex $pt={"inner-padding-xl"} $background={"red50"}>
-        {counterSlot}
-      </OakFlex>
-    );
+    return <OakFlex $pt={"inner-padding-xl"}>{counterSlot}</OakFlex>;
   }
 };
 

--- a/src/components/organisms/pupil/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
@@ -8,8 +8,7 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
 }
 
 .c2 {
-  margin-top: 1.5rem;
-  margin-bottom: 1.5rem;
+  padding-top: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -28,6 +27,7 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 1.5rem;
 }
 
 .c3 {

--- a/src/components/organisms/pupil/OakPupilJourneyPreviousLessons/OakPupilJourneyPreviousLessons.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyPreviousLessons/OakPupilJourneyPreviousLessons.tsx
@@ -31,7 +31,7 @@ export const OakPupilJourneyPreviousLessons = (
       $flexGrow={[null, 1]}
       $alignItems={["flex-start", "center"]}
       $gap={"space-between-m"}
-      $mt={"space-between-m2"}
+      $pt={"inner-padding-xl"}
     >
       <OakPupilJourneyListCounter
         tag="h1"

--- a/src/components/organisms/pupil/OakPupilJourneyPreviousLessons/__snapshots__/OakPupilJourneyPreviousLessons.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyPreviousLessons/__snapshots__/OakPupilJourneyPreviousLessons.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakPupilJourneyPreviousLessons matches snapshot 1`] = `
 [
   " ",
   .c0 {
-  margin-top: 2rem;
+  padding-top: 1.5rem;
   font-family: Lexend,sans-serif;
 }
 


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

### Job Story

A group of oak secondary buttons which behave like a radio group to be used for the subject category filters on the unit listing page

## Link to the design doc

https://www.figma.com/design/zqpeecgzMGKRli2gUdJOLp/Pupil-Browse?node-id=5536-197199&m=dev

## A link to the component in the deployment preview

https://deploy-preview-223--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oakbuttonasradiogroup--docs

https://deploy-preview-223--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oaksecondarybuttonasradio--docs

## Testing instructions

- run the test suite
- try clicking on a button
- change the default button

## ACs

- [x]  matches design
- [x]  callback for value changed
- [x]  acts like a radio button group
- [x]  WCAG compliant
- [x]  tests
- [x]  docs
