### PR TITLE
fix: update so that pupil lesson svg backgrounds only show on large displays

### DIFF
--- a/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.tsx
+++ b/src/components/organisms/pupil/OakLessonLayout/OakLessonLayout.tsx
@@ -42,16 +42,18 @@ const StyledLayoutBox = styled(OakBox)<{
   @media (min-width: ${getBreakpoint("small")}px) {
     padding-top: ${parseSpacing("space-between-xl")};
   }
-  ${(props) => css`
-    ${getBackgroundUrlForLesson(
-      props.sectionName,
-      props.phase,
-      props.celebrate,
-    )}
-  `}
-  background-repeat: no-repeat;
-  background-position-x: center;
-  background-size: 100%;
+  @media (min-width: ${getBreakpoint("large")}px) {
+    ${(props) => css`
+      ${getBackgroundUrlForLesson(
+        props.sectionName,
+        props.phase,
+        props.celebrate,
+      )}
+    `}
+    background-repeat: no-repeat;
+    background-position-x: center;
+    background-size: 100%;
+  }
 `;
 
 const StickyFooter = styled(OakBox)`


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Update so that pupil lesson svg backgrounds only show on large displays

## Link to the design doc

## A link to the component in the deployment preview

https://deploy-preview-243--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-pupil-oaklessonlayout--default

## Testing instructions

Go to https://deploy-preview-243--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-pupil-oaklessonlayout--default&globals=viewport:tablet

You shouldn't see the svg backgrounds on the tablet viewport

## ACs
