### PR TITLE
LESQ-955: OakPagination component 

### DIFF
--- a/src/components/CopyPasteThisComponent/CopyPasteThisComponent.stories.tsx
+++ b/src/components/CopyPasteThisComponent/CopyPasteThisComponent.stories.tsx
@@ -4,7 +4,7 @@ import { StoryObj, Meta } from "@storybook/react";
 import { CopyPasteThisComponent } from "./CopyPasteThisComponent";
 
 const meta: Meta<typeof CopyPasteThisComponent> = {
-  //  "title" is the title of the story and where to look for compoent in the storybook
+  //  "title" is the title of the story and where to look for component in the storybook
   title: "Components/CopyPasteThisComponent",
   component: CopyPasteThisComponent,
   tags: ["autodocs"],

--- a/src/components/organisms/OakPagination/OakPagination.stories.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.stories.tsx
@@ -10,10 +10,11 @@ const meta: Meta<typeof OakPagination> = {
   argTypes: {
     totalPages: { type: "number" },
     paginationHref: { type: "string" },
+    pageName: { type: "string" },
   },
   parameters: {
     controls: {
-      include: ["totalPages", "paginationHref", "type"],
+      include: ["totalPages", "paginationHref", "pageName", "type"],
     },
   },
 };
@@ -28,5 +29,6 @@ export const Default: Story = {
     totalPages: 7,
     currentPage: 1,
     paginationHref: "#",
+    pageName: "test",
   },
 };

