### PR TITLE
[PUPIL-797] New pupil lesson svg backgrounds and colours

### DIFF
--- a/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.stories.tsx
+++ b/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.stories.tsx
@@ -5,7 +5,11 @@ import { OakLessonTopNav } from "../OakLessonTopNav";
 import { OakLessonBottomNav } from "../OakLessonBottomNav";
 import { OakQuizCounter } from "../OakQuizCounter";
 
-import { OakLessonLayout, OakLessonLayoutProps } from "./OakLessonLayout";
+import {
+  OakLessonLayout,
+  OakLessonLayoutProps,
+  lessonSectionNames,
+} from "./OakLessonLayout";
 
 import { OakBackLink, OakPrimaryButton } from "@/components/molecules";
 import { OakBox } from "@/components/atoms";
@@ -15,14 +19,28 @@ const meta: Meta<typeof OakLessonLayout> = {
   tags: ["autodocs"],
   title: "components/organisms/pupil/OakLessonLayout",
   decorators: [(Story) => <Story />],
+  argTypes: {
+    lessonSectionName: {
+      options: [...lessonSectionNames],
+      control: { type: "radio" },
+    },
+    phase: {
+      options: ["primary", "secondary"],
+      control: { type: "radio" },
+    },
+    celebrate: {
+      control: { type: "boolean" },
+    },
+  },
   parameters: {
     controls: {
-      include: ["lessonSectionName"],
+      include: ["lessonSectionName", "celebrate", "phase"],
     },
     layout: "fullscreen",
   },
   args: {
-    lessonSectionName: "intro",
+    lessonSectionName: lessonSectionNames[0],
+    celebrate: false,
   },
 };
 export default meta;
