### PR TITLE
fix: change heading tag to h1

### DIFF
--- a/src/components/organisms/OakHeaderHero/OakHeaderHero.tsx
+++ b/src/components/organisms/OakHeaderHero/OakHeaderHero.tsx
@@ -89,7 +89,7 @@ const UnstyledComponent = (props: OakHeaderHeroProps) => {
               $justifyContent={"center"}
             >
               <OakHeading
-                tag="h2"
+                tag="h1"
                 $color={"grey80"}
                 $font={["heading-4", "heading-3"]}
                 $mb={"space-between-m"}

--- a/src/components/organisms/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
+++ b/src/components/organisms/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
@@ -547,11 +547,11 @@ exports[`OakHeaderHero matches snapshot 1`] = `
         <div
           className="c10 c11"
         >
-          <h2
+          <h1
             className="c12"
           >
             How to plan a lesson: a helpful guide for teachers
-          </h2>
+          </h1>
           <div
             className="c13 c14"
           >


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- change heading level for oakHeaderHero to h1
- https://deploy-preview-226--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-oakheaderhero--docs
