### PR TITLE
[PUPIL-864] Fix accessibility issue on OakQuizHint

### DIFF
--- a/src/components/organisms/pupil/OakLessonBottomNav/OakLessonBottomNav.tsx
+++ b/src/components/organisms/pupil/OakLessonBottomNav/OakLessonBottomNav.tsx
@@ -41,7 +41,7 @@ export const OakLessonBottomNav = ({
       );
       break;
     case !!hint:
-      content = <OakQuizHint hint={hint} />;
+      content = <OakQuizHint hint={hint} id="quiz-hint" />;
       break;
     default:
       content = null;

--- a/src/components/organisms/pupil/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/organisms/pupil/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -13,6 +13,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 .c5 {
+  display: none;
+  font-family: Lexend,sans-serif;
+}
+
+.c6 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -20,7 +25,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c12 {
+.c13 {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -31,7 +36,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c14 {
+.c15 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -40,7 +45,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c15 {
+.c16 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -49,7 +54,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c18 {
+.c19 {
   width: 100%;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -79,14 +84,14 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -105,7 +110,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   gap: 0.75rem;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -120,7 +125,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -138,7 +143,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c17 {
+.c18 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -149,11 +154,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c16 {
+.c17 {
   object-fit: contain;
 }
 
-.c9 {
+.c10 {
   background: none;
   color: inherit;
   border: none;
@@ -167,59 +172,59 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   color: #222222;
 }
 
-.c9:disabled {
+.c10:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   position: relative;
 }
 
-.c10:hover {
+.c11:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
 }
 
-.c10:active {
+.c11:active {
   color: #222222;
 }
 
-.c10:disabled {
+.c11:disabled {
   color: #808080;
 }
 
-.c7 > :first-child:focus-visible .shadow {
+.c8 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c7 > :first-child:hover .shadow {
+.c8 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c7 > :first-child:active .shadow {
+.c8 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c7 > :first-child:disabled .icon-container {
+.c8 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c7 > :first-child:hover .icon-container {
+.c8 > :first-child:hover .icon-container {
   background: #ffe555;
 }
 
-.c7 > :first-child:active .icon-container {
+.c8 > :first-child:active .icon-container {
   background: #ffe555;
 }
 
-.c8:hover .shadow {
+.c9:hover .shadow {
   box-shadow: none !important;
 }
 
-.c8:active .shadow {
+.c9:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%) !important;
 }
 
@@ -228,7 +233,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c18 {
+  .c19 {
     width: auto;
   }
 }
@@ -242,7 +247,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c19 {
+  .c20 {
     -webkit-box-pack: end;
     -webkit-justify-content: flex-end;
     -ms-flex-pack: end;
@@ -257,6 +262,12 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       className="c3 c4"
     >
       <div
+        className="c5"
+        id="quiz-hint"
+      >
+        The answer is right in front of your eyes
+      </div>
+      <div
         style={
           {
             "display": "contents",
@@ -264,32 +275,32 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
         }
       >
         <div
-          className="c5 c6 c7 c8"
+          className="c6 c7 c8 c9"
         >
           <button
-            aria-describedby="hint-tooltip"
-            className="c9 c10"
+            aria-describedby="quiz-hint"
+            className="c10 c11"
             data-rac={true}
             onClick={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
           >
             <div
-              className="c3 c11"
+              className="c3 c12"
             >
               <div
-                className="c12 c13 icon-container"
+                className="c13 c14 icon-container"
               >
                 <div
-                  className="c14 shadow"
+                  className="c15 shadow"
                 />
                 <div
-                  className="c15"
+                  className="c16"
                   data-icon-for="button"
                 >
                   <img
                     alt="lightbulb"
-                    className="c16"
+                    className="c17"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -314,7 +325,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
                 </div>
               </div>
               <span
-                className="c17"
+                className="c18"
               >
                 Need a hint?
               </span>
@@ -324,7 +335,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c18 c19"
+      className="c19 c20"
     />
   </div>,
   .c0 {

--- a/src/components/organisms/pupil/OakQuizHint/OakQuizHint.stories.tsx
+++ b/src/components/organisms/pupil/OakQuizHint/OakQuizHint.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta<typeof OakQuizHint> = {
   ],
   args: {
     hint: "A football and an orange are both sphere shaped, like Earth.",
+    id: "quiz-hint",
   },
 };
 export default meta;

--- a/src/components/organisms/pupil/OakQuizHint/OakQuizHint.test.tsx
+++ b/src/components/organisms/pupil/OakQuizHint/OakQuizHint.test.tsx
@@ -11,7 +11,11 @@ describe(OakQuizHint, () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <OakQuizHint hint="The answer is right in front of your eyes" />,
+        <OakQuizHint
+          hint="The answer is right in front of your eyes"
+          id="quiz-hint"
+        />
+        ,
       </OakThemeProvider>,
     ).toJSON();
 

--- a/src/components/organisms/pupil/OakQuizHint/OakQuizHint.tsx
+++ b/src/components/organisms/pupil/OakQuizHint/OakQuizHint.tsx
@@ -2,35 +2,37 @@ import React, { MouseEventHandler, ReactNode, useState } from "react";
 
 import { OakTooltip } from "@/components/molecules";
 import { OakHintButton } from "@/components/organisms/pupil/OakHintButton";
+import { OakBox } from "@/components/atoms";
 
 export type OakQuizHintProps = {
   /**
    * Some content to give as a hint to answer a question
    */
   hint: ReactNode;
+  id: string;
 };
 
 /**
  * Presents a button which will show a hint when clicked
  */
-export const OakQuizHint = ({ hint }: OakQuizHintProps) => {
+export const OakQuizHint = ({ hint, id }: OakQuizHintProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const handleClick: MouseEventHandler = () => {
     setIsOpen(!isOpen);
   };
 
   return (
-    <OakTooltip
-      tooltip={hint}
-      isOpen={isOpen}
-      id="hint-tooltip"
-      tooltipPosition="top-left"
-    >
-      <OakHintButton
-        isOpen={isOpen}
-        onClick={handleClick}
-        buttonProps={{ "aria-describedby": "hint-tooltip" }}
-      />
-    </OakTooltip>
+    <>
+      <OakBox $display="none" id={id}>
+        {hint}
+      </OakBox>
+      <OakTooltip tooltip={hint} isOpen={isOpen} tooltipPosition="top-left">
+        <OakHintButton
+          isOpen={isOpen}
+          onClick={handleClick}
+          buttonProps={{ "aria-describedby": id }}
+        />
+      </OakTooltip>
+    </>
   );
 };

--- a/src/components/organisms/pupil/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/organisms/pupil/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -3,6 +3,17 @@
 exports[`OakQuizHint matches snapshot 1`] = `
 [
   .c0 {
+  display: none;
+  font-family: Lexend,sans-serif;
+}
+
+<div
+    className="c0"
+    id="quiz-hint"
+  >
+    The answer is right in front of your eyes
+  </div>,
+  .c0 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -180,7 +191,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
       className="c0 c1 c2 c3"
     >
       <button
-        aria-describedby="hint-tooltip"
+        aria-describedby="quiz-hint"
         className="c4 c5"
         data-rac={true}
         onClick={[Function]}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

There was an issue with the `aria-describedby` referring to an id of an element that is only rendered when the button is clicked.

The fix is to place an additional hidden div with that id next to the component that contains the hint.

In addition, I noticed that with the `id` hardcoded it would mean we could only use the OakQuizHint once on a page. I adjusted it so the id is passed in. This also meant OakLessonBottomNav needed to include an `id` on the usage of OakQuizHint.

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