@@ -57,7 +75,13 @@ export const Default: Story = {
       topNavSlot={
         lessonSectionName !== "overview" && lessonSectionName !== "review" ? (
           <OakLessonTopNav
-            lessonSectionName={lessonSectionName}
+            lessonSectionName={
+              lessonSectionName as
+                | "intro"
+                | "starter-quiz"
+                | "video"
+                | "exit-quiz"
+            }
             backLinkSlot={<OakBackLink type="button" />}
             heading={headings[lessonSectionName]}
             mobileSummary={mobileSumamry[lessonSectionName]}

--- a/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.stories.tsx
+++ b/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.stories.tsx
@@ -75,13 +75,7 @@ export const Default: Story = {
       topNavSlot={
         lessonSectionName !== "overview" && lessonSectionName !== "review" ? (
           <OakLessonTopNav
-            lessonSectionName={
-              lessonSectionName as
-                | "intro"
-                | "starter-quiz"
-                | "video"
-                | "exit-quiz"
-            }
+            lessonSectionName={lessonSectionName}
             backLinkSlot={<OakBackLink type="button" />}
             heading={headings[lessonSectionName]}
             mobileSummary={mobileSumamry[lessonSectionName]}

--- a/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.tsx
+++ b/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.tsx
@@ -17,9 +17,9 @@ export const lessonSectionNames: string[] = [
   "review",
 ];
 
-type Phase = "primary" | "secondary";
+export type LessonSectionName = (typeof lessonSectionNames)[number];
 
-type LessonSectionName = (typeof lessonSectionNames)[number];
+type Phase = "primary" | "secondary";
 
 export type OakLessonLayoutProps = {
   lessonSectionName: LessonSectionName;

--- a/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.tsx
+++ b/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.tsx
@@ -1,21 +1,29 @@
 import React, { ReactNode } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { OakBox, OakFlex } from "@/components/atoms";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
 import { getBreakpoint } from "@/styles/utils/responsiveStyle";
 import { OakCombinedColorToken } from "@/styles";
+import { backgrounds } from "@/image-map";
 
-type LessonSectionName =
-  | "overview"
-  | "intro"
-  | "starter-quiz"
-  | "video"
-  | "exit-quiz"
-  | "review";
+export const lessonSectionNames: string[] = [
+  "overview",
+  "intro",
+  "starter-quiz",
+  "video",
+  "exit-quiz",
+  "review",
+];
+
+type Phase = "primary" | "secondary";
+
+type LessonSectionName = (typeof lessonSectionNames)[number];
 
 export type OakLessonLayoutProps = {
   lessonSectionName: LessonSectionName;
+  phase: Phase;
+  celebrate: boolean;
   topNavSlot: ReactNode;
   bottomNavSlot: ReactNode;
   children: ReactNode;
@@ -25,10 +33,24 @@ export type OakLessonLayoutProps = {
  * `OakBox` does not support space-between tokens on `padding` only `margin`, so we need to
  * set it here to apply appropriate padding to the top of the content.
  */
-const StyledLayoutBox = styled(OakBox)`
+const StyledLayoutBox = styled(OakBox)<{
+  sectionName: LessonSectionName;
+  phase: Phase;
+  celebrate: boolean;
+}>`
   @media (min-width: ${getBreakpoint("small")}px) {
     padding-top: ${parseSpacing("space-between-xl")};
   }
+  ${(props) => css`
+    ${getBackgroundUrlForLesson(
+      props.sectionName,
+      props.phase,
+      props.celebrate,
+    )}
+  `}
+  background-repeat: no-repeat;
+  background-position-x: center;
+  background-size: 100%;
 `;
 
 const StickyFooter = styled(OakBox)`
@@ -42,6 +64,8 @@ const StickyFooter = styled(OakBox)`
  */
 export const OakLessonLayout = ({
   lessonSectionName,
+  phase = "primary",
+  celebrate = false,
   topNavSlot,
   bottomNavSlot,
   children,
@@ -51,7 +75,7 @@ export const OakLessonLayout = ({
     contentBackgroundColor,
     contentBorderColor,
     mobileContentBackgroundColor,
-  ] = pickSectionColours(lessonSectionName);
+  ] = pickSectionColours(lessonSectionName, phase);
 
   return (
     <StyledLayoutBox
@@ -60,6 +84,9 @@ export const OakLessonLayout = ({
       $minHeight={"100%"}
       $ph={["inner-padding-none", "inner-padding-xl"]}
       $background={pageBackgroundColor}
+      sectionName={lessonSectionName}
+      celebrate={celebrate}
+      phase={phase}
     >
       <OakFlex
         $flexDirection="column"
@@ -110,6 +137,7 @@ export const OakLessonLayout = ({
 
 function pickSectionColours(
   sectionName: LessonSectionName,
+  phase: Phase,
 ): [
   pageBackgroundColor: OakCombinedColorToken,
   contentBackgroundColor: OakCombinedColorToken,
@@ -118,12 +146,19 @@ function pickSectionColours(
 ] {
   switch (sectionName) {
     case "overview":
-      return [
-        "bg-decorative1-main",
-        "bg-primary",
-        "border-decorative1-stronger",
-        "bg-primary",
-      ];
+      return phase === "secondary"
+        ? [
+            "bg-decorative3-subdued",
+            "bg-primary",
+            "border-decorative3",
+            "bg-primary",
+          ]
+        : [
+            "bg-decorative4-subdued",
+            "bg-primary",
+            "border-decorative4",
+            "bg-primary",
+          ];
     case "intro":
       return [
         "bg-decorative2-subdued",
@@ -153,11 +188,57 @@ function pickSectionColours(
         "bg-decorative5-subdued",
       ];
     case "review":
+      return phase === "secondary"
+        ? [
+            "bg-decorative3-subdued",
+            "bg-primary",
+            "border-decorative3",
+            "bg-primary",
+          ]
+        : [
+            "bg-decorative4-subdued",
+            "bg-primary",
+            "border-decorative4",
+            "bg-primary",
+          ];
+    default:
       return [
-        "bg-decorative1-main",
+        "bg-decorative3-subdued",
         "bg-primary",
-        "border-decorative1-stronger",
+        "border-decorative3",
         "bg-primary",
       ];
+  }
+}
+
+function getBackgroundUrlForLesson(
+  sectionName: LessonSectionName,
+  phase: Phase,
+  celebrate: boolean,
+) {
+  const prefix = `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/`;
+  switch (sectionName) {
+    case "overview":
+      return phase === "secondary"
+        ? `background-image: url(${prefix}${backgrounds["lesson-confetti-lavender"]});`
+        : `background-image: url(${prefix}${backgrounds["lesson-confetti-pink"]});`;
+    case "intro":
+      return `background-image: url(${prefix}${backgrounds["lesson-confetti-mint"]});`;
+    case "starter-quiz":
+      return celebrate
+        ? `background-image: url(${prefix}${backgrounds["lesson-confetti-green"]});`
+        : ``;
+    case "video":
+      return `background-image: url(${prefix}${backgrounds["lesson-confetti-pink"]});`;
+    case "exit-quiz":
+      return celebrate
+        ? `background-image: url(${prefix}${backgrounds["lesson-confetti-green-lemon"]});`
+        : ``;
+    case "review":
+      return phase === "secondary"
+        ? `background-image: url(${prefix}${backgrounds["lesson-confetti-lavender"]});`
+        : `background-image: url(${prefix}${backgrounds["lesson-confetti-pink"]});`;
+    default:
+      return "";
   }
 }

--- a/src/components/organisms/pupil/OakLessonTopNav/OakLessonTopNav.tsx
+++ b/src/components/organisms/pupil/OakLessonTopNav/OakLessonTopNav.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode } from "react";
 import styled from "styled-components";
 
+import { LessonSectionName } from "../OakLessonLayout";
+
 import {
   OakBox,
   OakFlex,
@@ -11,7 +13,7 @@ import {
 import { OakRoundIcon } from "@/components/molecules";
 import { getBreakpoint } from "@/styles/utils/responsiveStyle";
 
-type LessonSectionName = "intro" | "starter-quiz" | "video" | "exit-quiz";
+type LessonTopNavSectionName = Omit<LessonSectionName, "overview" | "review">;
 
 const StyledMobileSummary = styled(OakSpan)`
   @media (min-width: ${getBreakpoint("small")}px) {
@@ -20,7 +22,7 @@ const StyledMobileSummary = styled(OakSpan)`
 `;
 
 export type OakLessonTopNavProps = {
-  lessonSectionName: LessonSectionName;
+  lessonSectionName: LessonTopNavSectionName;
   /**
    * Slot to render `OakBackLink` or similar
    */
@@ -75,7 +77,7 @@ export const OakLessonTopNav = ({
 };
 
 function pickSectionIcon(
-  sectionName: LessonSectionName,
+  sectionName: LessonTopNavSectionName,
 ): Pick<OakIconProps, "iconName" | "$background"> {
   switch (sectionName) {
     case "intro":
@@ -97,6 +99,11 @@ function pickSectionIcon(
       return {
         iconName: "quiz",
         $background: "lemon110",
+      };
+    default:
+      return {
+        iconName: "intro",
+        $background: "aqua110",
       };
   }
 }

--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -120,6 +120,13 @@ export const backgrounds = {
   "confetti-pink": "pupil-journey/confetti-pink.svg",
   "confetti-lavender": "pupil-journey/confetti-lavender.svg",
   "confetti-mint": "pupil-journey/confetti-mint.svg",
+  "lesson-confetti-green": "pupil-journey/lesson/lesson-confetti-green.svg",
+  "lesson-confetti-mint": "pupil-journey/lesson/lesson-confetti-mint.svg",
+  "lesson-confetti-pink": "pupil-journey/lesson/lesson-confetti-pink.svg",
+  "lesson-confetti-green-lemon":
+    "pupil-journey/lesson/lesson-confetti-green-lemon.svg",
+  "lesson-confetti-lavender":
+    "pupil-journey/lesson/lesson-confetti-lavender.svg",
   "line-pink": "pupil-journey/line-pink.svg",
   "line-lavender": "pupil-journey/line-lavender.svg",
   "line-mint": "pupil-journey/line-mint.svg",


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitive files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Started [svg background ticket](https://www.notion.so/oaknationalacademy/OakComponents-OakLessonLayout-SVG-Illustration-applied-to-desktop-page-backgrounds-03b172a946894d47b3c8077971816d37) and then realised then also realised it needed the [overview and review colour updates](https://www.notion.so/oaknationalacademy/OakComponents-Lesson-overview-Lesson-review-colour-updates-065f72d47fdb4b7a9d808b20a87bcb5a), so I'm doing them as one ticket.

This adds primary and secondary backgrounds to the lesson overview and review, as well as the svg backgrounds for lesson introduction, quizzes and video.

The layout now has a celebrate property that will show the svg background on the quiz pages. I'm happy to review the naming etc in the code review.

Video for Richard 😁 
![svg backgrounds](https://github.com/user-attachments/assets/fc61c11c-ecec-49d9-b32f-5dbc7d5e0063)

## Link to the design doc

## A link to the component in the deployment preview

https://deploy-preview-240--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-pupil-oaklessonlayout--default

## Testing instructions

You might need to drag the controls up from the bottom to change the sections, phase and celebrate option (which only takes effect on quiz sections).

 - Moving between the section types should change the background colours and borders etc.
 - For Overview and Review the phase can be changed to show a primary and secondary colour scheme.
 - The celebrate option should display the svg background on the quiz sections.
 - On mobile the svg and backgrounds aren't visible.
 
## ACs
