### PR TITLE
fix: missed marking 2 OakLessonLayoutProps props as optional

### DIFF
--- a/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.tsx
+++ b/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.tsx
@@ -23,8 +23,8 @@ type Phase = "primary" | "secondary";
 
 export type OakLessonLayoutProps = {
   lessonSectionName: LessonSectionName;
-  phase: Phase;
-  celebrate: boolean;
+  phase?: Phase;
+  celebrate?: boolean;
   topNavSlot: ReactNode;
   bottomNavSlot: ReactNode;
   children: ReactNode;


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Missed marking 2 props as optional.

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
