### PR TITLE
feat: added filter slot and refactored

### DIFF
--- a/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.tsx
@@ -11,6 +11,16 @@ export type OakPupilJourneyListProps = {
   counterSlot: React.ReactNode;
 };
 
+/*
+ 
+FIXME: 
+This component falls into the swiss army knife trap. 
+Conditional logic is being used to handle a range of specific layout needs at a higher level in the tree.
+It would be better to decompose this component and recompose more specific components handling the specific layout needs.
+However, I do not want to introduce break changes in this PR.
+
+*/
+
 const Slots = ({
   titleSlot,
   filterSlot,
@@ -21,13 +31,13 @@ const Slots = ({
 >) => {
   if (titleSlot) {
     return (
-      <OakFlex
-        $flexDirection={"column"}
-        $gap={["space-between-m", "space-between-m2", "space-between-m2"]}
-      >
-        {titleSlot}
-        <OakHandDrawnHR hrColor={"white"} $height={"all-spacing-1"} />
-        <OakFlex $flexDirection={"column"} $gap={"space-between-m"}>
+      <OakFlex $flexDirection={"column"} $gap={"space-between-m"}>
+        <OakFlex $flexDirection={"column"} $gap={"space-between-m2"}>
+          {titleSlot}
+          <OakHandDrawnHR hrColor={"white"} $height={"all-spacing-1"} />
+        </OakFlex>
+
+        <OakFlex $flexDirection={"column"} $gap={"space-between-m2"}>
           {filterSlot && (
             <OakFlex $justifyContent={"end"}>{filterSlot}</OakFlex>
           )}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

**When** using OakPupilJourneyList,
**I want to add a filter component**
**So that the user can filter subjects**.

I've had to do a little bit of refactoring inside the component to get this to work. But my long term preference would be to split OakPupilJourney which seems to cover too many layout conditions to be a single component.

## Link to the design doc

https://www.figma.com/design/zqpeecgzMGKRli2gUdJOLp/Pupil-Browse?node-id=5646-7377&m=dev

## A link to the component in the deployment preview

?path=/story/components-organisms-pupil-oakpupiljourneylist--default

## Testing instructions

- look at all 3 use cases in the storybook and confirm that the designs match

## ACs

- [x]  component appears in the correct positioning
- [x]  prop exposed for filterSlot