--- a/src/components/organisms/OakPagination/OakPagination.stories.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.stories.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { StoryObj, Meta } from "@storybook/react";
+
+import { OakPagination } from "./OakPagination";
+
+const meta: Meta<typeof OakPagination> = {
+  //  "title" is the title of the story and where to look for component in the storybook
+  title: "Components/organisms/OakPagination",
+  component: OakPagination,
+  tags: ["autodocs"],
+  argTypes: {
+    totalPages: { type: "number" },
+  },
+  parameters: {
+    controls: {
+      include: ["totalPages", "type"],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OakPagination>;
+
+export const Default: Story = {
+  render: (args) => <OakPagination {...args} />,
+  args: {
+    totalPages: 7,
+    currentPage: 1,
+  },
+};

--- a/src/components/organisms/OakPagination/OakPagination.stories.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.stories.tsx
@@ -4,16 +4,16 @@ import { StoryObj, Meta } from "@storybook/react";
 import { OakPagination } from "./OakPagination";
 
 const meta: Meta<typeof OakPagination> = {
-  //  "title" is the title of the story and where to look for component in the storybook
   title: "Components/organisms/OakPagination",
   component: OakPagination,
   tags: ["autodocs"],
   argTypes: {
     totalPages: { type: "number" },
+    paginationHref: { type: "string" },
   },
   parameters: {
     controls: {
-      include: ["totalPages", "type"],
+      include: ["totalPages", "paginationHref", "type"],
     },
   },
 };
@@ -27,5 +27,6 @@ export const Default: Story = {
   args: {
     totalPages: 7,
     currentPage: 1,
+    paginationHref: "#",
   },
 };

--- a/src/components/organisms/OakPagination/OakPagination.test.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.test.tsx
@@ -6,28 +6,35 @@ import { OakPagination } from "./OakPagination";
 import { generatePageNumbers } from "./utils";
 
 import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { OakThemeProvider } from "@/components/atoms";
+import { oakDefaultTheme } from "@/styles";
 
 describe("OakPagination Component", () => {
   it("renders", () => {
     const { getByTestId } = renderWithTheme(
-      <OakPagination
-        paginationHref={""}
-        pageName={"test"}
-        currentPage={1}
-        totalPages={8}
-      />,
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakPagination
+          paginationHref={""}
+          pageName={"test"}
+          currentPage={1}
+          totalPages={8}
+        />
+        ,
+      </OakThemeProvider>,
     );
     expect(getByTestId("pagination")).toBeInTheDocument();
   });
 
   it("renders the correct number of pages", () => {
     const { getAllByTestId } = renderWithTheme(
-      <OakPagination
-        paginationHref={""}
-        pageName={"test"}
-        currentPage={1}
-        totalPages={7}
-      />,
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakPagination
+          paginationHref={""}
+          pageName={"test"}
+          currentPage={1}
+          totalPages={7}
+        />
+      </OakThemeProvider>,
     );
 
     expect(getAllByTestId("page-number-component")).toHaveLength(7);
@@ -35,24 +42,28 @@ describe("OakPagination Component", () => {
 
   it("disables the backwards button when on the first page", () => {
     const { getByTestId } = renderWithTheme(
-      <OakPagination
-        paginationHref={""}
-        pageName={"test"}
-        currentPage={1}
-        totalPages={7}
-      />,
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakPagination
+          paginationHref={""}
+          pageName={"test"}
+          currentPage={1}
+          totalPages={7}
+        />
+      </OakThemeProvider>,
     );
     expect(getByTestId("backwards-button")).toBeDisabled();
   });
 
   it("disables the backwards button when on the first page", () => {
     const { getByTestId } = renderWithTheme(
-      <OakPagination
-        paginationHref={""}
-        pageName={"test"}
-        currentPage={7}
-        totalPages={7}
-      />,
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakPagination
+          paginationHref={""}
+          pageName={"test"}
+          currentPage={7}
+          totalPages={7}
+        />
+      </OakThemeProvider>,
     );
 
     const forwardsButton = getByTestId("forwards-button");
@@ -62,12 +73,14 @@ describe("OakPagination Component", () => {
 
   it("matches snapshot", () => {
     const tree = create(
-      <OakPagination
-        paginationHref={""}
-        pageName={"test"}
-        currentPage={1}
-        totalPages={7}
-      />,
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakPagination
+          paginationHref={""}
+          pageName={"test"}
+          currentPage={1}
+          totalPages={7}
+        />
+      </OakThemeProvider>,
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/organisms/OakPagination/OakPagination.test.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { create } from "react-test-renderer";
-import { fireEvent } from "@testing-library/react";
+// import { fireEvent } from "@testing-library/react";
 
 import { OakPagination } from "./OakPagination";
 
@@ -17,33 +17,32 @@ describe("OakPagination Component", () => {
 
   it("renders the correct number of pages", () => {
     const { getAllByTestId } = renderWithTheme(
-      <OakPagination currentPage={1} totalPages={8} />,
+      <OakPagination currentPage={1} totalPages={7} />,
     );
 
-    expect(getAllByTestId("page-number-component")).toHaveLength(8);
+    expect(getAllByTestId("page-number-component")).toHaveLength(7);
   });
 
   it("disables the backwards button when on the first page", () => {
     const { getByTestId } = renderWithTheme(
-      <OakPagination currentPage={1} totalPages={8} />,
+      <OakPagination currentPage={1} totalPages={7} />,
     );
     expect(getByTestId("backwards-button")).toBeDisabled();
   });
 
   it("disables the backwards button when on the first page", () => {
     const { getByTestId } = renderWithTheme(
-      <OakPagination currentPage={7} totalPages={8} />,
+      <OakPagination currentPage={7} totalPages={7} />,
     );
 
     const forwardsButton = getByTestId("forwards-button");
-    expect(forwardsButton).not.toBeDisabled();
-    fireEvent.click(forwardsButton);
+
     expect(forwardsButton).toBeDisabled();
   });
 
-  it("matches snapshot", () => {
+  it.skip("matches snapshot", () => {
     const tree = create(
-      <OakPagination currentPage={1} totalPages={8} />,
+      <OakPagination currentPage={1} totalPages={7} />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/organisms/OakPagination/OakPagination.test.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { create } from "react-test-renderer";
-// import { fireEvent } from "@testing-library/react";
 
 import { OakPagination } from "./OakPagination";
+import { generatePageNumbers } from "./utils";
 
 import renderWithTheme from "@/test-helpers/renderWithTheme";
 
@@ -60,7 +60,7 @@ describe("OakPagination Component", () => {
     expect(forwardsButton).toBeDisabled();
   });
 
-  it.skip("matches snapshot", () => {
+  it("matches snapshot", () => {
     const tree = create(
       <OakPagination
         paginationHref={""}
@@ -70,5 +70,27 @@ describe("OakPagination Component", () => {
       />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  describe("generatePageNumbers", () => {
+    test("should return all page numbers if totalPages is less than or equal to 7", () => {
+      expect(generatePageNumbers(0, 5)).toEqual([0, 1, 2, 3, 4]);
+      expect(generatePageNumbers(3, 7)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    });
+
+    test("should return correct page numbers when activePage is less than or equal to 3", () => {
+      expect(generatePageNumbers(0, 10)).toEqual([0, 1, 2, 3, "...", 9]);
+      expect(generatePageNumbers(3, 10)).toEqual([0, 1, 2, 3, "...", 9]);
+    });
+
+    test("should return correct page numbers when activePage is between 4 and totalPages - 3", () => {
+      expect(generatePageNumbers(4, 10)).toEqual([0, "...", 3, 4, "...", 9]);
+      expect(generatePageNumbers(6, 10)).toEqual([0, "...", 5, 6, "...", 9]);
+    });
+
+    test("should return correct page numbers when activePage is greater than or equal to totalPages - 3", () => {
+      expect(generatePageNumbers(7, 10)).toEqual([0, "...", 6, 7, 8, 9]);
+      expect(generatePageNumbers(9, 10)).toEqual([0, "...", 6, 7, 8, 9]);
+    });
   });
 });

--- a/src/components/organisms/OakPagination/OakPagination.test.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.test.tsx
@@ -33,7 +33,7 @@ describe("OakPagination Component", () => {
     expect(getAllByTestId("page-number-component")).toHaveLength(7);
   });
 
-  it.only("disables the backwards button when on the first page", () => {
+  it("disables the backwards button when on the first page", () => {
     const { getByTestId } = renderWithTheme(
       <OakPagination
         paginationHref={""}
@@ -45,7 +45,7 @@ describe("OakPagination Component", () => {
     expect(getByTestId("backwards-button")).toBeDisabled();
   });
 
-  it.only("disables the backwards button when on the first page", () => {
+  it("disables the backwards button when on the first page", () => {
     const { getByTestId } = renderWithTheme(
       <OakPagination
         paginationHref={""}

--- a/src/components/organisms/OakPagination/OakPagination.test.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+import { fireEvent } from "@testing-library/react";
+
+import { OakPagination } from "./OakPagination";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+
+describe("OakPagination Component", () => {
+  it("renders", () => {
+    const { getByTestId } = renderWithTheme(
+      <OakPagination currentPage={1} totalPages={8} />,
+    );
+    expect(getByTestId("pagination")).toBeInTheDocument();
+  });
+
+  it("renders the correct number of pages", () => {
+    const { getAllByTestId } = renderWithTheme(
+      <OakPagination currentPage={1} totalPages={8} />,
+    );
+
+    expect(getAllByTestId("page-number-component")).toHaveLength(8);
+  });
+
+  it("disables the backwards button when on the first page", () => {
+    const { getByTestId } = renderWithTheme(
+      <OakPagination currentPage={1} totalPages={8} />,
+    );
+    expect(getByTestId("backwards-button")).toBeDisabled();
+  });
+
+  it("disables the backwards button when on the first page", () => {
+    const { getByTestId } = renderWithTheme(
+      <OakPagination currentPage={7} totalPages={8} />,
+    );
+
+    const forwardsButton = getByTestId("forwards-button");
+    expect(forwardsButton).not.toBeDisabled();
+    fireEvent.click(forwardsButton);
+    expect(forwardsButton).toBeDisabled();
+  });
+
+  it("matches snapshot", () => {
+    const tree = create(
+      <OakPagination currentPage={1} totalPages={8} />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/OakPagination/OakPagination.test.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.test.tsx
@@ -33,7 +33,7 @@ describe("OakPagination Component", () => {
     expect(getAllByTestId("page-number-component")).toHaveLength(7);
   });
 
-  it("disables the backwards button when on the first page", () => {
+  it.only("disables the backwards button when on the first page", () => {
     const { getByTestId } = renderWithTheme(
       <OakPagination
         paginationHref={""}
@@ -45,7 +45,7 @@ describe("OakPagination Component", () => {
     expect(getByTestId("backwards-button")).toBeDisabled();
   });
 
-  it("disables the backwards button when on the first page", () => {
+  it.only("disables the backwards button when on the first page", () => {
     const { getByTestId } = renderWithTheme(
       <OakPagination
         paginationHref={""}

--- a/src/components/organisms/OakPagination/OakPagination.test.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.test.tsx
@@ -10,14 +10,24 @@ import renderWithTheme from "@/test-helpers/renderWithTheme";
 describe("OakPagination Component", () => {
   it("renders", () => {
     const { getByTestId } = renderWithTheme(
-      <OakPagination currentPage={1} totalPages={8} />,
+      <OakPagination
+        paginationHref={""}
+        pageName={"test"}
+        currentPage={1}
+        totalPages={8}
+      />,
     );
     expect(getByTestId("pagination")).toBeInTheDocument();
   });
 
   it("renders the correct number of pages", () => {
     const { getAllByTestId } = renderWithTheme(
-      <OakPagination currentPage={1} totalPages={7} />,
+      <OakPagination
+        paginationHref={""}
+        pageName={"test"}
+        currentPage={1}
+        totalPages={7}
+      />,
     );
 
     expect(getAllByTestId("page-number-component")).toHaveLength(7);
@@ -25,14 +35,24 @@ describe("OakPagination Component", () => {
 
   it("disables the backwards button when on the first page", () => {
     const { getByTestId } = renderWithTheme(
-      <OakPagination currentPage={1} totalPages={7} />,
+      <OakPagination
+        paginationHref={""}
+        pageName={"test"}
+        currentPage={1}
+        totalPages={7}
+      />,
     );
     expect(getByTestId("backwards-button")).toBeDisabled();
   });
 
   it("disables the backwards button when on the first page", () => {
     const { getByTestId } = renderWithTheme(
-      <OakPagination currentPage={7} totalPages={7} />,
+      <OakPagination
+        paginationHref={""}
+        pageName={"test"}
+        currentPage={7}
+        totalPages={7}
+      />,
     );
 
     const forwardsButton = getByTestId("forwards-button");
@@ -42,7 +62,12 @@ describe("OakPagination Component", () => {
 
   it.skip("matches snapshot", () => {
     const tree = create(
-      <OakPagination currentPage={1} totalPages={7} />,
+      <OakPagination
+        paginationHref={""}
+        pageName={"test"}
+        currentPage={1}
+        totalPages={7}
+      />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -34,6 +34,10 @@ const StyledChevronButton = styled(InternalButton)<{ disabledColor: string }>`
       color: ${props.disabledColor};
       cursor: pointer;
     }
+    &:focus {
+      outline: 2px solid #374cf1;
+      outline-offset: 2px;
+    }
   `}
 `;
 
@@ -59,6 +63,10 @@ const StyledNumberButton = styled(InternalButton)<{ selected: boolean }>`
     background-color: ${props.selected ? "black" : "white"};
     color: ${props.selected ? "white" : "black"};
   `}
+  &:focus {
+    outline: 2px solid #374cf1;
+    outline-offset: 2px;
+  }
 `;
 
 const StyledEllipsis = styled(InternalButton)`
@@ -77,6 +85,7 @@ const OakPageNumber = ({
   const isActive = currentPage === pageNumber;
   return (
     <StyledNumberButton
+      element="a"
       data-testid="page-number-component"
       aria-label={`${pageName} page ${pageNumber}`}
       aria-current={isActive ? "page" : false}
@@ -138,11 +147,13 @@ export const OakPagination = ({
         $gap={["space-between-ssx", "space-between-s", "space-between-s"]}
       >
         <StyledChevronButton
-          element={isFirstPage ? "button" : "a"}
+          element="a"
+          rel="prev"
           data-testid="backwards-button"
           onClick={() => {
             handleChevronClick("backwards");
           }}
+          tabIndex={isFirstPage ? -1 : 0}
           href={prevHref}
           aria-disabled={isFirstPage}
           disabled={isFirstPage}
@@ -191,7 +202,9 @@ export const OakPagination = ({
           })}
         </OakUL>
         <StyledChevronButton
-          element={isLastPage ? "button" : "a"}
+          element="a"
+          rel="next"
+          tabIndex={isLastPage ? -1 : 0}
           data-testid="forwards-button"
           href={nextHref}
           onClick={() => {

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -6,6 +6,8 @@ import { generatePageNumbers } from "./utils";
 import { OakFlex, OakIcon, OakLI, OakUL } from "@/components/atoms";
 import { InternalButton } from "@/components/atoms/InternalButton";
 import { parseColorFilter } from "@/styles/helpers/parseColorFilter";
+import { OakLink } from "@/components/molecules";
+import { typographyStyle } from "@/styles/utils/typographyStyle";
 
 export type OakPaginationProps = {
   currentPage: number;
@@ -27,16 +29,12 @@ type OakPageNumberProps = {
   pageName: string;
 };
 
-const StyledChevronButton = styled(InternalButton)<{ disabledColor: string }>`
+const StyledChevronButton = styled(OakLink)<{ disabledColor: string }>`
   display: inline-block;
   ${(props) => css`
     &:disabled {
       color: ${props.disabledColor};
       cursor: pointer;
-    }
-    &:focus {
-      outline: 2px solid #374cf1;
-      outline-offset: 2px;
     }
   `}
 `;
@@ -51,21 +49,37 @@ const StyledIcon = styled(OakIcon)<{ disabled: boolean }>`
   }}
 `;
 
-const StyledNumberButton = styled(InternalButton)<{ selected: boolean }>`
+const StyledNumberButton = styled(OakLink)<{ selected: boolean }>`
   height: 30px;
   width: 30px;
   border-radius: 100px;
   display: flex;
   align-items: center;
   justify-content: center;
+  text-decoration: none;
+  ${typographyStyle}
+  color: black;
 
   ${(props) => css`
     background-color: ${props.selected ? "black" : "white"};
-    color: ${props.selected ? "white" : "black"};
-  `}
-  &:focus {
-    outline: 2px solid #374cf1;
-    outline-offset: 2px;
+  `};
+
+  ${(props) =>
+    props.selected &&
+    css`
+      color: white;
+      &:visited {
+        color: white;
+      }
+    `}
+
+  &:hover {
+    text-decoration: underline;
+    ${(props) =>
+      props.selected &&
+      css`
+        color: white;
+      `}
   }
 `;
 
@@ -85,7 +99,6 @@ const OakPageNumber = ({
   const isActive = currentPage === pageNumber;
   return (
     <StyledNumberButton
-      element="a"
       data-testid="page-number-component"
       aria-label={`${pageName} page ${pageNumber}`}
       aria-current={isActive ? "page" : false}
@@ -144,6 +157,7 @@ export const OakPagination = ({
       <OakFlex
         $alignItems={"center"}
         $justifyContent={"center"}
+        $width={"100%"}
         $gap={["space-between-ssx", "space-between-s", "space-between-s"]}
       >
         <StyledChevronButton

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -79,6 +79,10 @@ const StyledNumberButton = styled(OakLink)<{ selected: boolean }>`
       props.selected &&
       css`
         color: white;
+        @media (hover: hover) {
+    &:hover:not(:disabled) {
+      color: white;
+    }
       `}
   }
 `;

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -112,13 +112,14 @@ export const OakPagination = ({
 
     if (totalPages <= 7) {
       return Array.from({ length: totalPages }, (_, i) => i);
-    }
-    if (totalPages > 7 && activePage <= 3) {
+    } else if (totalPages > 7 && activePage <= 3) {
       const pages = [0, 1, 2, 3, "...", totalPages - 1];
       return pages;
-    }
-
-    if (totalPages > 7 && activePage >= 4 && activePage < totalPages - 3) {
+    } else if (
+      totalPages > 7 &&
+      activePage >= 4 &&
+      activePage < totalPages - 3
+    ) {
       const pages = [
         0,
         "...",
@@ -128,9 +129,7 @@ export const OakPagination = ({
         totalPages - 1,
       ];
       return pages;
-    }
-
-    if (totalPages > 7 && activePage >= 5) {
+    } else if (totalPages > 7 && activePage >= 5) {
       const pages = [
         0,
         "...",
@@ -140,8 +139,9 @@ export const OakPagination = ({
         totalPages - 1,
       ];
       return pages;
+    } else {
+      return pageNumbers;
     }
-    return pageNumbers;
   };
 
   const [activePage, setActivePage] = useState(currentPage);
@@ -192,10 +192,10 @@ export const OakPagination = ({
           />
         </StyledChevronButton>
         <OakUL $reset $display={"flex"}>
-          {pageNumbers.map((pageIndex) => {
+          {pageNumbers.map((pageIndex, i) => {
             if (typeof pageIndex === "number") {
               return (
-                <OakLI key={pageIndex} $mh={"space-between-ssx"}>
+                <OakLI key={`${pageIndex} ${i}`} $mh={"space-between-ssx"}>
                   <OakPageNumber
                     pageName={pageName}
                     key={pageIndex}
@@ -208,7 +208,7 @@ export const OakPagination = ({
               );
             } else {
               return (
-                <OakLI $mh={"space-between-ssx"} key={pageIndex}>
+                <OakLI $mh={"space-between-ssx"} key={`${pageIndex} ${i}`}>
                   <OakFlex $height={"100%"} $alignSelf={"center"}>
                     <OakEllipsis />
                   </OakFlex>

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -147,11 +147,18 @@ export const OakPagination = ({
         $gap={["space-between-ssx", "space-between-s", "space-between-s"]}
       >
         <StyledChevronButton
-          element="a"
+          element={isFirstPage ? "button" : "a"}
           rel="prev"
           data-testid="backwards-button"
           onClick={() => {
             handleChevronClick("backwards");
+          }}
+          onKeyDown={(
+            e: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>,
+          ) => {
+            if (e.key === "Enter") {
+              handleChevronClick("backwards");
+            }
           }}
           tabIndex={isFirstPage ? -1 : 0}
           href={prevHref}
@@ -202,13 +209,20 @@ export const OakPagination = ({
           })}
         </OakUL>
         <StyledChevronButton
-          element="a"
+          element={isLastPage ? "button" : "a"}
           rel="next"
           tabIndex={isLastPage ? -1 : 0}
           data-testid="forwards-button"
           href={nextHref}
           onClick={() => {
             handleChevronClick("forwards");
+          }}
+          onKeyDown={(
+            e: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>,
+          ) => {
+            if (e.key === "Enter") {
+              handleChevronClick("forwards");
+            }
           }}
           aria-disabled={isLastPage}
           disabled={isLastPage}

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -114,7 +114,7 @@ export const OakPagination = ({
 }: OakPaginationProps) => {
   const [activePage, setActivePage] = useState(currentPage);
 
-  const pageNumbers = generatePageNumbers(activePage, totalPages);
+  const pages = generatePageNumbers(activePage, totalPages);
 
   const isFirstPage = activePage <= 1;
   const isLastPage = activePage >= totalPages;
@@ -151,11 +151,11 @@ export const OakPagination = ({
           <StyledIcon disabled={isFirstPage} iconName="chevron-left" />
         </StyledChevronButton>
         <OakUL $reset $display={"flex"}>
-          {pageNumbers.map((pageIndex, i) => {
-            if (typeof pageIndex === "number") {
+          {pages.map((page, i) => {
+            if (typeof page === "number") {
               return (
                 <OakLI
-                  key={`${pageIndex} ${i}`}
+                  key={`${page} ${i}`}
                   $mh={[
                     "space-between-sssx",
                     "space-between-ssx",
@@ -164,11 +164,11 @@ export const OakPagination = ({
                 >
                   <OakPageNumber
                     pageName={pageName}
-                    key={pageIndex}
-                    pageNumber={pageIndex + 1}
+                    key={page}
+                    pageNumber={page + 1}
                     currentPage={activePage}
-                    href={`${paginationHref}?page=${pageIndex + 1}`}
-                    onClick={() => handleNumberClick(pageIndex + 1)}
+                    href={`${paginationHref}?page=${page + 1}`}
+                    onClick={() => handleNumberClick(page + 1)}
                   />
                 </OakLI>
               );
@@ -180,7 +180,7 @@ export const OakPagination = ({
                     "space-between-ssx",
                     "space-between-ssx",
                   ]}
-                  key={`${pageIndex} ${i}`}
+                  key={`${page} ${i}`}
                 >
                   <OakFlex $height={"100%"} $alignSelf={"center"}>
                     <OakEllipsis />

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -215,9 +215,4 @@ export const OakPagination = ({
  *
  * Pagination component for navigating through pages
  *
- *
- * ### Callbacks
- * make sure to add descriptions and types for any callbacks for the component
- *
- * NB. We must export a styled component for it to be inheritable
  */

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -1,13 +1,14 @@
 import React, { RefObject, useState } from "react";
 import styled, { css } from "styled-components";
 
-import { OakFlex, OakIcon } from "@/components/atoms";
+import { OakFlex, OakIcon, OakLI, OakUL } from "@/components/atoms";
 import { InternalButton } from "@/components/atoms/InternalButton";
 
 /**
  * TODO: Pagination component
  * ! - refactor chevron button to OakIconButton component
  * ! - refactor code to make it clean
+ * ! - Add tests
  * ? - Create and OakIconButton compoent?
  */
 
@@ -17,6 +18,8 @@ export type OakPaginationProps = {
   firstItemRef?: RefObject<HTMLAnchorElement> | null;
   nextHref?: string;
   prevHref?: string;
+  paginationHref: string;
+  pageName: string;
 };
 
 type OakPageNumberProps = {
@@ -26,6 +29,7 @@ type OakPageNumberProps = {
   firstItemRef?: RefObject<HTMLAnchorElement> | null;
   href: string;
   onClick?: (event: React.MouseEvent) => void;
+  pageName: string;
 };
 
 const StyledChevronButton = styled(InternalButton)<{ disabledColor: string }>`
@@ -63,12 +67,13 @@ const OakPageNumber = ({
   pageIndex,
   onClick,
   href,
+  pageName,
 }: OakPageNumberProps) => {
   const isActive = currentPage === pageIndex;
   return (
     <StyledNumberButton
       data-testid="page-number-component"
-      aria-label={`Go to page ${pageIndex}`}
+      aria-label={`${pageName} page ${pageIndex}`}
       $font={"heading-7"}
       onClick={onClick}
       element="a"
@@ -99,6 +104,8 @@ export const OakPagination = ({
   totalPages,
   nextHref,
   prevHref,
+  paginationHref,
+  pageName,
 }: OakPaginationProps) => {
   const generatePageNumbers = (activePage: number, totalPages: number) => {
     const pageNumbers: (number | string)[] = [];
@@ -175,6 +182,7 @@ export const OakPagination = ({
             handleChevronClick("backwards");
           }}
           href={prevHref}
+          aria-disabled={isFirstPage}
           disabled={activePage <= 1}
           aria-label={isFirstPage ? "No previous pages" : "Go to previous page"}
         >
@@ -183,27 +191,32 @@ export const OakPagination = ({
             $colorFilter={isFirstPage ? "icon-disabled" : null}
           />
         </StyledChevronButton>
-        <OakFlex $gap={"space-between-s"}>
+        <OakUL $reset $display={"flex"}>
           {pageNumbers.map((pageIndex) => {
             if (typeof pageIndex === "number") {
               return (
-                <OakPageNumber
-                  key={pageIndex}
-                  pageIndex={pageIndex + 1}
-                  currentPage={activePage}
-                  href={`#`}
-                  onClick={() => handleNumberClick(pageIndex + 1)}
-                />
+                <OakLI key={pageIndex} $mh={"space-between-ssx"}>
+                  <OakPageNumber
+                    pageName={pageName}
+                    key={pageIndex}
+                    pageIndex={pageIndex + 1}
+                    currentPage={activePage}
+                    href={`${paginationHref}/${pageIndex + 1}`}
+                    onClick={() => handleNumberClick(pageIndex + 1)}
+                  />
+                </OakLI>
               );
             } else {
               return (
-                <OakFlex $alignSelf={"flex-end"}>
-                  <OakEllipsis key={pageIndex} />
-                </OakFlex>
+                <OakLI $mh={"space-between-ssx"} key={pageIndex}>
+                  <OakFlex $height={"100%"} $alignSelf={"center"}>
+                    <OakEllipsis />
+                  </OakFlex>
+                </OakLI>
               );
             }
           })}
-        </OakFlex>
+        </OakUL>
         <StyledChevronButton
           element={isLastPage ? "button" : "a"}
           data-testid="forwards-button"
@@ -211,6 +224,7 @@ export const OakPagination = ({
           onClick={() => {
             handleChevronClick("forwards");
           }}
+          aria-disabled={isLastPage}
           disabled={isLastPage}
           aria-label={isLastPage ? "No further pages" : "Go to next page"}
         >

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -1,6 +1,5 @@
-import React, { RefObject, useEffect, useState } from "react";
+import React, { RefObject, useState } from "react";
 import styled, { css } from "styled-components";
-import { useRouter } from "next/router";
 
 import { OakFlex, OakIcon } from "@/components/atoms";
 import { InternalButton } from "@/components/atoms/InternalButton";
@@ -100,7 +99,6 @@ export const OakPagination = ({
   totalPages,
   nextHref,
   prevHref,
-  firstItemRef,
 }: OakPaginationProps) => {
   const generatePageNumbers = (activePage: number, totalPages: number) => {
     const pageNumbers: (number | string)[] = [];
@@ -138,14 +136,6 @@ export const OakPagination = ({
     }
     return pageNumbers;
   };
-
-  const router = useRouter();
-  useEffect(() => {
-    if (router.query.page && firstItemRef?.current) {
-      firstItemRef.current.focus();
-      window.scrollTo({ top: 0, behavior: "smooth" });
-    }
-  }, [firstItemRef, router.query.page]);
 
   const [activePage, setActivePage] = useState(currentPage);
 

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -19,7 +19,7 @@ export type OakPaginationProps = {
 
 type OakPageNumberProps = {
   currentPage: number;
-  pageIndex: number;
+  pageNumber: number;
   totalPages?: number;
   firstItemRef?: RefObject<HTMLAnchorElement> | null;
   href: string;
@@ -69,23 +69,23 @@ const StyledEllipsis = styled(InternalButton)`
 
 const OakPageNumber = ({
   currentPage,
-  pageIndex,
+  pageNumber,
   onClick,
   href,
   pageName,
 }: OakPageNumberProps) => {
-  const isActive = currentPage === pageIndex;
+  const isActive = currentPage === pageNumber;
   return (
     <StyledNumberButton
       data-testid="page-number-component"
-      aria-label={`${pageName} page ${pageIndex}`}
+      aria-label={`${pageName} page ${pageNumber}`}
       aria-current={isActive ? "page" : false}
       $font={"heading-7"}
       onClick={onClick}
       selected={isActive}
       href={href}
     >
-      {pageIndex}
+      {pageNumber}
     </StyledNumberButton>
   );
 };
@@ -145,7 +145,7 @@ export const OakPagination = ({
           }}
           href={prevHref}
           aria-disabled={isFirstPage}
-          disabled={activePage <= 1}
+          disabled={isFirstPage}
           aria-label={isFirstPage ? "No previous pages" : "Go to previous page"}
         >
           <StyledIcon disabled={isFirstPage} iconName="chevron-left" />
@@ -165,7 +165,7 @@ export const OakPagination = ({
                   <OakPageNumber
                     pageName={pageName}
                     key={pageIndex}
-                    pageIndex={pageIndex + 1}
+                    pageNumber={pageIndex + 1}
                     currentPage={activePage}
                     href={`${paginationHref}?page=${pageIndex + 1}`}
                     onClick={() => handleNumberClick(pageIndex + 1)}

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -1,16 +1,11 @@
 import React, { RefObject, useState } from "react";
 import styled, { css } from "styled-components";
 
+import { generatePageNumbers } from "./utils";
+
 import { OakFlex, OakIcon, OakLI, OakUL } from "@/components/atoms";
 import { InternalButton } from "@/components/atoms/InternalButton";
-
-/**
- * TODO: Pagination component
- * ! - refactor chevron button to OakIconButton component
- * ! - refactor code to make it clean
- * ! - Add tests
- * ? - Create and OakIconButton compoent?
- */
+import { parseColorFilter } from "@/styles/helpers/parseColorFilter";
 
 export type OakPaginationProps = {
   currentPage: number;
@@ -40,6 +35,16 @@ const StyledChevronButton = styled(InternalButton)<{ disabledColor: string }>`
       cursor: pointer;
     }
   `}
+`;
+
+const StyledIcon = styled(OakIcon)<{ disabled: boolean }>`
+  ${(props) => {
+    if (props.disabled) {
+      return css`
+        filter: ${parseColorFilter("grey50")};
+      `;
+    }
+  }}
 `;
 
 const StyledNumberButton = styled(InternalButton)<{ selected: boolean }>`
@@ -74,9 +79,9 @@ const OakPageNumber = ({
     <StyledNumberButton
       data-testid="page-number-component"
       aria-label={`${pageName} page ${pageIndex}`}
+      aria-current={isActive ? "page" : false}
       $font={"heading-7"}
       onClick={onClick}
-      element="a"
       selected={isActive}
       href={href}
     >
@@ -107,43 +112,6 @@ export const OakPagination = ({
   paginationHref,
   pageName,
 }: OakPaginationProps) => {
-  const generatePageNumbers = (activePage: number, totalPages: number) => {
-    const pageNumbers: (number | string)[] = [];
-
-    if (totalPages <= 7) {
-      return Array.from({ length: totalPages }, (_, i) => i);
-    } else if (totalPages > 7 && activePage <= 3) {
-      const pages = [0, 1, 2, 3, "...", totalPages - 1];
-      return pages;
-    } else if (
-      totalPages > 7 &&
-      activePage >= 4 &&
-      activePage < totalPages - 3
-    ) {
-      const pages = [
-        0,
-        "...",
-        activePage - 1,
-        activePage,
-        "...",
-        totalPages - 1,
-      ];
-      return pages;
-    } else if (totalPages > 7 && activePage >= 5) {
-      const pages = [
-        0,
-        "...",
-        totalPages - 4,
-        totalPages - 3,
-        totalPages - 2,
-        totalPages - 1,
-      ];
-      return pages;
-    } else {
-      return pageNumbers;
-    }
-  };
-
   const [activePage, setActivePage] = useState(currentPage);
 
   const pageNumbers = generatePageNumbers(activePage, totalPages);
@@ -156,13 +124,7 @@ export const OakPagination = ({
   };
 
   const handleChevronClick = (direction: "backwards" | "forwards") => {
-    setActivePage((currNum) => {
-      if (direction === "backwards") {
-        return (currNum = currNum - 1);
-      } else {
-        return (currNum = currNum + 1);
-      }
-    });
+    setActivePage((currNum) => currNum + (direction === "backwards" ? -1 : 1));
   };
 
   if (currentPage === 1 && totalPages < 2) {
@@ -173,7 +135,7 @@ export const OakPagination = ({
       <OakFlex
         $alignItems={"center"}
         $justifyContent={"center"}
-        $gap={"space-between-s"}
+        $gap={["space-between-ssx", "space-between-s", "space-between-s"]}
       >
         <StyledChevronButton
           element={isFirstPage ? "button" : "a"}
@@ -186,29 +148,40 @@ export const OakPagination = ({
           disabled={activePage <= 1}
           aria-label={isFirstPage ? "No previous pages" : "Go to previous page"}
         >
-          <OakIcon
-            iconName="chevron-left"
-            $colorFilter={isFirstPage ? "icon-disabled" : null}
-          />
+          <StyledIcon disabled={isFirstPage} iconName="chevron-left" />
         </StyledChevronButton>
         <OakUL $reset $display={"flex"}>
           {pageNumbers.map((pageIndex, i) => {
             if (typeof pageIndex === "number") {
               return (
-                <OakLI key={`${pageIndex} ${i}`} $mh={"space-between-ssx"}>
+                <OakLI
+                  key={`${pageIndex} ${i}`}
+                  $mh={[
+                    "space-between-sssx",
+                    "space-between-ssx",
+                    "space-between-ssx",
+                  ]}
+                >
                   <OakPageNumber
                     pageName={pageName}
                     key={pageIndex}
                     pageIndex={pageIndex + 1}
                     currentPage={activePage}
-                    href={`${paginationHref}/${pageIndex + 1}`}
+                    href={`${paginationHref}?page=${pageIndex + 1}`}
                     onClick={() => handleNumberClick(pageIndex + 1)}
                   />
                 </OakLI>
               );
             } else {
               return (
-                <OakLI $mh={"space-between-ssx"} key={`${pageIndex} ${i}`}>
+                <OakLI
+                  $mh={[
+                    "space-between-sssx",
+                    "space-between-ssx",
+                    "space-between-ssx",
+                  ]}
+                  key={`${pageIndex} ${i}`}
+                >
                   <OakFlex $height={"100%"} $alignSelf={"center"}>
                     <OakEllipsis />
                   </OakFlex>
@@ -228,10 +201,7 @@ export const OakPagination = ({
           disabled={isLastPage}
           aria-label={isLastPage ? "No further pages" : "Go to next page"}
         >
-          <OakIcon
-            iconName="chevron-right"
-            $colorFilter={isLastPage ? "icon-disabled" : null}
-          />
+          <StyledIcon disabled={isLastPage} iconName="chevron-right" />
         </StyledChevronButton>
       </OakFlex>
     </nav>
@@ -242,6 +212,9 @@ export const OakPagination = ({
  *
  * Add the description of the component here and it will appear on the story for the component
  * The following callbacks are available for tracking focus events:
+ *
+ * Pagination component for navigating through pages
+ *
  *
  * ### Callbacks
  * make sure to add descriptions and types for any callbacks for the component

--- a/src/components/organisms/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/OakPagination/OakPagination.tsx
@@ -1,0 +1,246 @@
+import React, { RefObject, useEffect, useState } from "react";
+import styled, { css } from "styled-components";
+import { useRouter } from "next/router";
+
+import { OakFlex, OakIcon } from "@/components/atoms";
+import { InternalButton } from "@/components/atoms/InternalButton";
+
+/**
+ * TODO: Pagination component
+ * ! - refactor chevron button to OakIconButton component
+ * ! - refactor code to make it clean
+ * ? - Create and OakIconButton compoent?
+ */
+
+export type OakPaginationProps = {
+  currentPage: number;
+  totalPages: number;
+  firstItemRef?: RefObject<HTMLAnchorElement> | null;
+  nextHref?: string;
+  prevHref?: string;
+};
+
+type OakPageNumberProps = {
+  currentPage: number;
+  pageIndex: number;
+  totalPages?: number;
+  firstItemRef?: RefObject<HTMLAnchorElement> | null;
+  href: string;
+  onClick?: (event: React.MouseEvent) => void;
+};
+
+const StyledChevronButton = styled(InternalButton)<{ disabledColor: string }>`
+  display: inline-block;
+  ${(props) => css`
+    &:disabled {
+      color: ${props.disabledColor};
+      cursor: pointer;
+    }
+  `}
+`;
+
+const StyledNumberButton = styled(InternalButton)<{ selected: boolean }>`
+  height: 30px;
+  width: 30px;
+  border-radius: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  ${(props) => css`
+    background-color: ${props.selected ? "black" : "white"};
+    color: ${props.selected ? "white" : "black"};
+  `}
+`;
+
+const StyledEllipsis = styled(InternalButton)`
+  &:disabled {
+    cursor: pointer;
+  }
+`;
+
+const OakPageNumber = ({
+  currentPage,
+  pageIndex,
+  onClick,
+  href,
+}: OakPageNumberProps) => {
+  const isActive = currentPage === pageIndex;
+  return (
+    <StyledNumberButton
+      data-testid="page-number-component"
+      aria-label={`Go to page ${pageIndex}`}
+      $font={"heading-7"}
+      onClick={onClick}
+      element="a"
+      selected={isActive}
+      href={href}
+    >
+      {pageIndex}
+    </StyledNumberButton>
+  );
+};
+
+const OakEllipsis = () => {
+  return (
+    <StyledEllipsis
+      $color="text-primary"
+      $font={"heading-7"}
+      $background="white"
+      aria-label="Hidden page numbers"
+      disabled
+    >
+      ...
+    </StyledEllipsis>
+  );
+};
+
+export const OakPagination = ({
+  currentPage,
+  totalPages,
+  nextHref,
+  prevHref,
+  firstItemRef,
+}: OakPaginationProps) => {
+  const generatePageNumbers = (activePage: number, totalPages: number) => {
+    const pageNumbers: (number | string)[] = [];
+
+    if (totalPages <= 7) {
+      return Array.from({ length: totalPages }, (_, i) => i);
+    }
+    if (totalPages > 7 && activePage <= 3) {
+      const pages = [0, 1, 2, 3, "...", totalPages - 1];
+      return pages;
+    }
+
+    if (totalPages > 7 && activePage >= 4 && activePage < totalPages - 3) {
+      const pages = [
+        0,
+        "...",
+        activePage - 1,
+        activePage,
+        "...",
+        totalPages - 1,
+      ];
+      return pages;
+    }
+
+    if (totalPages > 7 && activePage >= 5) {
+      const pages = [
+        0,
+        "...",
+        totalPages - 4,
+        totalPages - 3,
+        totalPages - 2,
+        totalPages - 1,
+      ];
+      return pages;
+    }
+    return pageNumbers;
+  };
+
+  const router = useRouter();
+  useEffect(() => {
+    if (router.query.page && firstItemRef?.current) {
+      firstItemRef.current.focus();
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  }, [firstItemRef, router.query.page]);
+
+  const [activePage, setActivePage] = useState(currentPage);
+
+  const pageNumbers = generatePageNumbers(activePage, totalPages);
+
+  const isFirstPage = activePage <= 1;
+  const isLastPage = activePage >= totalPages;
+
+  const handleNumberClick = (num: number) => {
+    setActivePage(num);
+  };
+
+  const handleChevronClick = (direction: "backwards" | "forwards") => {
+    setActivePage((currNum) => {
+      if (direction === "backwards") {
+        return (currNum = currNum - 1);
+      } else {
+        return (currNum = currNum + 1);
+      }
+    });
+  };
+
+  if (currentPage === 1 && totalPages < 2) {
+    return null;
+  }
+  return (
+    <nav aria-label="pagination" data-testid="pagination">
+      <OakFlex
+        $alignItems={"center"}
+        $justifyContent={"center"}
+        $gap={"space-between-s"}
+      >
+        <StyledChevronButton
+          element={isFirstPage ? "button" : "a"}
+          data-testid="backwards-button"
+          onClick={() => {
+            handleChevronClick("backwards");
+          }}
+          href={prevHref}
+          disabled={activePage <= 1}
+          aria-label={isFirstPage ? "No previous pages" : "Go to previous page"}
+        >
+          <OakIcon
+            iconName="chevron-left"
+            $colorFilter={isFirstPage ? "icon-disabled" : null}
+          />
+        </StyledChevronButton>
+        <OakFlex $gap={"space-between-s"}>
+          {pageNumbers.map((pageIndex) => {
+            if (typeof pageIndex === "number") {
+              return (
+                <OakPageNumber
+                  key={pageIndex}
+                  pageIndex={pageIndex + 1}
+                  currentPage={activePage}
+                  href={`#`}
+                  onClick={() => handleNumberClick(pageIndex + 1)}
+                />
+              );
+            } else {
+              return (
+                <OakFlex $alignSelf={"flex-end"}>
+                  <OakEllipsis key={pageIndex} />
+                </OakFlex>
+              );
+            }
+          })}
+        </OakFlex>
+        <StyledChevronButton
+          element={isLastPage ? "button" : "a"}
+          data-testid="forwards-button"
+          href={nextHref}
+          onClick={() => {
+            handleChevronClick("forwards");
+          }}
+          disabled={isLastPage}
+          aria-label={isLastPage ? "No further pages" : "Go to next page"}
+        >
+          <OakIcon
+            iconName="chevron-right"
+            $colorFilter={isLastPage ? "icon-disabled" : null}
+          />
+        </StyledChevronButton>
+      </OakFlex>
+    </nav>
+  );
+};
+
+/**
+ *
+ * Add the description of the component here and it will appear on the story for the component
+ * The following callbacks are available for tracking focus events:
+ *
+ * ### Callbacks
+ * make sure to add descriptions and types for any callbacks for the component
+ *
+ * NB. We must export a styled component for it to be inheritable
+ */

--- a/src/components/organisms/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -1,0 +1,401 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakPagination Component matches snapshot 1`] = `
+.c0 {
+  font-family: Lexend,sans-serif;
+}
+
+.c4 {
+  position: relative;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
+  font-family: Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.c6 {
+  object-fit: contain;
+}
+
+.c7 {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: Lexend,sans-serif;
+}
+
+.c8 {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  display: revert;
+  font-family: Lexend,sans-serif;
+  font-family: Lexend,sans-serif;
+  display: revert;
+}
+
+.c2 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+}
+
+.c2:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c9 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c9:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c3 {
+  display: inline-block;
+}
+
+.c3:disabled {
+  cursor: pointer;
+}
+
+.c5 {
+  -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+  filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
+}
+
+.c10 {
+  height: 30px;
+  width: 30px;
+  border-radius: 100px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background-color: black;
+  color: white;
+}
+
+.c11 {
+  height: 30px;
+  width: 30px;
+  border-radius: 100px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background-color: white;
+  color: black;
+}
+
+@media (min-width:750px) {
+  .c1 {
+    gap: 1rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c1 {
+    gap: 1rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c8 {
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c8 {
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c8 {
+    margin-right: 0.5rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c8 {
+    margin-right: 0.5rem;
+  }
+}
+
+<nav
+  aria-label="pagination"
+  data-testid="pagination"
+>
+  <div
+    className="c0 c1"
+  >
+    <button
+      aria-disabled={true}
+      aria-label="No previous pages"
+      className="c2 c3"
+      data-testid="backwards-button"
+      disabled={true}
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="c4 c5"
+        disabled={true}
+      >
+        <img
+          alt="chevron-left"
+          className="c6"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/rbvzan0ozubmr4j0uqdn.svg"
+          style={
+            {
+              "bottom": 0,
+              "color": "transparent",
+              "height": "100%",
+              "left": 0,
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": "100%",
+            }
+          }
+        />
+      </div>
+    </button>
+    <ul
+      className="c7"
+    >
+      <li
+        className="c8"
+      >
+        <button
+          aria-current="page"
+          aria-label="test page 1"
+          className="c9 c10"
+          data-testid="page-number-component"
+          href="?page=1"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          selected={true}
+        >
+          1
+        </button>
+      </li>
+      <li
+        className="c8"
+      >
+        <button
+          aria-current={false}
+          aria-label="test page 2"
+          className="c9 c11"
+          data-testid="page-number-component"
+          href="?page=2"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          selected={false}
+        >
+          2
+        </button>
+      </li>
+      <li
+        className="c8"
+      >
+        <button
+          aria-current={false}
+          aria-label="test page 3"
+          className="c9 c11"
+          data-testid="page-number-component"
+          href="?page=3"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          selected={false}
+        >
+          3
+        </button>
+      </li>
+      <li
+        className="c8"
+      >
+        <button
+          aria-current={false}
+          aria-label="test page 4"
+          className="c9 c11"
+          data-testid="page-number-component"
+          href="?page=4"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          selected={false}
+        >
+          4
+        </button>
+      </li>
+      <li
+        className="c8"
+      >
+        <button
+          aria-current={false}
+          aria-label="test page 5"
+          className="c9 c11"
+          data-testid="page-number-component"
+          href="?page=5"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          selected={false}
+        >
+          5
+        </button>
+      </li>
+      <li
+        className="c8"
+      >
+        <button
+          aria-current={false}
+          aria-label="test page 6"
+          className="c9 c11"
+          data-testid="page-number-component"
+          href="?page=6"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          selected={false}
+        >
+          6
+        </button>
+      </li>
+      <li
+        className="c8"
+      >
+        <button
+          aria-current={false}
+          aria-label="test page 7"
+          className="c9 c11"
+          data-testid="page-number-component"
+          href="?page=7"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          selected={false}
+        >
+          7
+        </button>
+      </li>
+    </ul>
+    <a
+      aria-disabled={false}
+      aria-label="Go to next page"
+      className="c2 c3"
+      data-testid="forwards-button"
+      disabled={false}
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="c4 "
+        disabled={false}
+      >
+        <img
+          alt="chevron-right"
+          className="c6"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+          style={
+            {
+              "bottom": 0,
+              "color": "transparent",
+              "height": "100%",
+              "left": 0,
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": "100%",
+            }
+          }
+        />
+      </div>
+    </a>
+  </div>
+</nav>
+`;

--- a/src/components/organisms/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -234,6 +234,12 @@ exports[`OakPagination Component matches snapshot 1`] = `
   }
 }
 
+@media (hover:hover) {
+  .c10:hover:hover:not(:disabled) {
+    color: white;
+  }
+}
+
 <nav
   aria-label="pagination"
   data-testid="pagination"

--- a/src/components/organisms/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -105,6 +105,11 @@ exports[`OakPagination Component matches snapshot 1`] = `
   cursor: pointer;
 }
 
+.c3:focus {
+  outline: 2px solid #374cf1;
+  outline-offset: 2px;
+}
+
 .c5 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
@@ -130,6 +135,11 @@ exports[`OakPagination Component matches snapshot 1`] = `
   color: white;
 }
 
+.c10:focus {
+  outline: 2px solid #374cf1;
+  outline-offset: 2px;
+}
+
 .c11 {
   height: 30px;
   width: 30px;
@@ -148,6 +158,11 @@ exports[`OakPagination Component matches snapshot 1`] = `
   justify-content: center;
   background-color: white;
   color: black;
+}
+
+.c11:focus {
+  outline: 2px solid #374cf1;
+  outline-offset: 2px;
 }
 
 @media (min-width:750px) {
@@ -193,7 +208,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   <div
     className="c0 c1"
   >
-    <button
+    <a
       aria-disabled={true}
       aria-label="No previous pages"
       className="c2 c3"
@@ -202,6 +217,8 @@ exports[`OakPagination Component matches snapshot 1`] = `
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
+      rel="prev"
+      tabIndex={-1}
     >
       <div
         className="c4 c5"
@@ -232,14 +249,14 @@ exports[`OakPagination Component matches snapshot 1`] = `
           }
         />
       </div>
-    </button>
+    </a>
     <ul
       className="c7"
     >
       <li
         className="c8"
       >
-        <button
+        <a
           aria-current="page"
           aria-label="test page 1"
           className="c9 c10"
@@ -251,12 +268,12 @@ exports[`OakPagination Component matches snapshot 1`] = `
           selected={true}
         >
           1
-        </button>
+        </a>
       </li>
       <li
         className="c8"
       >
-        <button
+        <a
           aria-current={false}
           aria-label="test page 2"
           className="c9 c11"
@@ -268,12 +285,12 @@ exports[`OakPagination Component matches snapshot 1`] = `
           selected={false}
         >
           2
-        </button>
+        </a>
       </li>
       <li
         className="c8"
       >
-        <button
+        <a
           aria-current={false}
           aria-label="test page 3"
           className="c9 c11"
@@ -285,12 +302,12 @@ exports[`OakPagination Component matches snapshot 1`] = `
           selected={false}
         >
           3
-        </button>
+        </a>
       </li>
       <li
         className="c8"
       >
-        <button
+        <a
           aria-current={false}
           aria-label="test page 4"
           className="c9 c11"
@@ -302,12 +319,12 @@ exports[`OakPagination Component matches snapshot 1`] = `
           selected={false}
         >
           4
-        </button>
+        </a>
       </li>
       <li
         className="c8"
       >
-        <button
+        <a
           aria-current={false}
           aria-label="test page 5"
           className="c9 c11"
@@ -319,12 +336,12 @@ exports[`OakPagination Component matches snapshot 1`] = `
           selected={false}
         >
           5
-        </button>
+        </a>
       </li>
       <li
         className="c8"
       >
-        <button
+        <a
           aria-current={false}
           aria-label="test page 6"
           className="c9 c11"
@@ -336,12 +353,12 @@ exports[`OakPagination Component matches snapshot 1`] = `
           selected={false}
         >
           6
-        </button>
+        </a>
       </li>
       <li
         className="c8"
       >
-        <button
+        <a
           aria-current={false}
           aria-label="test page 7"
           className="c9 c11"
@@ -353,7 +370,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
           selected={false}
         >
           7
-        </button>
+        </a>
       </li>
     </ul>
     <a
@@ -365,6 +382,8 @@ exports[`OakPagination Component matches snapshot 1`] = `
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
+      rel="next"
+      tabIndex={0}
     >
       <div
         className="c4 "

--- a/src/components/organisms/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -208,13 +208,14 @@ exports[`OakPagination Component matches snapshot 1`] = `
   <div
     className="c0 c1"
   >
-    <a
+    <button
       aria-disabled={true}
       aria-label="No previous pages"
       className="c2 c3"
       data-testid="backwards-button"
       disabled={true}
       onClick={[Function]}
+      onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       rel="prev"
@@ -249,7 +250,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
           }
         />
       </div>
-    </a>
+    </button>
     <ul
       className="c7"
     >
@@ -380,6 +381,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
       data-testid="forwards-button"
       disabled={false}
       onClick={[Function]}
+      onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       rel="next"

--- a/src/components/organisms/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -2,10 +2,11 @@
 
 exports[`OakPagination Component matches snapshot 1`] = `
 .c0 {
+  width: 100%;
   font-family: Lexend,sans-serif;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -30,11 +31,15 @@ exports[`OakPagination Component matches snapshot 1`] = `
   gap: 0.5rem;
 }
 
-.c6 {
-  object-fit: contain;
+.c4 {
+  font-family: Lexend,sans-serif;
 }
 
 .c7 {
+  object-fit: contain;
+}
+
+.c8 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -45,7 +50,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c8 {
+.c9 {
   margin-left: 0.25rem;
   margin-right: 0.25rem;
   display: revert;
@@ -55,46 +60,46 @@ exports[`OakPagination Component matches snapshot 1`] = `
 }
 
 .c2 {
-  background: none;
-  color: inherit;
-  border: none;
-  padding: 0;
-  font: inherit;
-  cursor: pointer;
-  text-align: left;
-  font-family: unset;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.25rem;
   outline: none;
-  font-family: Lexend,sans-serif;
-}
-
-.c2:disabled {
-  pointer-events: none;
-  cursor: default;
-}
-
-.c9 {
-  background: none;
-  color: inherit;
-  border: none;
-  padding: 0;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
   font: inherit;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
   cursor: pointer;
-  text-align: left;
-  font-family: unset;
-  outline: none;
-  font-family: Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
+  color: #0d24c4;
 }
 
-.c9:disabled {
-  pointer-events: none;
-  cursor: default;
+.c2:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c2:visited {
+  color: #081676;
+}
+
+.c2:active {
+  color: #081676;
+}
+
+.c2[disabled] {
+  cursor: not-allowed;
+  color: #808080;
 }
 
 .c3 {
@@ -105,12 +110,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   cursor: pointer;
 }
 
-.c3:focus {
-  outline: 2px solid #374cf1;
-  outline-offset: 2px;
-}
-
-.c5 {
+.c6 {
   -webkit-filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
   filter: invert(54%) sepia(0%) saturate(38%) hue-rotate(176deg) brightness(92%) contrast(91%);
 }
@@ -131,13 +131,29 @@ exports[`OakPagination Component matches snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  color: black;
   background-color: black;
   color: white;
 }
 
-.c10:focus {
-  outline: 2px solid #374cf1;
-  outline-offset: 2px;
+.c10:visited {
+  color: white;
+}
+
+.c10:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: white;
 }
 
 .c11 {
@@ -156,13 +172,23 @@ exports[`OakPagination Component matches snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  background-color: white;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
   color: black;
+  background-color: white;
 }
 
-.c11:focus {
-  outline: 2px solid #374cf1;
-  outline-offset: 2px;
+.c11:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 @media (min-width:750px) {
@@ -178,26 +204,33 @@ exports[`OakPagination Component matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c9 {
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c8 {
+  .c9 {
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c9 {
     margin-right: 0.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c8 {
+  .c9 {
     margin-right: 0.5rem;
+  }
+}
+
+@media (hover:hover) {
+  .c2:hover,
+  .c2:visited:hover {
+    color: #0a1d9d;
   }
 }
 
@@ -216,161 +249,177 @@ exports[`OakPagination Component matches snapshot 1`] = `
       disabled={true}
       onClick={[Function]}
       onKeyDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
       rel="prev"
       tabIndex={-1}
     >
-      <div
-        className="c4 c5"
-        disabled={true}
+      <span
+        className="c4"
       >
-        <img
-          alt="chevron-left"
-          className="c6"
-          data-nimg="fill"
-          decoding="async"
-          loading="lazy"
-          onError={[Function]}
-          onLoad={[Function]}
-          src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/rbvzan0ozubmr4j0uqdn.svg"
-          style={
-            {
-              "bottom": 0,
-              "color": "transparent",
-              "height": "100%",
-              "left": 0,
-              "objectFit": undefined,
-              "objectPosition": undefined,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-              "width": "100%",
+        <div
+          className="c5 c6"
+          disabled={true}
+        >
+          <img
+            alt="chevron-left"
+            className="c7"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/rbvzan0ozubmr4j0uqdn.svg"
+            style={
+              {
+                "bottom": 0,
+                "color": "transparent",
+                "height": "100%",
+                "left": 0,
+                "objectFit": undefined,
+                "objectPosition": undefined,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": "100%",
+              }
             }
-          }
-        />
-      </div>
+          />
+        </div>
+      </span>
     </button>
     <ul
-      className="c7"
+      className="c8"
     >
       <li
-        className="c8"
+        className="c9"
       >
         <a
           aria-current="page"
           aria-label="test page 1"
-          className="c9 c10"
+          className="c2 c10"
           data-testid="page-number-component"
           href="?page=1"
           onClick={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
           selected={true}
         >
-          1
+          <span
+            className="c4"
+          >
+            1
+          </span>
         </a>
       </li>
       <li
-        className="c8"
+        className="c9"
       >
         <a
           aria-current={false}
           aria-label="test page 2"
-          className="c9 c11"
+          className="c2 c11"
           data-testid="page-number-component"
           href="?page=2"
           onClick={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
           selected={false}
         >
-          2
+          <span
+            className="c4"
+          >
+            2
+          </span>
         </a>
       </li>
       <li
-        className="c8"
+        className="c9"
       >
         <a
           aria-current={false}
           aria-label="test page 3"
-          className="c9 c11"
+          className="c2 c11"
           data-testid="page-number-component"
           href="?page=3"
           onClick={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
           selected={false}
         >
-          3
+          <span
+            className="c4"
+          >
+            3
+          </span>
         </a>
       </li>
       <li
-        className="c8"
+        className="c9"
       >
         <a
           aria-current={false}
           aria-label="test page 4"
-          className="c9 c11"
+          className="c2 c11"
           data-testid="page-number-component"
           href="?page=4"
           onClick={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
           selected={false}
         >
-          4
+          <span
+            className="c4"
+          >
+            4
+          </span>
         </a>
       </li>
       <li
-        className="c8"
+        className="c9"
       >
         <a
           aria-current={false}
           aria-label="test page 5"
-          className="c9 c11"
+          className="c2 c11"
           data-testid="page-number-component"
           href="?page=5"
           onClick={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
           selected={false}
         >
-          5
+          <span
+            className="c4"
+          >
+            5
+          </span>
         </a>
       </li>
       <li
-        className="c8"
+        className="c9"
       >
         <a
           aria-current={false}
           aria-label="test page 6"
-          className="c9 c11"
+          className="c2 c11"
           data-testid="page-number-component"
           href="?page=6"
           onClick={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
           selected={false}
         >
-          6
+          <span
+            className="c4"
+          >
+            6
+          </span>
         </a>
       </li>
       <li
-        className="c8"
+        className="c9"
       >
         <a
           aria-current={false}
           aria-label="test page 7"
-          className="c9 c11"
+          className="c2 c11"
           data-testid="page-number-component"
           href="?page=7"
           onClick={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
           selected={false}
         >
-          7
+          <span
+            className="c4"
+          >
+            7
+          </span>
         </a>
       </li>
     </ul>
@@ -382,40 +431,42 @@ exports[`OakPagination Component matches snapshot 1`] = `
       disabled={false}
       onClick={[Function]}
       onKeyDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
       rel="next"
       tabIndex={0}
     >
-      <div
-        className="c4 "
-        disabled={false}
+      <span
+        className="c4"
       >
-        <img
-          alt="chevron-right"
-          className="c6"
-          data-nimg="fill"
-          decoding="async"
-          loading="lazy"
-          onError={[Function]}
-          onLoad={[Function]}
-          src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
-          style={
-            {
-              "bottom": 0,
-              "color": "transparent",
-              "height": "100%",
-              "left": 0,
-              "objectFit": undefined,
-              "objectPosition": undefined,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-              "width": "100%",
+        <div
+          className="c5 "
+          disabled={false}
+        >
+          <img
+            alt="chevron-right"
+            className="c7"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+            style={
+              {
+                "bottom": 0,
+                "color": "transparent",
+                "height": "100%",
+                "left": 0,
+                "objectFit": undefined,
+                "objectPosition": undefined,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": "100%",
+              }
             }
-          }
-        />
-      </div>
+          />
+        </div>
+      </span>
     </a>
   </div>
 </nav>

--- a/src/components/organisms/OakPagination/index.ts
+++ b/src/components/organisms/OakPagination/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakPagination";

--- a/src/components/organisms/OakPagination/utils.ts
+++ b/src/components/organisms/OakPagination/utils.ts
@@ -1,0 +1,25 @@
+export const generatePageNumbers = (activePage: number, totalPages: number) => {
+  const pageNumbers: (number | string)[] = [];
+
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i);
+  }
+
+  pageNumbers.push(0);
+
+  if (activePage <= 3) {
+    pageNumbers.push(1, 2, 3, "...", totalPages - 1);
+  } else if (activePage >= 4 && activePage < totalPages - 3) {
+    pageNumbers.push("...", activePage - 1, activePage, "...", totalPages - 1);
+  } else {
+    pageNumbers.push(
+      "...",
+      totalPages - 4,
+      totalPages - 3,
+      totalPages - 2,
+      totalPages - 1,
+    );
+  }
+
+  return pageNumbers;
+};


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

#LESQ-955

Oak Pagination component to be utilised across OWA

## Link to the design doc

https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=9613-1123&m=dev

## A link to the component in the deployment preview

https://deploy-preview-245--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-oakpagination--docs

## Testing instructions

### Functionality
- Chevrons can be used to increment and decrement pages
- Each number is a clickable link which can take you to the correct URL which is passed in 

### Style 
- If a page is selected it should indicate it's active (black bolding)
- As you scroll, when there are 8 or more pages, ellipse should shorten list to only include last page
- If the active page is 4 there should be a double ellipses on the start and end of the list
- If the active page is 5, single ellipses at the start of the menu after 1

## ACs

- [ ]  Page number links should be called “DOMAIN page x” (where domain is blogs/subject name etc)” for a11y
- [ ] “No previous/further pages” when chevrons are disabled
- [ ] Ellipses are invisible to keyboard users/screen readers
- [ ] Same on tablet/mobile


