### PR TITLE
[PUPIL-864] Updating the quiz hint tooltip position

### DIFF
--- a/src/components/organisms/pupil/OakQuizHint/OakQuizHint.tsx
+++ b/src/components/organisms/pupil/OakQuizHint/OakQuizHint.tsx
@@ -20,7 +20,12 @@ export const OakQuizHint = ({ hint }: OakQuizHintProps) => {
   };
 
   return (
-    <OakTooltip tooltip={hint} isOpen={isOpen} id="hint-tooltip">
+    <OakTooltip
+      tooltip={hint}
+      isOpen={isOpen}
+      id="hint-tooltip"
+      tooltipPosition="top-left"
+    >
       <OakHintButton
         isOpen={isOpen}
         onClick={handleClick}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Quick update to change quiz hint position from below to top left.

| Current | New |
|----------|----------|
| <img width="684" alt="image" src="https://github.com/user-attachments/assets/f2df2e50-331c-4683-a6b5-046c546ddc3a"> | <img width="624" alt="image" src="https://github.com/user-attachments/assets/ea86be67-ba1b-4b5b-a3b8-9f09af9d2feb"> |


## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
