### PR TITLE
fix: alignment and minHeight for flex box

### DIFF
--- a/src/components/organisms/pupil/quiz/OakQuizResultItem/OakQuizResultItem.tsx
+++ b/src/components/organisms/pupil/quiz/OakQuizResultItem/OakQuizResultItem.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 
-import { OakFlex, OakIcon, OakImage, OakSpan } from "@/components/atoms";
+import {
+  OakBox,
+  OakFlex,
+  OakIcon,
+  OakImage,
+  OakSpan,
+} from "@/components/atoms";
 import { OakAllSpacingToken } from "@/styles";
 
 export type InternalQuizResultItemProps = {
@@ -23,19 +29,20 @@ const DisplayText = ({
       <OakFlex
         $color={"text-primary"}
         $minHeight={height}
-        $alignItems={"start"}
-        $flexDirection={["column", "row"]}
+        $alignItems={"center"}
       >
-        <OakSpan $font={"body-2-bold"}>{boldPrefixText}</OakSpan>
-        <OakSpan $font={"body-2"}>
-          {"\u00A0"}-{"\u00A0"}
-          {standardText}
-        </OakSpan>
+        <OakBox>
+          <OakSpan $font={"body-2-bold"}>{boldPrefixText}</OakSpan>
+          <OakSpan $font={"body-2"}>
+            {"\u00A0"}-{"\u00A0"}
+            {standardText}
+          </OakSpan>
+        </OakBox>
       </OakFlex>
     );
   } else if (standardText) {
     return (
-      <OakFlex $minHeight={height}>
+      <OakFlex $minHeight={height} $alignItems={"center"}>
         <OakSpan $color={"text-primary"} $font={"body-2"}>
           {standardText}
         </OakSpan>

--- a/src/components/organisms/pupil/quiz/OakQuizResultItem/OakQuizResultItem.tsx
+++ b/src/components/organisms/pupil/quiz/OakQuizResultItem/OakQuizResultItem.tsx
@@ -23,7 +23,7 @@ const DisplayText = ({
       <OakFlex
         $color={"text-primary"}
         $minHeight={height}
-        $alignItems={"center"}
+        $alignItems={"start"}
         $flexDirection={["column", "row"]}
       >
         <OakSpan $font={"body-2-bold"}>{boldPrefixText}</OakSpan>
@@ -35,7 +35,7 @@ const DisplayText = ({
     );
   } else if (standardText) {
     return (
-      <OakFlex $alignItems={"center"} $height={height}>
+      <OakFlex $minHeight={height}>
         <OakSpan $color={"text-primary"} $font={"body-2"}>
           {standardText}
         </OakSpan>

--- a/src/components/organisms/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
@@ -52,6 +52,10 @@ exports[`OakQuizResultItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c6 {

--- a/src/components/organisms/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`OakQuizResultItem matches snapshot 1`] = `
 }
 
 .c4 {
-  height: 2rem;
+  min-height: 2rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -52,10 +52,6 @@ exports[`OakQuizResultItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c6 {


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

**When** I am rendering reviewing quiz results,
**I want to render the answers and grading, aligned to the left (start), and items display correctly when spanning more than two lines**
**So that I can present the results to the user**.

## Link to the design doc

https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?m=auto&node-id=9563-22060

## A link to the component in the deployment preview

https://deploy-preview-264--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-pupil-quiz-oakquizresultitem--default

## Testing instructions

try with 
- small mobile
- lots of standard text
- lots of bold text


## ACs

- [x] vertical alignment is centered
- [x] horizontal alignment is left
- [x] text wrapped without new line for standard text after bold

