### PR TITLE
fix: nested links in `OakUnitListItem` causing hydration errors

### DIFF
--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
@@ -169,6 +169,7 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
                 isTrailingIcon
                 iconName="chevron-right"
                 disabled={unavailable}
+                element="span"
               >
                 <OakSpan
                   $font={"heading-light-7"}

--- a/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -396,7 +396,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
           <div
             className="c16 c19"
           >
-            <a
+            <span
               className="c20 c21"
             >
               <span
@@ -437,7 +437,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
                   }
                 />
               </div>
-            </a>
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/OakUnitListOptionalityItemCard.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/OakUnitListOptionalityItemCard.tsx
@@ -112,6 +112,7 @@ export const OakUnitListOptionalityItemCard = (
               isTrailingIcon
               iconName="chevron-right"
               disabled={unavailable}
+              element="span"
             >
               <OakSpan
                 $font={"heading-light-7"}

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
@@ -224,7 +224,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
         <div
           className="c4 c7"
         >
-          <a
+          <span
             className="c8 c9"
           >
             <span
@@ -265,7 +265,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
                 }
               />
             </div>
-          </a>
+          </span>
         </div>
       </div>
     </a>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

this link doesn't appear to be used as a proper link and is only needed for its styling. So making it a span seems reasonable.

These were the related warnings in the test runner:

<img width="1124" alt="Screenshot 2024-08-01 at 10 51 50" src="https://github.com/user-attachments/assets/1cd55616-1897-4319-8f7e-5f9a1b2653ea">

<img width="1148" alt="Screenshot 2024-08-01 at 10 51 35" src="https://github.com/user-attachments/assets/0172e57f-6c4c-4869-97de-e2829e0b0f09">


## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
