### PR TITLE
PUPIL-873 feat(angle-label): add oak jaunty angle label component to storybook

### DIFF
--- a/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.stories.tsx
+++ b/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof OakJauntyAngleLabel> = {
   component: OakJauntyAngleLabel,
   tags: ["autodocs"],
   title: "components/molecules/OakJauntyAngleLabel",
-  args: { label: "Select one answer", type: "starter" },
+  args: { label: "Select one answer" },
   decorators: [
     (Story) => (
       <OakFlex $pa={"inner-padding-xl"} $flexDirection={"row"}>
@@ -24,4 +24,5 @@ type Story = StoryObj<typeof OakJauntyAngleLabel>;
 
 export const Default: Story = {
   render: (args) => <OakJauntyAngleLabel {...args} />,
+  args: { $background: "bg-decorative1-main" },
 };

--- a/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.stories.tsx
+++ b/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.stories.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakJauntyAngleLabel } from "./OakJauntyAngleLabel";
+
+import { OakFlex } from "@/components/atoms";
+
+const meta: Meta<typeof OakJauntyAngleLabel> = {
+  component: OakJauntyAngleLabel,
+  tags: ["autodocs"],
+  title: "components/molecules/OakJauntyAngleLabel",
+  args: { label: "Select one answer", type: "starter" },
+  decorators: [
+    (Story) => (
+      <OakFlex $pa={"inner-padding-xl"} $flexDirection={"row"}>
+        <Story />
+      </OakFlex>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof OakJauntyAngleLabel>;
+
+export const Default: Story = {
+  render: (args) => <OakJauntyAngleLabel {...args} />,
+};

--- a/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.test.tsx
+++ b/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.test.tsx
@@ -11,7 +11,7 @@ describe("OakjauntyAngleLabel", () => {
   it("matches snapshot", () => {
     const tree = create(
       <ThemeProvider theme={oakDefaultTheme}>
-        <OakJauntyAngleLabel type="starter" label="Select one answer" />
+        <OakJauntyAngleLabel label="Select one answer" />
       </ThemeProvider>,
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.test.tsx
+++ b/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+import { ThemeProvider } from "styled-components";
+
+import { OakJauntyAngleLabel } from "./OakJauntyAngleLabel";
+
+import { oakDefaultTheme } from "@/styles";
+
+describe("OakjauntyAngleLabel", () => {
+  it("matches snapshot", () => {
+    const tree = create(
+      <ThemeProvider theme={oakDefaultTheme}>
+        <OakJauntyAngleLabel type="starter" label="Select one answer" />
+      </ThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.tsx
+++ b/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import { OakBox } from "@/components/atoms";
+
+export type OakJauntyAngleLabelProps = {
+  label: string;
+  type: "starter" | "exit";
+};
+export const OakJauntyAngleLabel = (props: OakJauntyAngleLabelProps) => {
+  const { label, type } = props;
+  return (
+    <OakBox
+      $borderRadius={"border-radius-m"}
+      $ph={"inner-padding-xs"}
+      $pv={"inner-padding-ssx"}
+      $font={["heading-7", "heading-6"]}
+      $background={
+        "starter" === type ? "bg-decorative1-main" : "bg-decorative5-main"
+      }
+      $transform={"rotate(-1.5deg)"}
+    >
+      {label}
+    </OakBox>
+  );
+};

--- a/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.tsx
+++ b/src/components/molecules/OakJauntyAngleLabel/OakJauntyAngleLabel.tsx
@@ -1,23 +1,20 @@
 import React from "react";
 
-import { OakBox } from "@/components/atoms";
+import { OakBox, OakBoxProps } from "@/components/atoms";
 
 export type OakJauntyAngleLabelProps = {
   label: string;
-  type: "starter" | "exit";
-};
+} & Omit<OakBoxProps, "onClick" | "label">;
 export const OakJauntyAngleLabel = (props: OakJauntyAngleLabelProps) => {
-  const { label, type } = props;
+  const { label, ...oakBoxProps } = props;
   return (
     <OakBox
       $borderRadius={"border-radius-m"}
       $ph={"inner-padding-xs"}
       $pv={"inner-padding-ssx"}
       $font={["heading-7", "heading-6"]}
-      $background={
-        "starter" === type ? "bg-decorative1-main" : "bg-decorative5-main"
-      }
       $transform={"rotate(-1.5deg)"}
+      {...oakBoxProps}
     >
       {label}
     </OakBox>

--- a/src/components/molecules/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
+++ b/src/components/molecules/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakjauntyAngleLabel matches snapshot 1`] = `
+.c0 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  background: #bef2bd;
+  border-radius: 0.375rem;
+  -webkit-transform: rotate(-1.5deg);
+  -ms-transform: rotate(-1.5deg);
+  transform: rotate(-1.5deg);
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+@media (min-width:750px) {
+  .c0 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    font-size: 1.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+<div
+  className="c0"
+>
+  Select one answer
+</div>
+`;

--- a/src/components/molecules/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
+++ b/src/components/molecules/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`OakjauntyAngleLabel matches snapshot 1`] = `
   padding-right: 0.5rem;
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
-  background: #bef2bd;
   border-radius: 0.375rem;
   -webkit-transform: rotate(-1.5deg);
   -ms-transform: rotate(-1.5deg);

--- a/src/components/molecules/OakJauntyAngleLabel/index.ts
+++ b/src/components/molecules/OakJauntyAngleLabel/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakJauntyAngleLabel";


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
OakJauntyAngleLabel
## Link to the design doc
https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/%F0%9F%9F%A2-Oak-Design-Kit?m=auto&node-id=9600-1211
## A link to the component in the deployment preview

## Testing instructions

## ACs
