### PR TITLE
Fix/pupil journey units filter

### DIFF
--- a/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.stories.tsx
+++ b/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.stories.tsx
@@ -4,16 +4,16 @@ import styled from "styled-components";
 
 import { OakHandDrawnHR } from "../OakHandDrawnHR";
 
-import { InternalShadowAccordion } from "./InternalShadowAccordion";
+import { InternalChevronAccordion } from "./InternalChevronAccordion";
 
 import { OakFlex } from "@/components/atoms";
 import { PositionStyleProps } from "@/styles/utils/positionStyle";
 import { SizeStyleProps } from "@/styles/utils/sizeStyle";
 
-const meta: Meta<typeof InternalShadowAccordion> = {
-  component: InternalShadowAccordion,
+const meta: Meta<typeof InternalChevronAccordion> = {
+  component: InternalChevronAccordion,
   tags: ["autodocs"],
-  title: "components/molecules/InternalShadowAccordion",
+  title: "components/molecules/InternalChevronAccordion",
   parameters: {
     controls: {
       include: ["header", "headerAfterSlot", "children"],
@@ -37,11 +37,11 @@ const meta: Meta<typeof InternalShadowAccordion> = {
     children:
       "Any cookies required for video or other embedded learning content to work",
   },
-  render: (args) => <InternalShadowAccordion {...args} />,
+  render: (args) => <InternalChevronAccordion {...args} />,
 };
 export default meta;
 
-type Story = StoryObj<typeof InternalShadowAccordion>;
+type Story = StoryObj<typeof InternalChevronAccordion>;
 
 export const Default: Story = {};
 
@@ -54,7 +54,7 @@ const StyledHandDrawnHR = styled(OakHandDrawnHR)<
   bottom: 0.125rem;
 `;
 
-export const OutLineAccordion: Story = {
+export const OutlineAccordion: Story = {
   render: () => {
     return (
       <OakFlex
@@ -63,9 +63,9 @@ export const OutLineAccordion: Story = {
         $flexDirection={"column"}
       >
         <StyledHandDrawnHR />
-        <InternalShadowAccordion header={"Title"} id={"out-line-accordion"}>
+        <InternalChevronAccordion header={"Title"} id={"out-line-accordion"}>
           Subcopy area
-        </InternalShadowAccordion>
+        </InternalChevronAccordion>
         <StyledHandDrawnHR $position={"absolute"} $width={"100%"} />
       </OakFlex>
     );
@@ -76,14 +76,14 @@ export const OutLineAccordion: Story = {
 export const FillAccordion: Story = {
   render: () => {
     return (
-      <InternalShadowAccordion
+      <InternalChevronAccordion
         header={"Title"}
         id={"out-line-accordion"}
         $background={"bg-decorative4-very-subdued"}
         $borderRadius={"border-radius-s"}
       >
         Subcopy area
-      </InternalShadowAccordion>
+      </InternalChevronAccordion>
     );
   },
   args: {},
@@ -98,22 +98,22 @@ export const MultipleAccordions: Story = {
   render: () => {
     return (
       <>
-        <InternalShadowAccordion
+        <InternalChevronAccordion
           id="necessary-accordion"
           header="Strictly necessary"
         >
           Necessary for the website to function
-        </InternalShadowAccordion>
-        <InternalShadowAccordion
+        </InternalChevronAccordion>
+        <InternalChevronAccordion
           id="embedded-accordion"
           header="Embedded content"
         >
           Any cookies required for video or other embedded learning content to
           work
-        </InternalShadowAccordion>
-        <InternalShadowAccordion id="statistics-accordion" header="Statistics">
+        </InternalChevronAccordion>
+        <InternalChevronAccordion id="statistics-accordion" header="Statistics">
           Any cookies that may be used to track website usage
-        </InternalShadowAccordion>
+        </InternalChevronAccordion>
       </>
     );
   },

--- a/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.test.tsx
+++ b/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.test.tsx
@@ -3,19 +3,19 @@ import { create } from "react-test-renderer";
 import { act, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-import { InternalShadowAccordion } from "./InternalShadowAccordion";
+import { InternalChevronAccordion } from "./InternalChevronAccordion";
 
 import { OakThemeProvider } from "@/components/atoms";
 import { oakDefaultTheme } from "@/styles";
 import renderWithTheme from "@/test-helpers/renderWithTheme";
 
-describe(InternalShadowAccordion, () => {
+describe(InternalChevronAccordion, () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <InternalShadowAccordion initialOpen header="See more" id="see-more">
+        <InternalChevronAccordion initialOpen header="See more" id="see-more">
           Here it is
-        </InternalShadowAccordion>
+        </InternalChevronAccordion>
       </OakThemeProvider>,
     ).toJSON();
 
@@ -24,9 +24,9 @@ describe(InternalShadowAccordion, () => {
 
   it("toggles open and closed", () => {
     const { queryByRole, queryByText, getByText } = renderWithTheme(
-      <InternalShadowAccordion header="See more" id="see-more">
+      <InternalChevronAccordion header="See more" id="see-more">
         Here it is
-      </InternalShadowAccordion>,
+      </InternalChevronAccordion>,
     );
 
     expect(queryByRole("region")).not.toBeInTheDocument();

--- a/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.tsx
+++ b/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.tsx
@@ -16,7 +16,7 @@ import { FlexStyleProps, flexStyle } from "@/styles/utils/flexStyle";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
 import { ColorStyleProps } from "@/styles/utils/colorStyle";
 
-export type InternalShadowAccordionProps = {
+export type InternalChevronAccordionProps = {
   /**
    * The header of the accordion
    */
@@ -55,18 +55,14 @@ export const StyledAccordionButton = styled(
   }
 `;
 
-export const StyledAccordion = styled(InternalAccordion)<
-  OakBoxProps & FlexStyleProps
->`
+const StyledAccordion = styled(InternalAccordion)<FlexStyleProps>`
   ${StyledAccordionUnderline} {
     visibility: hidden;
   }
   ${StyledAccordionButton}:focus-visible ~ ${StyledAccordionUnderline} {
     visibility: visible;
   }
-  ${StyledAccordionButton}:active ~ ${StyledAccordionUnderline} {
-    visibility: visible;
-  }
+
   ${oakBoxCss}
   ${flexStyle}
 `;
@@ -80,7 +76,7 @@ const Accordion = ({
   children,
   id,
   ...styleProps
-}: InternalShadowAccordionProps) => {
+}: InternalChevronAccordionProps) => {
   const { isOpen } = useAccordionContext();
 
   return (
@@ -123,8 +119,8 @@ const Accordion = ({
  * other flex, box and color style proops can be passed to the accordion as props
  */
 
-export const InternalShadowAccordion = (
-  props: InternalShadowAccordionProps,
+export const InternalChevronAccordion = (
+  props: InternalChevronAccordionProps,
 ) => {
   return (
     <InternalAccordionProvider isInitialOpen={false}>

--- a/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
+++ b/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InternalShadowAccordion matches snapshot 1`] = `
+exports[`InternalChevronAccordion matches snapshot 1`] = `
 .c0 {
   position: relative;
   padding-top: 0.75rem;
@@ -115,10 +115,6 @@ exports[`InternalShadowAccordion matches snapshot 1`] = `
 }
 
 .c1 .c5:focus-visible ~ .c11 {
-  visibility: visible;
-}
-
-.c1 .c5:active ~ .c11 {
   visibility: visible;
 }
 

--- a/src/components/molecules/InternalChevronAccordion/index.ts
+++ b/src/components/molecules/InternalChevronAccordion/index.ts
@@ -1,0 +1,1 @@
+export * from "./InternalChevronAccordion";

--- a/src/components/molecules/InternalShadowAccordion/index.ts
+++ b/src/components/molecules/InternalShadowAccordion/index.ts
@@ -1,1 +1,0 @@
-export * from "./InternalShadowAccordion";

--- a/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.tsx
+++ b/src/components/molecules/OakButtonAsRadioGroup/OakButtonAsRadioGroup.tsx
@@ -37,7 +37,10 @@ export type OakButtonAsRadioGroupProps = {
   defaultValue?: string;
 } & Pick<TypographyStyleProps, "$font"> &
   ColorStyleProps &
-  Pick<FlexStyleProps, "$flexDirection" | "$alignItems" | "$gap" | "$flexWrap">;
+  Pick<
+    FlexStyleProps,
+    "$flexDirection" | "$alignItems" | "$gap" | "$flexWrap" | "$justifyContent"
+  >;
 
 /**
  *

--- a/src/components/molecules/OakOutlineAccordion/OakOutlineAccordion.tsx
+++ b/src/components/molecules/OakOutlineAccordion/OakOutlineAccordion.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from "react";
 import styled from "styled-components";
 
 import { OakHandDrawnHR } from "../OakHandDrawnHR";
-import { InternalShadowAccordion } from "../InternalShadowAccordion";
+import { InternalChevronAccordion } from "../InternalChevronAccordion";
 
 import { OakFlex } from "@/components/atoms";
 import { PositionStyleProps } from "@/styles/utils/positionStyle";
@@ -51,16 +51,16 @@ export const OakOutlineAccordion = ({
   ...styleProps
 }: OakOutlineAccordionProps) => {
   return (
-    <OakFlex $position={"relative"} $display={"flex"} $flexDirection={"column"}>
-      <StyledHandDrawnHR />
-      <InternalShadowAccordion
+    <OakFlex $position={"relative"} $flexDirection={"column"}>
+      <StyledHandDrawnHR $width={"100%"} />
+      <InternalChevronAccordion
         header={header}
         id={id}
         initialOpen={initialOpen}
         {...styleProps}
       >
         {children}
-      </InternalShadowAccordion>
+      </InternalChevronAccordion>
       <StyledHandDrawnHR $position={"absolute"} $width={"100%"} />
     </OakFlex>
   );

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -3,10 +3,6 @@
 exports[`OakOutlineAccordion matches snapshot 1`] = `
 .c0 {
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-family: Lexend,sans-serif;
 }
 
@@ -137,12 +133,9 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   visibility: visible;
 }
 
-.c6 .c10:active ~ .c14 {
-  visibility: visible;
-}
-
 .c4 {
   height: 0.125rem;
+  width: 100%;
   bottom: 0.125rem;
 }
 

--- a/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.stories.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.stories.tsx
@@ -12,6 +12,7 @@ import {
   OakButtonAsRadioGroup,
   OakSecondaryButtonAsRadio,
 } from "@/components/molecules";
+import { OakFlex } from "@/components/atoms/OakFlex";
 
 const meta: Meta<typeof OakPupilJourneyList> = {
   component: OakPupilJourneyList,
@@ -101,12 +102,16 @@ export const WithFilter: Story = {
         />
       }
       filterSlot={
-        <OakButtonAsRadioGroup ariaLabelledby="test" name="test">
-          <OakSecondaryButtonAsRadio value="all">All</OakSecondaryButtonAsRadio>
-          <OakSecondaryButtonAsRadio value="1">
-            Option 1
-          </OakSecondaryButtonAsRadio>
-        </OakButtonAsRadioGroup>
+        <OakFlex $justifyContent={"end"}>
+          <OakButtonAsRadioGroup ariaLabelledby="test" name="test">
+            <OakSecondaryButtonAsRadio value="all">
+              All
+            </OakSecondaryButtonAsRadio>
+            <OakSecondaryButtonAsRadio value="1">
+              Option 1
+            </OakSecondaryButtonAsRadio>
+          </OakButtonAsRadioGroup>
+        </OakFlex>
       }
     >
       <OakPupilJourneyListItem title="Lesson 1" index={1} href="#" />

--- a/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyList/OakPupilJourneyList.tsx
@@ -38,9 +38,7 @@ const Slots = ({
         </OakFlex>
 
         <OakFlex $flexDirection={"column"} $gap={"space-between-m2"}>
-          {filterSlot && (
-            <OakFlex $justifyContent={"end"}>{filterSlot}</OakFlex>
-          )}
+          {filterSlot}
           <OakFlex>{counterSlot}</OakFlex>
         </OakFlex>
       </OakFlex>

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.stories.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { StoryObj, Meta } from "@storybook/react";
 
 import { OakPupilJourneyUnitsFilter } from "./OakPupilJourneyUnitsFilter";
+import { OakFlex } from "@/components/atoms";
 
 const meta: Meta<typeof OakPupilJourneyUnitsFilter> = {
   title: "Components/organisms/pupil/OakPupilJourneyUnitsFilter",
@@ -37,7 +38,11 @@ export default meta;
 type Story = StoryObj<typeof OakPupilJourneyUnitsFilter>;
 
 export const Default: Story = {
-  render: (args) => <OakPupilJourneyUnitsFilter {...args} />,
+  render: (args) => (
+    <OakFlex>
+      <OakPupilJourneyUnitsFilter {...args} />
+    </OakFlex>
+  ),
   args: {
     menuItems: [
       { displayText: "All", value: "all" },

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.stories.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.stories.tsx
@@ -40,12 +40,12 @@ export const Default: Story = {
   render: (args) => <OakPupilJourneyUnitsFilter {...args} />,
   args: {
     menuItems: [
-      { text: "All", id: 0 },
-      { text: "Biology", id: 1 },
-      { text: "Chemistry", id: 2 },
-      { text: "Physics", id: 3 },
+      { displayText: "All", value: "all" },
+      { displayText: "Biology", value: "biology" },
+      { displayText: "Chemistry", value: "chemistry" },
+      { displayText: "Physics", value: "physics" },
     ],
-    selected: 2,
-    onSelected: (menuItemId: number) => console.log(menuItemId),
+    selected: "all",
+    onSelected: (menuItem) => console.log(menuItem.value),
   },
 };

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.stories.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { StoryObj, Meta } from "@storybook/react";
 
 import { OakPupilJourneyUnitsFilter } from "./OakPupilJourneyUnitsFilter";
+
 import { OakFlex } from "@/components/atoms";
 
 const meta: Meta<typeof OakPupilJourneyUnitsFilter> = {
@@ -16,10 +17,8 @@ const meta: Meta<typeof OakPupilJourneyUnitsFilter> = {
       },
     },
     selected: {
-      description: "Selected menu item",
-      control: {
-        type: "number",
-      },
+      control: { type: "select" },
+      options: ["all", "biology", "chemistry", "physics"],
     },
     onSelected: {
       description: "Function to be called when a menu item is selected",

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.test.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.test.tsx
@@ -17,15 +17,14 @@ const menuItems = [
 
 describe("PupilJourneyUnitsFilter", () => {
   it("renders", () => {
-    const { getByTestId } = renderWithTheme(
+    const { getAllByLabelText } = renderWithTheme(
       <OakPupilJourneyUnitsFilter
         menuItems={menuItems}
         selected={"all"}
         onSelected={() => null}
-        data-testid="test"
       />,
     );
-    expect(getByTestId("test")).toBeInTheDocument();
+    expect(getAllByLabelText("OakPupilJourneyUnitsFilter")).toHaveLength(2);
   });
 
   it("matches snapshot", () => {

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.test.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.test.tsx
@@ -9,10 +9,10 @@ import renderWithTheme from "@/test-helpers/renderWithTheme";
 import { oakDefaultTheme } from "@/styles";
 
 const menuItems = [
-  { text: "All", id: 0 },
-  { text: "Biology", id: 1 },
-  { text: "Chemistry", id: 2 },
-  { text: "Physics", id: 3 },
+  { displayText: "All", value: "all" },
+  { displayText: "Biology", value: "biology" },
+  { displayText: "Chemistry", value: "chemistry" },
+  { displayText: "Physics", value: "physics" },
 ];
 
 describe("PupilJourneyUnitsFilter", () => {
@@ -51,7 +51,7 @@ describe("PupilJourneyUnitsFilter", () => {
       />,
     );
     menuItems.forEach((item) => {
-      expect(getAllByText(item.text)[0]).toBeInTheDocument();
+      expect(getAllByText(item.displayText)[0]).toBeInTheDocument();
     });
   });
   it("renders the correct button as selected", () => {
@@ -76,6 +76,9 @@ describe("PupilJourneyUnitsFilter", () => {
       />,
     );
     getAllByText("Physics")[0]?.click();
-    expect(onSelected).toHaveBeenCalledWith({ text: "Physics", id: 3 });
+    expect(onSelected).toHaveBeenCalledWith({
+      displayText: "Physics",
+      value: "physics",
+    });
   });
 });

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.test.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { create } from "react-test-renderer";
+import { act, create } from "react-test-renderer";
 import { ThemeProvider } from "styled-components";
 
 import { OakPupilJourneyUnitsFilter } from "./OakPupilJourneyUnitsFilter";
@@ -20,7 +20,7 @@ describe("PupilJourneyUnitsFilter", () => {
     const { getByTestId } = renderWithTheme(
       <OakPupilJourneyUnitsFilter
         menuItems={menuItems}
-        selected={1}
+        selected={"all"}
         onSelected={() => null}
         data-testid="test"
       />,
@@ -33,7 +33,7 @@ describe("PupilJourneyUnitsFilter", () => {
       <ThemeProvider theme={oakDefaultTheme}>
         <OakPupilJourneyUnitsFilter
           menuItems={menuItems}
-          selected={1}
+          selected={"all"}
           onSelected={() => null}
           data-testid="test"
         />
@@ -45,7 +45,7 @@ describe("PupilJourneyUnitsFilter", () => {
     const { getAllByText } = renderWithTheme(
       <OakPupilJourneyUnitsFilter
         menuItems={menuItems}
-        selected={1}
+        selected={"all"}
         onSelected={() => null}
         data-testid="test"
       />,
@@ -58,7 +58,7 @@ describe("PupilJourneyUnitsFilter", () => {
     const { getAllByText } = renderWithTheme(
       <OakPupilJourneyUnitsFilter
         menuItems={menuItems}
-        selected={1}
+        selected={"biology"}
         onSelected={() => null}
         data-testid="test"
       />,
@@ -70,12 +70,14 @@ describe("PupilJourneyUnitsFilter", () => {
     const { getAllByText } = renderWithTheme(
       <OakPupilJourneyUnitsFilter
         menuItems={menuItems}
-        selected={1}
+        selected={"all"}
         onSelected={onSelected}
         data-testid="test"
       />,
     );
-    getAllByText("Physics")[0]?.click();
+    act(() => {
+      getAllByText("Physics")[0]?.click();
+    });
     expect(onSelected).toHaveBeenCalledWith({
       displayText: "Physics",
       value: "physics",

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.tsx
@@ -14,7 +14,7 @@ type MenuItem = {
 
 export type OakPupilJourneyUnitsFilterProps = {
   menuItems: MenuItem[];
-  selected: number;
+  selected: string;
   onSelected: (arg0: MenuItem) => void;
 };
 

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.tsx
@@ -1,22 +1,21 @@
 import React from "react";
 import styled from "styled-components";
 
-import {
-  OakButtonAsRadioGroup,
-  OakOutlineAccordion,
-  OakSecondaryButtonAsRadio,
-} from "../../../molecules";
-import { OakBox, OakHeading } from "../../../atoms";
+import { OakButtonAsRadioGroup } from "@/components/molecules/OakButtonAsRadioGroup";
+import { OakSecondaryButtonAsRadio } from "@/components/molecules/OakSecondaryButtonAsRadio";
+import { OakOutlineAccordion } from "@/components/molecules/OakOutlineAccordion";
+import { OakBox } from "@/components/atoms/OakBox";
+import { OakHeading } from "@/components/atoms/OakHeading";
 
-export type menuItem = {
-  text: string;
-  id: number;
+type MenuItem = {
+  displayText: string;
+  value: string;
 };
 
 export type OakPupilJourneyUnitsFilterProps = {
-  menuItems: menuItem[];
+  menuItems: MenuItem[];
   selected: number;
-  onSelected: (arg0: menuItem) => void;
+  onSelected: (arg0: MenuItem) => void;
 };
 
 const UnstyledComponent = (props: OakPupilJourneyUnitsFilterProps) => {
@@ -27,18 +26,22 @@ const UnstyledComponent = (props: OakPupilJourneyUnitsFilterProps) => {
       name="OakPupilJourneyUnitsFilter"
       ariaLabel="OakPupilJourneyUnitsFilter"
       onChange={(value) => {
-        const selectedItem = menuItems.find(
-          (item) => item.id.toString() === value,
-        );
-        onSelected(selectedItem || { text: "", id: 0 }); // Provide a default value for selectedItem
+        const selectedItem = menuItems.find((item) => item.value === value);
+        if (!selectedItem) {
+          throw new Error("Selected item not found");
+        }
+        onSelected(selectedItem);
       }}
       defaultValue={selected.toString()}
       $flexWrap={"wrap"}
     >
-      {menuItems.map((item) => {
+      {menuItems.map((item, i) => {
         return (
-          <OakSecondaryButtonAsRadio value={item.id.toString()}>
-            {item.text}
+          <OakSecondaryButtonAsRadio
+            key={item.value + "_" + i}
+            value={item.value}
+          >
+            {item.displayText}
           </OakSecondaryButtonAsRadio>
         );
       })}

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import styled from "styled-components";
 
 import { OakButtonAsRadioGroup } from "@/components/molecules/OakButtonAsRadioGroup";
 import { OakSecondaryButtonAsRadio } from "@/components/molecules/OakSecondaryButtonAsRadio";
 import { OakOutlineAccordion } from "@/components/molecules/OakOutlineAccordion";
-import { OakBox } from "@/components/atoms/OakBox";
 import { OakHeading } from "@/components/atoms/OakHeading";
+import { OakFlex } from "@/components/atoms";
 
 type MenuItem = {
   displayText: string;
@@ -18,8 +17,21 @@ export type OakPupilJourneyUnitsFilterProps = {
   onSelected: (arg0: MenuItem) => void;
 };
 
-const UnstyledComponent = (props: OakPupilJourneyUnitsFilterProps) => {
-  const { menuItems, selected, onSelected, ...rest } = props;
+/**
+ *
+ * OakPupilJourneyUnitsFilter component is a radio group of buttons that can be used to filter pupil journey units
+ * add the menu items as an array of objects with text and id properties and provide a selected item id, and a callback function to handle the selection event.
+ * The following callbacks are available for tracking focus events:
+ *
+ * ### Callbacks
+ * onSelected: Callback when a menu item is selected, takes the selected item as an argument
+ *
+ */
+
+export const OakPupilJourneyUnitsFilter = (
+  props: OakPupilJourneyUnitsFilterProps,
+) => {
+  const { menuItems, selected, onSelected } = props;
 
   const OakRadioGroup = (
     <OakButtonAsRadioGroup
@@ -32,7 +44,8 @@ const UnstyledComponent = (props: OakPupilJourneyUnitsFilterProps) => {
         }
         onSelected(selectedItem);
       }}
-      defaultValue={selected.toString()}
+      defaultValue={selected}
+      $justifyContent={["start", "start", "end"]}
       $flexWrap={"wrap"}
     >
       {menuItems.map((item, i) => {
@@ -49,8 +62,8 @@ const UnstyledComponent = (props: OakPupilJourneyUnitsFilterProps) => {
   );
 
   return (
-    <OakBox {...rest}>
-      <OakBox $display={["block", "none"]}>
+    <>
+      <OakFlex $display={["block", "none"]}>
         <OakOutlineAccordion
           id={"mobile-unit-filter-accordion"}
           header={
@@ -63,20 +76,10 @@ const UnstyledComponent = (props: OakPupilJourneyUnitsFilterProps) => {
         >
           {OakRadioGroup}
         </OakOutlineAccordion>
-      </OakBox>
-      <OakBox $display={["none", "block"]}>{OakRadioGroup}</OakBox>
-    </OakBox>
+      </OakFlex>
+      <OakFlex $display={["none", "block"]} $flexGrow={1}>
+        {OakRadioGroup}
+      </OakFlex>
+    </>
   );
 };
-
-/**
- *
- * OakPupilJourneyUnitsFilter component is a radio group of buttons that can be used to filter pupil journey units
- * add the menu items as an array of objects with text and id properties and provide a selected item id, and a callback function to handle the selection event.
- * The following callbacks are available for tracking focus events:
- *
- * ### Callbacks
- * onSelected: Callback when a menu item is selected, takes the selected item as an argument
- *
- */
-export const OakPupilJourneyUnitsFilter = styled(UnstyledComponent)``;

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.tsx
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/OakPupilJourneyUnitsFilter.tsx
@@ -63,7 +63,7 @@ export const OakPupilJourneyUnitsFilter = (
 
   return (
     <>
-      <OakFlex $display={["block", "none"]}>
+      <OakFlex $display={["block", "none"]} $flexGrow={1}>
         <OakOutlineAccordion
           id={"mobile-unit-filter-accordion"}
           header={

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c27 {
+.c29 {
   display: none;
   font-family: Lexend,sans-serif;
 }
@@ -165,8 +165,8 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: unset;
   outline: none;
   font-family: Lexend,sans-serif;
-  color: #222222;
-  background: #ffffff;
+  color: #ffffff;
+  background: #222222;
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.75rem;
@@ -181,6 +181,33 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   cursor: default;
 }
 
+.c24 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  color: #222222;
+  background: #ffffff;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.25rem;
+}
+
+.c24:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
 .c21 {
   position: relative;
   width: 100%;
@@ -191,18 +218,45 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 .c21:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  color: #ffffff;
+  background: #575757;
+  border-color: #575757;
+}
+
+.c21:active {
+  background: #222222;
+  border-color: #222222;
+  color: #ffffff;
+}
+
+.c21:disabled {
+  background: #808080;
+  border-color: #808080;
+  color: #ffffff;
+}
+
+.c25 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: inline-block;
+}
+
+.c25:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
   color: #222222;
   background: #f2f2f2;
   border-color: #222222;
 }
 
-.c21:active {
+.c25:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c21:disabled {
+.c25:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
@@ -245,7 +299,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   padding: 0;
 }
 
-.c25 {
+.c27 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
@@ -288,15 +342,15 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c7 .c24 {
+.c7 .c26 {
   visibility: hidden;
 }
 
-.c7 .c11:focus-visible ~ .c24 {
+.c7 .c11:focus-visible ~ .c26 {
   visibility: visible;
 }
 
-.c7 .c11:active ~ .c24 {
+.c7 .c11:active ~ .c26 {
   visibility: visible;
 }
 
@@ -305,7 +359,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   bottom: 0.125rem;
 }
 
-.c26 {
+.c28 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
@@ -319,7 +373,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c27 {
+  .c29 {
     display: block;
   }
 }
@@ -426,7 +480,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 className="c19 yellow-shadow"
               />
               <button
-                aria-checked={false}
+                aria-checked={true}
                 className="c20 c21 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
@@ -455,7 +509,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
               />
               <button
                 aria-checked={false}
-                className="c20 c21 internal-button"
+                className="c24 c25 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -483,7 +537,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
               />
               <button
                 aria-checked={false}
-                className="c20 c21 internal-button"
+                className="c24 c25 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -511,7 +565,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
               />
               <button
                 aria-checked={false}
-                className="c20 c21 internal-button"
+                className="c24 c25 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -531,7 +585,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c0 c4 c24 c25"
+          className="c0 c4 c26 c27"
         >
           <svg
             className=""
@@ -553,7 +607,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c0 c4 c26"
+        className="c0 c4 c28"
       >
         <svg
           className=""
@@ -576,7 +630,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c27"
+    className="c29"
   >
     <div
       aria-label="OakPupilJourneyUnitsFilter"
@@ -593,7 +647,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           className="c19 yellow-shadow"
         />
         <button
-          aria-checked={false}
+          aria-checked={true}
           className="c20 c21 internal-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
@@ -622,7 +676,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         />
         <button
           aria-checked={false}
-          className="c20 c21 internal-button"
+          className="c24 c25 internal-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
@@ -650,7 +704,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         />
         <button
           aria-checked={false}
-          className="c20 c21 internal-button"
+          className="c24 c25 internal-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
@@ -678,7 +732,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         />
         <button
           aria-checked={false}
-          className="c20 c21 internal-button"
+          className="c24 c25 internal-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c29 {
+.c27 {
   display: none;
   font-family: Lexend,sans-serif;
 }
@@ -181,33 +181,6 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   cursor: default;
 }
 
-.c24 {
-  background: none;
-  color: inherit;
-  border: none;
-  padding: 0;
-  font: inherit;
-  cursor: pointer;
-  text-align: left;
-  font-family: unset;
-  outline: none;
-  font-family: Lexend,sans-serif;
-  color: #ffffff;
-  background: #222222;
-  padding-left: 1rem;
-  padding-right: 1rem;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  border: 0.125rem solid;
-  border-color: #222222;
-  border-radius: 0.25rem;
-}
-
-.c24:disabled {
-  pointer-events: none;
-  cursor: default;
-}
-
 .c21 {
   position: relative;
   width: 100%;
@@ -233,33 +206,6 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
-}
-
-.c25 {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  display: inline-block;
-}
-
-.c25:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  color: #ffffff;
-  background: #575757;
-  border-color: #575757;
-}
-
-.c25:active {
-  background: #222222;
-  border-color: #222222;
-  color: #ffffff;
-}
-
-.c25:disabled {
-  background: #808080;
-  border-color: #808080;
-  color: #ffffff;
 }
 
 .c18 .grey-shadow:has(+ * + .internal-button:focus-visible) {
@@ -299,7 +245,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   padding: 0;
 }
 
-.c27 {
+.c25 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
@@ -342,15 +288,15 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c7 .c26 {
+.c7 .c24 {
   visibility: hidden;
 }
 
-.c7 .c11:focus-visible ~ .c26 {
+.c7 .c11:focus-visible ~ .c24 {
   visibility: visible;
 }
 
-.c7 .c11:active ~ .c26 {
+.c7 .c11:active ~ .c24 {
   visibility: visible;
 }
 
@@ -359,7 +305,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   bottom: 0.125rem;
 }
 
-.c28 {
+.c26 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
@@ -373,7 +319,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c29 {
+  .c27 {
     display: block;
   }
 }
@@ -508,8 +454,8 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 className="c19 yellow-shadow"
               />
               <button
-                aria-checked={true}
-                className="c24 c25 internal-button"
+                aria-checked={false}
+                className="c20 c21 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
@@ -585,7 +531,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c0 c4 c26 c27"
+          className="c0 c4 c24 c25"
         >
           <svg
             className=""
@@ -607,7 +553,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c0 c4 c28"
+        className="c0 c4 c26"
       >
         <svg
           className=""
@@ -630,7 +576,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c29"
+    className="c27"
   >
     <div
       aria-label="OakPupilJourneyUnitsFilter"
@@ -675,8 +621,8 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           className="c19 yellow-shadow"
         />
         <button
-          aria-checked={true}
-          className="c24 c25 internal-button"
+          aria-checked={false}
+          className="c20 c21 internal-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -63,6 +63,10 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 
 .c1 {
   display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c3 {

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -1,25 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
-.c0 {
-  font-family: Lexend,sans-serif;
-}
-
-.c1 {
+[
+  .c0 {
   display: block;
   font-family: Lexend,sans-serif;
 }
 
 .c2 {
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-family: Lexend,sans-serif;
 }
 
-.c6 {
+.c4 {
+  font-family: Lexend,sans-serif;
+}
+
+.c7 {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
@@ -30,15 +27,15 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c8 {
+.c9 {
   font-family: Lexend,sans-serif;
 }
 
-.c8:hover {
+.c9:hover {
   cursor: pointer;
 }
 
-.c14 {
+.c15 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -47,7 +44,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c17 {
+.c18 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -55,7 +52,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c19 {
+.c20 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -64,9 +61,8 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c29 {
-  display: none;
-  font-family: Lexend,sans-serif;
+.c1 {
+  display: block;
 }
 
 .c3 {
@@ -79,14 +75,14 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -97,7 +93,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c16 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -105,10 +101,14 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
   gap: 1rem;
 }
 
-.c22 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -127,7 +127,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 0.5rem;
 }
 
-.c23 {
+.c24 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -139,11 +139,11 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
 }
 
-.c15 {
+.c16 {
   object-fit: contain;
 }
 
-.c13 {
+.c14 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -154,7 +154,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c20 {
+.c21 {
   background: none;
   color: inherit;
   border: none;
@@ -176,12 +176,12 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c20:disabled {
+.c21:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c24 {
+.c25 {
   background: none;
   color: inherit;
   border: none;
@@ -203,19 +203,19 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c24:disabled {
+.c25:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c21 {
+.c22 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c21:hover {
+.c22:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -223,26 +223,26 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-color: #575757;
 }
 
-.c21:active {
+.c22:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c21:disabled {
+.c22:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c25 {
+.c26 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c25:hover {
+.c26:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -250,44 +250,44 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-color: #222222;
 }
 
-.c25:active {
+.c26:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c25:disabled {
+.c26:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c18 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c19 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c18 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c19 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c18 .yellow-shadow:has(+ .internal-button:hover),
-.c18 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c19 .yellow-shadow:has(+ .internal-button:hover),
+.c19 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c18 .grey-shadow:has(+ * + .internal-button:hover) {
+.c19 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c18 .grey-shadow:has(+ * + .internal-button:active) {
+.c19 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c18 .yellow-shadow:has(+ .internal-button:active) {
+.c19 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c10 {
+.c11 {
   font: inherit;
   color: inherit;
   border: none;
@@ -299,13 +299,13 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   padding: 0;
 }
 
-.c27 {
+.c28 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -318,12 +318,12 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c12:hover {
+.c13:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c7 {
+.c8 {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
@@ -342,28 +342,35 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c7 .c26 {
+.c8 .c27 {
   visibility: hidden;
 }
 
-.c7 .c11:focus-visible ~ .c26 {
+.c8 .c12:focus-visible ~ .c27 {
   visibility: visible;
 }
 
-.c7 .c11:active ~ .c26 {
-  visibility: visible;
-}
-
-.c5 {
+.c6 {
   height: 0.125rem;
+  width: 100%;
   bottom: 0.125rem;
 }
 
-.c28 {
+.c29 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
   bottom: 0.125rem;
+}
+
+@media (min-width:750px) {
+  .c0 {
+    display: none;
+  }
+}
+
+@media (min-width:750px) {
+
 }
 
 @media (min-width:750px) {
@@ -373,23 +380,35 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c29 {
-    display: block;
+  .c17 {
+    -webkit-box-pack: start;
+    -webkit-justify-content: start;
+    -ms-flex-pack: start;
+    justify-content: start;
   }
 }
 
+@media (min-width:1280px) {
+  .c17 {
+    -webkit-box-pack: end;
+    -webkit-justify-content: end;
+    -ms-flex-pack: end;
+    justify-content: end;
+  }
+}
+
+@media (min-width:750px) {
+
+}
+
 <div
-  className="c0 "
-  data-testid="test"
->
-  <div
-    className="c1"
+    className="c0 c1"
   >
     <div
       className="c2 c3"
     >
       <div
-        className="c0 c4 c5"
+        className="c4 c5 c6"
       >
         <svg
           className=""
@@ -410,22 +429,22 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </svg>
       </div>
       <div
-        className="c6 c7"
+        className="c7 c8"
       >
         <button
           aria-expanded={false}
-          className="c8 c9 c10 c11  c12"
+          className="c9 c10 c11 c12  c13"
           id="mobile-unit-filter-accordion"
           onClick={[Function]}
           type="button"
         >
           <h2
-            className="c13"
+            className="c14"
           >
             Categories
           </h2>
           <div
-            className="c14"
+            className="c15"
             style={
               {
                 "transform": "none",
@@ -435,7 +454,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           >
             <img
               alt=""
-              className="c15"
+              className="c16"
               data-nimg="fill"
               decoding="async"
               loading="lazy"
@@ -461,37 +480,37 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </button>
         <div
           aria-labelledby="mobile-unit-filter-accordion"
-          className="c0 "
+          className="c4 "
           hidden={true}
           role="region"
         >
           <div
             aria-label="OakPupilJourneyUnitsFilter"
-            className="c0 c16"
+            className="c4 c17"
             role="radiogroup"
           >
             <div
-              className="c17 c18"
+              className="c18 c19"
             >
               <div
-                className="c19 grey-shadow"
+                className="c20 grey-shadow"
               />
               <div
-                className="c19 yellow-shadow"
+                className="c20 yellow-shadow"
               />
               <button
                 aria-checked={true}
-                className="c20 c21 internal-button"
+                className="c21 c22 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 role="radio"
               >
                 <div
-                  className="c0 c22"
+                  className="c4 c23"
                 >
                   <span
-                    className="c23"
+                    className="c24"
                   >
                     All
                   </span>
@@ -499,27 +518,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
               </button>
             </div>
             <div
-              className="c17 c18"
+              className="c18 c19"
             >
               <div
-                className="c19 grey-shadow"
+                className="c20 grey-shadow"
               />
               <div
-                className="c19 yellow-shadow"
+                className="c20 yellow-shadow"
               />
               <button
                 aria-checked={false}
-                className="c24 c25 internal-button"
+                className="c25 c26 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 role="radio"
               >
                 <div
-                  className="c0 c22"
+                  className="c4 c23"
                 >
                   <span
-                    className="c23"
+                    className="c24"
                   >
                     Biology
                   </span>
@@ -527,27 +546,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
               </button>
             </div>
             <div
-              className="c17 c18"
+              className="c18 c19"
             >
               <div
-                className="c19 grey-shadow"
+                className="c20 grey-shadow"
               />
               <div
-                className="c19 yellow-shadow"
+                className="c20 yellow-shadow"
               />
               <button
                 aria-checked={false}
-                className="c24 c25 internal-button"
+                className="c25 c26 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 role="radio"
               >
                 <div
-                  className="c0 c22"
+                  className="c4 c23"
                 >
                   <span
-                    className="c23"
+                    className="c24"
                   >
                     Chemistry
                   </span>
@@ -555,27 +574,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
               </button>
             </div>
             <div
-              className="c17 c18"
+              className="c18 c19"
             >
               <div
-                className="c19 grey-shadow"
+                className="c20 grey-shadow"
               />
               <div
-                className="c19 yellow-shadow"
+                className="c20 yellow-shadow"
               />
               <button
                 aria-checked={false}
-                className="c24 c25 internal-button"
+                className="c25 c26 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 role="radio"
               >
                 <div
-                  className="c0 c22"
+                  className="c4 c23"
                 >
                   <span
-                    className="c23"
+                    className="c24"
                   >
                     Physics
                   </span>
@@ -585,7 +604,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c0 c4 c26 c27"
+          className="c4 c5 c27 c28"
         >
           <svg
             className=""
@@ -607,7 +626,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c0 c4 c28"
+        className="c4 c5 c29"
       >
         <svg
           className=""
@@ -628,37 +647,288 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </svg>
       </div>
     </div>
-  </div>
-  <div
-    className="c29"
+  </div>,
+  .c2 {
+  font-family: Lexend,sans-serif;
+}
+
+.c4 {
+  position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
+  position: absolute;
+  top: 0rem;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c0 {
+  display: none;
+  font-family: Lexend,sans-serif;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  gap: 1rem;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.c1 {
+  display: none;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c10 {
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  text-align: left;
+}
+
+.c7 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  color: #ffffff;
+  background: #222222;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.25rem;
+}
+
+.c7:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c11 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  color: #222222;
+  background: #ffffff;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-radius: 0.25rem;
+}
+
+.c11:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c8 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: inline-block;
+}
+
+.c8:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #ffffff;
+  background: #575757;
+  border-color: #575757;
+}
+
+.c8:active {
+  background: #222222;
+  border-color: #222222;
+  color: #ffffff;
+}
+
+.c8:disabled {
+  background: #808080;
+  border-color: #808080;
+  color: #ffffff;
+}
+
+.c12 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: inline-block;
+}
+
+.c12:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #222222;
+  background: #f2f2f2;
+  border-color: #222222;
+}
+
+.c12:active {
+  background: #ffffff;
+  border-color: #222222;
+  color: #222222;
+}
+
+.c12:disabled {
+  background: #e4e4e4;
+  border-color: #808080;
+  color: #808080;
+}
+
+.c5 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c5 .yellow-shadow:has(+ .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
+}
+
+.c5 .yellow-shadow:has(+ .internal-button:hover),
+.c5 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+.c5 .grey-shadow:has(+ * + .internal-button:hover) {
+  box-shadow: none;
+}
+
+.c5 .grey-shadow:has(+ * + .internal-button:active) {
+  box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
+}
+
+.c5 .yellow-shadow:has(+ .internal-button:active) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+@media (min-width:750px) {
+
+}
+
+@media (min-width:750px) {
+  .c0 {
+    display: block;
+  }
+}
+
+@media (min-width:750px) {
+
+}
+
+@media (min-width:750px) {
+  .c3 {
+    -webkit-box-pack: start;
+    -webkit-justify-content: start;
+    -ms-flex-pack: start;
+    justify-content: start;
+  }
+}
+
+@media (min-width:1280px) {
+  .c3 {
+    -webkit-box-pack: end;
+    -webkit-justify-content: end;
+    -ms-flex-pack: end;
+    justify-content: end;
+  }
+}
+
+@media (min-width:750px) {
+  .c1 {
+    display: block;
+  }
+}
+
+<div
+    className="c0 c1"
   >
     <div
       aria-label="OakPupilJourneyUnitsFilter"
-      className="c0 c16"
+      className="c2 c3"
       role="radiogroup"
     >
       <div
-        className="c17 c18"
+        className="c4 c5"
       >
         <div
-          className="c19 grey-shadow"
+          className="c6 grey-shadow"
         />
         <div
-          className="c19 yellow-shadow"
+          className="c6 yellow-shadow"
         />
         <button
           aria-checked={true}
-          className="c20 c21 internal-button"
+          className="c7 c8 internal-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           role="radio"
         >
           <div
-            className="c0 c22"
+            className="c2 c9"
           >
             <span
-              className="c23"
+              className="c10"
             >
               All
             </span>
@@ -666,27 +936,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </button>
       </div>
       <div
-        className="c17 c18"
+        className="c4 c5"
       >
         <div
-          className="c19 grey-shadow"
+          className="c6 grey-shadow"
         />
         <div
-          className="c19 yellow-shadow"
+          className="c6 yellow-shadow"
         />
         <button
           aria-checked={false}
-          className="c24 c25 internal-button"
+          className="c11 c12 internal-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           role="radio"
         >
           <div
-            className="c0 c22"
+            className="c2 c9"
           >
             <span
-              className="c23"
+              className="c10"
             >
               Biology
             </span>
@@ -694,27 +964,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </button>
       </div>
       <div
-        className="c17 c18"
+        className="c4 c5"
       >
         <div
-          className="c19 grey-shadow"
+          className="c6 grey-shadow"
         />
         <div
-          className="c19 yellow-shadow"
+          className="c6 yellow-shadow"
         />
         <button
           aria-checked={false}
-          className="c24 c25 internal-button"
+          className="c11 c12 internal-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           role="radio"
         >
           <div
-            className="c0 c22"
+            className="c2 c9"
           >
             <span
-              className="c23"
+              className="c10"
             >
               Chemistry
             </span>
@@ -722,27 +992,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </button>
       </div>
       <div
-        className="c17 c18"
+        className="c4 c5"
       >
         <div
-          className="c19 grey-shadow"
+          className="c6 grey-shadow"
         />
         <div
-          className="c19 yellow-shadow"
+          className="c6 yellow-shadow"
         />
         <button
           aria-checked={false}
-          className="c24 c25 internal-button"
+          className="c11 c12 internal-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           role="radio"
         >
           <div
-            className="c0 c22"
+            className="c2 c9"
           >
             <span
-              className="c23"
+              className="c10"
             >
               Physics
             </span>
@@ -750,6 +1020,6 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </button>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./components";
 export * from "./styles";
+export * from "./test-helpers";


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

A bunch of fixes to Accordians and the OakPupilJourneyUnitsFilter to make them suitable for pupil-760 
- OakPupilJourneyUnitsFilter has an interface which is not based on indexed position 
- Ensure Mobile Accordian stretches to full width of screen
- Simply Components where there is redundancy
- Improve nomenclature
- Fix any minor style errors
- Export test helpers which are now needed to support tests in OWA

## A link to the component in the deployment preview

## Testing instructions

## ACs
