### PR TITLE
Fix/chevron accordian size

### DIFF
--- a/src/components/atoms/InternalAccordion/InternalAccordion.stories.tsx
+++ b/src/components/atoms/InternalAccordion/InternalAccordion.stories.tsx
@@ -4,40 +4,32 @@ import { StoryObj, Meta } from "@storybook/react";
 import {
   InternalAccordionButton,
   InternalAccordionContent,
-  InternalAccordion,
 } from "./InternalAccordion";
 import { InternalAccordionProvider } from "./InternalAccordionProvider";
 
-const meta: Meta<typeof InternalAccordion> = {
+import { OakFlex } from "@/components/atoms/OakFlex";
+
+const meta: Meta<typeof InternalAccordionProvider> = {
   title: "Components/atoms/InternalAccordion",
-  component: InternalAccordion,
+  component: InternalAccordionProvider,
   tags: ["autodocs"],
-  argTypes: {},
-  parameters: {
-    controls: {
-      include: ["type"],
-    },
-  },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof InternalAccordion>;
+type Story = StoryObj<typeof InternalAccordionProvider>;
 
 export const Default: Story = {
-  render: (args) => (
-    <InternalAccordionProvider isInitialOpen={true}>
-      <InternalAccordion {...args}>
-        <InternalAccordionButton {...args}>
+  render: () => (
+    <InternalAccordionProvider isInitialOpen={false}>
+      <OakFlex $flexDirection={"column"}>
+        <InternalAccordionButton id={"generic-accordion"}>
           accordion button
         </InternalAccordionButton>
-        <InternalAccordionContent {...args}>
+        <InternalAccordionContent aria-labelledby={"generic-accordion"}>
           accordion content
         </InternalAccordionContent>
-      </InternalAccordion>
+      </OakFlex>
     </InternalAccordionProvider>
   ),
-  args: {
-    id: "generic-accordion",
-  },
 };

--- a/src/components/atoms/InternalAccordion/InternalAccordion.test.tsx
+++ b/src/components/atoms/InternalAccordion/InternalAccordion.test.tsx
@@ -3,26 +3,26 @@ import "@testing-library/jest-dom";
 import { create } from "react-test-renderer";
 
 import {
-  InternalAccordion,
   InternalAccordionButton,
   InternalAccordionContent,
 } from "./InternalAccordion";
 import AccordionProvider from "./InternalAccordionProvider";
 
 import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { OakFlex } from "@/components/atoms/OakFlex";
 
 describe("InternalAccordion", () => {
   it("renders", () => {
     const { getByTestId } = renderWithTheme(
       <AccordionProvider isInitialOpen={true}>
-        <InternalAccordion id={"internal-accordion"} data-testid="test">
+        <OakFlex id={"internal-accordion"} data-testid="test">
           <InternalAccordionButton id={"internal-accordion"}>
             accordion button
           </InternalAccordionButton>
-          <InternalAccordionContent id={"internal-accordion"}>
+          <InternalAccordionContent aria-labelledby={"internal-accordion"}>
             accordion content
           </InternalAccordionContent>
-        </InternalAccordion>
+        </OakFlex>
       </AccordionProvider>,
     );
     expect(getByTestId("test")).toBeInTheDocument();
@@ -31,14 +31,14 @@ describe("InternalAccordion", () => {
   it("matches snapshot", () => {
     const tree = create(
       <AccordionProvider isInitialOpen={true}>
-        <InternalAccordion id={"internal-accordion"} data-testid="test">
+        <OakFlex id={"internal-accordion"} data-testid="test">
           <InternalAccordionButton id={"internal-accordion"}>
             accordion button
           </InternalAccordionButton>
-          <InternalAccordionContent id={"internal-accordion"}>
+          <InternalAccordionContent aria-labelledby={"internal-accordion"}>
             accordion content
           </InternalAccordionContent>
-        </InternalAccordion>
+        </OakFlex>
       </AccordionProvider>,
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/src/components/atoms/InternalAccordion/InternalAccordion.tsx
+++ b/src/components/atoms/InternalAccordion/InternalAccordion.tsx
@@ -1,22 +1,11 @@
-import React, { ReactNode } from "react";
+import React from "react";
 import styled from "styled-components";
 
 import useAccordionContext from "./useAccordionContext";
 
 import { OakBox, OakBoxProps, OakFlex, OakFlexProps } from "@/components/atoms";
 
-export type InternalAccordionProps = {
-  /**
-   * The content of the accordion
-   */
-  children: ReactNode;
-  /**
-   * The id of the accordion
-   */
-  id: string;
-};
-
-const StyledButton = styled(OakFlex)`
+const FlexWithReset = styled(OakFlex)`
   font: inherit;
   color: inherit;
   border: none;
@@ -28,52 +17,41 @@ const StyledButton = styled(OakFlex)`
 
 /**
  *
- *  An accordion component that can be used to show/hide content
+ * Content which will appear and disappear
  *
- *
- * Must call this coponent inside the AccordionProvider where you can also access the useAccordionContext hook
- *
- * Must use the InternalAccordionButton and InternalAccordionContent components as direct children of InternalAccordion
- *
+ * Must appear as a sibling of InternalAccordionButton
  *
  */
 
-export const InternalAccordion = styled(OakBox)``;
-
-const UnstyledAccordionContent = ({
+const AccordionContent = ({
   children,
-  id,
-  ...styleProps
-}: InternalAccordionProps & OakBoxProps) => {
+  ...rest
+}: OakBoxProps & { "aria-labelledby": string }) => {
   const { isOpen } = useAccordionContext();
 
   return (
-    <OakBox hidden={!isOpen} aria-labelledby={id} role="region" {...styleProps}>
+    <OakBox hidden={!isOpen} role="region" {...rest}>
       {children}
     </OakBox>
   );
 };
 
+export const InternalAccordionContent = styled(AccordionContent)``;
+
 /**
  *
- *  An accordion component that can be used to show/hide content
+ * User interface to toggle visibility of InternalAccordionContent
  *
- * InternalAccordionContent is a child component of InternalAccordion and sibling of InternalAccordionButton
- *
- * The children of InternalAccordionContent will be hidden or shown based on the state of the InternalAccordionButton
+ * Must appear as a sibling of InternalAccordionContent
  *
  */
 
-export const InternalAccordionContent = styled(UnstyledAccordionContent)``;
-
-const UnstyledAccordionButton = (
-  props: InternalAccordionProps & OakFlexProps & OakBoxProps,
-) => {
+const AccordionButton = (props: { id: string } & OakFlexProps) => {
   const { children, id, ...rest } = props;
   const { isOpen, setOpen } = useAccordionContext();
 
   return (
-    <StyledButton
+    <FlexWithReset
       as="button"
       type="button"
       onClick={() => setOpen(!isOpen)}
@@ -83,18 +61,8 @@ const UnstyledAccordionButton = (
       {...rest}
     >
       {children}
-    </StyledButton>
+    </FlexWithReset>
   );
 };
 
-/**
- *
- *  An accordion component that can be used to show/hide content
- *
- * InternalAccordionButton is a child component of InternalAccordion and sibling of InternalAccordionContent
- *
- * The children of InternalAccordianButton will be used as the button to toggle the visibility of the InternalAccordionContent
- *
- */
-
-export const InternalAccordionButton = styled(UnstyledAccordionButton)``;
+export const InternalAccordionButton = styled(AccordionButton)``;

--- a/src/components/atoms/InternalAccordion/InternalAccordionProvider.tsx
+++ b/src/components/atoms/InternalAccordion/InternalAccordionProvider.tsx
@@ -7,6 +7,14 @@ type AccordionContext = {
 };
 
 export const accordionContext = createContext<AccordionContext | null>(null);
+/**
+ *
+ * Decomposed component comprising InternalAccordionButton and InternalAccordionContent wrapped by InternalAccordionProvider
+ *
+ * - InternalAccordionButton will toggle InternalAccordionContent visibility
+ * - It is up to the user to arrange the InternalAccordionButton and InternalAccordionContent components in the desired order
+ *
+ */
 
 export const InternalAccordionProvider: FC<{
   isInitialOpen: boolean;

--- a/src/components/atoms/InternalAccordion/__snapshots__/InternalAccordion.test.tsx.snap
+++ b/src/components/atoms/InternalAccordion/__snapshots__/InternalAccordion.test.tsx.snap
@@ -5,15 +5,22 @@ exports[`InternalAccordion matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c1 {
+.c2 {
   font-family: Lexend,sans-serif;
 }
 
-.c1:hover {
+.c2:hover {
   cursor: pointer;
 }
 
-.c2 {
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -24,7 +31,7 @@ exports[`InternalAccordion matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c3 {
+.c4 {
   font: inherit;
   color: inherit;
   border: none;
@@ -37,13 +44,13 @@ exports[`InternalAccordion matches snapshot 1`] = `
 }
 
 <div
-  className="c0"
+  className="c0 c1"
   data-testid="test"
   id="internal-accordion"
 >
   <button
     aria-expanded={true}
-    className="c1 c2 c3 "
+    className="c2 c3 c4 "
     id="internal-accordion"
     onClick={[Function]}
     type="button"

--- a/src/components/atoms/InternalClientPortal/InternalClientPortal.tsx
+++ b/src/components/atoms/InternalClientPortal/InternalClientPortal.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-type ClientPortalInterface = {
+
+type InternalClientPortalInterface = {
   children: React.ReactNode;
   show?: boolean;
   onClose?: () => void;
 };
-const ClientPortal = ({ children, show }: ClientPortalInterface) => {
+
+export const InternalClientPortal = ({
+  children,
+  show,
+}: InternalClientPortalInterface) => {
   const ref = useRef<Element | null>(null);
 
   useEffect(() => {
@@ -13,4 +18,3 @@ const ClientPortal = ({ children, show }: ClientPortalInterface) => {
   }, []);
   return show && ref.current ? createPortal(children, ref.current) : null;
 };
-export default ClientPortal;

--- a/src/components/atoms/InternalClientPortal/index.ts
+++ b/src/components/atoms/InternalClientPortal/index.ts
@@ -1,0 +1,1 @@
+export * from "./InternalClientPortal";

--- a/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.tsx
+++ b/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.tsx
@@ -92,12 +92,13 @@ const Accordion = ({
         id={id}
         $width={"100%"}
         $justifyContent={"space-between"}
+        $alignItems={"center"}
       >
         {header}
         <OakIcon
           iconName="chevron-down"
-          $width="all-spacing-6"
-          $height="all-spacing-6"
+          $width="all-spacing-8"
+          $height="all-spacing-8"
           alt=""
           style={{
             transform: isOpen ? "rotate(180deg)" : "none",

--- a/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.tsx
+++ b/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.tsx
@@ -3,9 +3,8 @@ import styled from "styled-components";
 
 import { OakHandDrawnFocusUnderline } from "../OakHandDrawnFocusUnderline";
 
-import { OakBoxProps, OakIcon, oakBoxCss } from "@/components/atoms";
+import { OakBoxProps, OakFlex, OakIcon, oakBoxCss } from "@/components/atoms";
 import {
-  InternalAccordion,
   InternalAccordionButton,
   InternalAccordionContent,
 } from "@/components/atoms/InternalAccordion";
@@ -55,14 +54,13 @@ export const StyledAccordionButton = styled(
   }
 `;
 
-const StyledAccordion = styled(InternalAccordion)<FlexStyleProps>`
+const StyledContainer = styled(OakFlex)`
   ${StyledAccordionUnderline} {
     visibility: hidden;
   }
   ${StyledAccordionButton}:focus-visible ~ ${StyledAccordionUnderline} {
     visibility: visible;
   }
-
   ${oakBoxCss}
   ${flexStyle}
 `;
@@ -80,10 +78,9 @@ const Accordion = ({
   const { isOpen } = useAccordionContext();
 
   return (
-    <StyledAccordion
+    <StyledContainer
       $position={"relative"}
       $pv={"inner-padding-s"}
-      $display={"flex"}
       $flexDirection={"column"}
       $gap={"all-spacing-1"}
       {...styleProps}
@@ -97,27 +94,25 @@ const Accordion = ({
         {header}
         <OakIcon
           iconName="chevron-down"
-          $width="all-spacing-8"
-          $height="all-spacing-8"
-          alt=""
+          $width="all-spacing-7"
+          $height="all-spacing-7"
+          alt="An arrow to indicate whether the item is open or closed"
           style={{
             transform: isOpen ? "rotate(180deg)" : "none",
             transition: "all 0.3s ease 0s",
           }}
         />
       </StyledAccordionButton>
-      <InternalAccordionContent id={id}>{children}</InternalAccordionContent>
+      <InternalAccordionContent aria-labelledby={id}>
+        {children}
+      </InternalAccordionContent>
       <StyledAccordionUnderline $fill={"border-decorative5-stronger"} />
-    </StyledAccordion>
+    </StyledContainer>
   );
 };
 
 /**
- * An Internal accordion component that can be used to show/hide content
- *
- * It has a shadow and a hand-drawn underline effect and a chevron icon that rotates when the accordion is open
- *
- * other flex, box and color style proops can be passed to the accordion as props
+ * InternalChevronAccordion has a chevron icon that rotates when the accordion is open
  */
 
 export const InternalChevronAccordion = (

--- a/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
+++ b/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
@@ -5,22 +5,18 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-family: Lexend,sans-serif;
 }
 
-.c2 {
+.c3 {
   font-family: Lexend,sans-serif;
 }
 
-.c2:hover {
+.c3:hover {
   cursor: pointer;
 }
 
-.c7 {
+.c8 {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -29,11 +25,22 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c9 {
+.c10 {
   font-family: Lexend,sans-serif;
 }
 
-.c3 {
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -44,18 +51,18 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c8 {
+.c9 {
   object-fit: contain;
 }
 
-.c4 {
+.c5 {
   font: inherit;
   color: inherit;
   border: none;
@@ -67,13 +74,13 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   padding: 0;
 }
 
-.c12 {
+.c13 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,19 +97,15 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c6:hover {
+.c7:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c1 {
+.c2 {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-family: Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
@@ -114,27 +117,27 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c1 .c11 {
+.c2 .c12 {
   visibility: hidden;
 }
 
-.c1 .c5:focus-visible ~ .c11 {
+.c2 .c6:focus-visible ~ .c12 {
   visibility: visible;
 }
 
 <div
-  className="c0 c1"
+  className="c0 c1 c2"
 >
   <button
     aria-expanded={false}
-    className="c2 c3 c4 c5  c6"
+    className="c3 c4 c5 c6  c7"
     id="see-more"
     onClick={[Function]}
     type="button"
   >
     See more
     <div
-      className="c7"
+      className="c8"
       style={
         {
           "transform": "none",
@@ -144,7 +147,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
     >
       <img
         alt=""
-        className="c8"
+        className="c9"
         data-nimg="fill"
         decoding="async"
         loading="lazy"
@@ -170,14 +173,14 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   </button>
   <div
     aria-labelledby="see-more"
-    className="c9 "
+    className="c10 "
     hidden={true}
     role="region"
   >
     Here it is
   </div>
   <div
-    className="c9 c10 c11 c12"
+    className="c10 c11 c12 c13"
   >
     <svg
       className=""

--- a/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
+++ b/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
@@ -18,10 +18,10 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
 
 .c8 {
   position: relative;
-  width: 2.5rem;
-  min-width: 2.5rem;
-  height: 2.5rem;
-  min-height: 2.5rem;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -146,7 +146,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
       }
     >
       <img
-        alt=""
+        alt="An arrow to indicate whether the item is open or closed"
         className="c9"
         data-nimg="fill"
         decoding="async"

--- a/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
+++ b/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
@@ -22,10 +22,10 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
 
 .c7 {
   position: relative;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  height: 1.5rem;
-  min-height: 1.5rem;
+  width: 2.5rem;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  min-height: 2.5rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -78,6 +78,10 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;

--- a/src/components/molecules/OakAccordion/OakAccordion.tsx
+++ b/src/components/molecules/OakAccordion/OakAccordion.tsx
@@ -1,11 +1,10 @@
 import React, { ReactNode } from "react";
 import styled from "styled-components";
 
-import { OakFlex, OakIcon } from "@/components/atoms";
+import { OakBox, OakFlex, OakIcon } from "@/components/atoms";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 import {
-  InternalAccordion,
   InternalAccordionButton,
   InternalAccordionContent,
 } from "@/components/atoms/InternalAccordion";
@@ -59,7 +58,7 @@ const Accordion = ({
   const { isOpen } = useAccordionContext();
 
   return (
-    <InternalAccordion
+    <OakBox
       id={id}
       $borderColor="border-neutral-lighter"
       $ba="border-solid-s"
@@ -87,7 +86,7 @@ const Accordion = ({
         )}
       </OakFlex>
       <InternalAccordionContent
-        id={id}
+        aria-labelledby={id}
         $ml="space-between-m"
         $pl="inner-padding-m"
         $mt="space-between-sssx"
@@ -95,7 +94,7 @@ const Accordion = ({
       >
         {children}
       </InternalAccordionContent>
-    </InternalAccordion>
+    </OakBox>
   );
 };
 

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -14,22 +14,18 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-family: Lexend,sans-serif;
 }
 
-.c7 {
+.c8 {
   font-family: Lexend,sans-serif;
 }
 
-.c7:hover {
+.c8:hover {
   cursor: pointer;
 }
 
-.c12 {
+.c13 {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -55,7 +51,18 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   display: flex;
 }
 
-.c8 {
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -66,11 +73,11 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c13 {
+.c14 {
   object-fit: contain;
 }
 
-.c9 {
+.c10 {
   font: inherit;
   color: inherit;
   border: none;
@@ -82,13 +89,13 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   padding: 0;
 }
 
-.c15 {
+.c16 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -105,19 +112,15 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c11:hover {
+.c12:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c6 {
+.c7 {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-family: Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
@@ -129,11 +132,11 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c6 .c14 {
+.c7 .c15 {
   visibility: hidden;
 }
 
-.c6 .c10:focus-visible ~ .c14 {
+.c7 .c11:focus-visible ~ .c15 {
   visibility: visible;
 }
 
@@ -143,7 +146,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   bottom: 0.125rem;
 }
 
-.c16 {
+.c17 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
@@ -175,18 +178,18 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
     </svg>
   </div>
   <div
-    className="c5 c6"
+    className="c5 c6 c7"
   >
     <button
       aria-expanded={false}
-      className="c7 c8 c9 c10  c11"
+      className="c8 c9 c10 c11  c12"
       id="see-more"
       onClick={[Function]}
       type="button"
     >
       See more
       <div
-        className="c12"
+        className="c13"
         style={
           {
             "transform": "none",
@@ -196,7 +199,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
       >
         <img
           alt=""
-          className="c13"
+          className="c14"
           data-nimg="fill"
           decoding="async"
           loading="lazy"
@@ -229,7 +232,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
       Here it is
     </div>
     <div
-      className="c2 c3 c14 c15"
+      className="c2 c3 c15 c16"
     >
       <svg
         className=""
@@ -251,7 +254,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c2 c3 c16"
+    className="c2 c3 c17"
   >
     <svg
       className=""

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -27,10 +27,10 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
 
 .c13 {
   position: relative;
-  width: 2.5rem;
-  min-width: 2.5rem;
-  height: 2.5rem;
-  min-height: 2.5rem;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -198,7 +198,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
         }
       >
         <img
-          alt=""
+          alt="An arrow to indicate whether the item is open or closed"
           className="c14"
           data-nimg="fill"
           decoding="async"

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -31,10 +31,10 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
 
 .c12 {
   position: relative;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  height: 1.5rem;
-  min-height: 1.5rem;
+  width: 2.5rem;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  min-height: 2.5rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -93,6 +93,10 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -33,10 +33,10 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 
 .c16 {
   position: relative;
-  width: 2.5rem;
-  min-width: 2.5rem;
-  height: 2.5rem;
-  min-height: 2.5rem;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -464,7 +464,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
             }
           >
             <img
-              alt=""
+              alt="An arrow to indicate whether the item is open or closed"
               className="c17"
               data-nimg="fill"
               decoding="async"

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -20,22 +20,18 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-family: Lexend,sans-serif;
 }
 
-.c9 {
+.c10 {
   font-family: Lexend,sans-serif;
 }
 
-.c9:hover {
+.c10:hover {
   cursor: pointer;
 }
 
-.c15 {
+.c16 {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -44,7 +40,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c18 {
+.c19 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -52,7 +48,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c20 {
+.c21 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -86,7 +82,18 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   display: flex;
 }
 
-.c10 {
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -97,7 +104,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -112,7 +119,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1rem;
 }
 
-.c23 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -131,7 +138,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 0.5rem;
 }
 
-.c24 {
+.c25 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -143,11 +150,11 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
 }
 
-.c16 {
+.c17 {
   object-fit: contain;
 }
 
-.c14 {
+.c15 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -158,7 +165,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c21 {
+.c22 {
   background: none;
   color: inherit;
   border: none;
@@ -180,12 +187,12 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c21:disabled {
+.c22:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c25 {
+.c26 {
   background: none;
   color: inherit;
   border: none;
@@ -207,19 +214,19 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c25:disabled {
+.c26:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c22 {
+.c23 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c22:hover {
+.c23:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -227,26 +234,26 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-color: #575757;
 }
 
-.c22:active {
+.c23:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c22:disabled {
+.c23:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c26 {
+.c27 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c26:hover {
+.c27:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -254,44 +261,44 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-color: #222222;
 }
 
-.c26:active {
+.c27:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c26:disabled {
+.c27:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c20 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c20 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:hover),
-.c19 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c20 .yellow-shadow:has(+ .internal-button:hover),
+.c20 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:hover) {
+.c20 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c19 .grey-shadow:has(+ * + .internal-button:active) {
+.c20 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c19 .yellow-shadow:has(+ .internal-button:active) {
+.c20 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c11 {
+.c12 {
   font: inherit;
   color: inherit;
   border: none;
@@ -303,13 +310,13 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   padding: 0;
 }
 
-.c28 {
+.c29 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -326,19 +333,15 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c13:hover {
+.c14:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c8 {
+.c9 {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-family: Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
@@ -350,11 +353,11 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c8 .c27 {
+.c9 .c28 {
   visibility: hidden;
 }
 
-.c8 .c12:focus-visible ~ .c27 {
+.c9 .c13:focus-visible ~ .c28 {
   visibility: visible;
 }
 
@@ -364,7 +367,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   bottom: 0.125rem;
 }
 
-.c29 {
+.c30 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
@@ -388,7 +391,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c17 {
+  .c18 {
     -webkit-box-pack: start;
     -webkit-justify-content: start;
     -ms-flex-pack: start;
@@ -397,7 +400,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c17 {
+  .c18 {
     -webkit-box-pack: end;
     -webkit-justify-content: end;
     -ms-flex-pack: end;
@@ -437,22 +440,22 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </svg>
       </div>
       <div
-        className="c7 c8"
+        className="c7 c8 c9"
       >
         <button
           aria-expanded={false}
-          className="c9 c10 c11 c12  c13"
+          className="c10 c11 c12 c13  c14"
           id="mobile-unit-filter-accordion"
           onClick={[Function]}
           type="button"
         >
           <h2
-            className="c14"
+            className="c15"
           >
             Categories
           </h2>
           <div
-            className="c15"
+            className="c16"
             style={
               {
                 "transform": "none",
@@ -462,7 +465,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           >
             <img
               alt=""
-              className="c16"
+              className="c17"
               data-nimg="fill"
               decoding="async"
               loading="lazy"
@@ -494,31 +497,31 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         >
           <div
             aria-label="OakPupilJourneyUnitsFilter"
-            className="c4 c17"
+            className="c4 c18"
             role="radiogroup"
           >
             <div
-              className="c18 c19"
+              className="c19 c20"
             >
               <div
-                className="c20 grey-shadow"
+                className="c21 grey-shadow"
               />
               <div
-                className="c20 yellow-shadow"
+                className="c21 yellow-shadow"
               />
               <button
                 aria-checked={true}
-                className="c21 c22 internal-button"
+                className="c22 c23 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 role="radio"
               >
                 <div
-                  className="c4 c23"
+                  className="c4 c24"
                 >
                   <span
-                    className="c24"
+                    className="c25"
                   >
                     All
                   </span>
@@ -526,27 +529,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
               </button>
             </div>
             <div
-              className="c18 c19"
+              className="c19 c20"
             >
               <div
-                className="c20 grey-shadow"
+                className="c21 grey-shadow"
               />
               <div
-                className="c20 yellow-shadow"
+                className="c21 yellow-shadow"
               />
               <button
                 aria-checked={false}
-                className="c25 c26 internal-button"
+                className="c26 c27 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 role="radio"
               >
                 <div
-                  className="c4 c23"
+                  className="c4 c24"
                 >
                   <span
-                    className="c24"
+                    className="c25"
                   >
                     Biology
                   </span>
@@ -554,27 +557,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
               </button>
             </div>
             <div
-              className="c18 c19"
+              className="c19 c20"
             >
               <div
-                className="c20 grey-shadow"
+                className="c21 grey-shadow"
               />
               <div
-                className="c20 yellow-shadow"
+                className="c21 yellow-shadow"
               />
               <button
                 aria-checked={false}
-                className="c25 c26 internal-button"
+                className="c26 c27 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 role="radio"
               >
                 <div
-                  className="c4 c23"
+                  className="c4 c24"
                 >
                   <span
-                    className="c24"
+                    className="c25"
                   >
                     Chemistry
                   </span>
@@ -582,27 +585,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
               </button>
             </div>
             <div
-              className="c18 c19"
+              className="c19 c20"
             >
               <div
-                className="c20 grey-shadow"
+                className="c21 grey-shadow"
               />
               <div
-                className="c20 yellow-shadow"
+                className="c21 yellow-shadow"
               />
               <button
                 aria-checked={false}
-                className="c25 c26 internal-button"
+                className="c26 c27 internal-button"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 role="radio"
               >
                 <div
-                  className="c4 c23"
+                  className="c4 c24"
                 >
                   <span
-                    className="c24"
+                    className="c25"
                   >
                     Physics
                   </span>
@@ -612,7 +615,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c4 c5 c27 c28"
+          className="c4 c5 c28 c29"
         >
           <svg
             className=""
@@ -634,7 +637,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c4 c5 c29"
+        className="c4 c5 c30"
       >
         <svg
           className=""

--- a/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -37,10 +37,10 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 
 .c15 {
   position: relative;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  height: 1.5rem;
-  min-height: 1.5rem;
+  width: 2.5rem;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  min-height: 2.5rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -314,6 +314,10 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;

--- a/src/components/organisms/pupil/OakQuizMatch/OakQuizMatch.tsx
+++ b/src/components/organisms/pupil/OakQuizMatch/OakQuizMatch.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/molecules";
 import { usePrefersReducedMotion } from "@/animation/usePrefersReducedMotion";
 import { InternalDndContext } from "@/components/atoms/InternalDndContext/InternalDndContext";
-import ClientPortal from "@/components/atoms/ClientPortal/ClientPortal";
+import { InternalClientPortal } from "@/components/atoms/InternalClientPortal";
 
 type DraggableId = string;
 type DroppableId = string;
@@ -212,13 +212,13 @@ export const OakQuizMatch = ({
             />
           ))}
         </OakFlex>
-        <ClientPortal show={true}>
+        <InternalClientPortal show={true}>
           <DragOverlay dropAnimation={prefersReducedMotion ? null : undefined}>
             {activeDraggable && (
               <OakDraggable isDragging>{activeDraggable.label}</OakDraggable>
             )}
           </DragOverlay>
-        </ClientPortal>
+        </InternalClientPortal>
       </InternalDndContext>
     </>
   );


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

- update the chevron size to match the designs 
- also centrally align the text to match the icon
- renamed client portal to adhere to naming rules
- tidied up InternalAccordion by removing unecessary exports and clarifying documentation - follow through on consuming components.

## Link to the design doc

https://www.figma.com/design/zqpeecgzMGKRli2gUdJOLp/Pupil-Browse?node-id=5646-7817&m=dev

## A link to the component in the deployment preview

https://deploy-preview-231--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oakoutlineaccordion--docs

Also check this hasn't changed :
https://deploy-preview-231--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oakaccordion--docs

## Testing instructions

## ACs
