### PR TITLE
Feat add expired counts to unit cards

### DIFF
--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.stories.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.stories.tsx
@@ -15,6 +15,7 @@ const meta: Meta<typeof OakUnitListItem> = {
     href: "#",
     yearTitle: "Year 10",
     lessonCount: 10,
+    expiredLessonCount: null,
     isLegacy: false,
     onClick: () => console.log("onClick!"),
   },
@@ -23,6 +24,7 @@ const meta: Meta<typeof OakUnitListItem> = {
     yearTitle: { control: { type: "text" } },
     index: { control: { type: "number" } },
     lessonCount: { control: { type: "number" } },
+    expiredLessonCount: { control: { type: "number" } },
     unavailable: { control: { type: "boolean" } },
     isLegacy: { control: { type: "boolean" } },
   },
@@ -89,13 +91,31 @@ const meta: Meta<typeof OakUnitListItem> = {
             isLegacy={false}
             href={""}
           />
+          <OakUnitListItem
+            title={
+              "'The Three Billy Goats Gruff': reading and writing 'The Three Billy Goats Gruff': reading and writing"
+            }
+            lessonCount={10}
+            expiredLessonCount={2}
+            index={5}
+            yearTitle="Year 9"
+            isLegacy={false}
+            href={""}
+          />
         </OakFlex>
       );
     },
   ],
   parameters: {
     controls: {
-      include: ["title", "index", "lessonCount", "unavailable", "isLegacy"],
+      include: [
+        "title",
+        "index",
+        "lessonCount",
+        "unavailable",
+        "isLegacy",
+        "expiredLessonCount",
+      ],
     },
   },
 };

--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.test.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.test.tsx
@@ -106,4 +106,58 @@ describe("OakUnitListItem", () => {
     expect(unitCard).toHaveStyleRule("cursor", "not-allowed");
     expect(unitCard).toHaveStyleRule("background", "#f2f2f2");
   });
+  it("applies shows expired lesson counts correctly - 1/4 lessons", () => {
+    const { getByText } = renderWithTheme(
+      <OakUnitListItem
+        data-testid="unit-card"
+        index={0}
+        title={""}
+        yearTitle={""}
+        lessonCount={4}
+        expiredLessonCount={3}
+        isLegacy={false}
+        href={""}
+        unavailable
+      />,
+    );
+
+    const lessonCount = getByText("1/4 lessons");
+    expect(lessonCount).toBeInTheDocument();
+  });
+  it("applies shows expired lesson counts correctly - 0/1 lesson", () => {
+    const { getByText } = renderWithTheme(
+      <OakUnitListItem
+        data-testid="unit-card"
+        index={0}
+        title={""}
+        yearTitle={""}
+        lessonCount={1}
+        expiredLessonCount={1}
+        isLegacy={false}
+        href={""}
+        unavailable
+      />,
+    );
+
+    const lessonCount = getByText("0/1 lesson");
+    expect(lessonCount).toBeInTheDocument();
+  });
+  it("applies shows expired lesson counts correctly - 1 lesson", () => {
+    const { getByText } = renderWithTheme(
+      <OakUnitListItem
+        data-testid="unit-card"
+        index={0}
+        title={""}
+        yearTitle={""}
+        lessonCount={1}
+        expiredLessonCount={null}
+        isLegacy={false}
+        href={""}
+        unavailable
+      />,
+    );
+
+    const lessonCount = getByText("1 lesson");
+    expect(lessonCount).toBeInTheDocument();
+  });
 });

--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.test.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.test.tsx
@@ -160,4 +160,22 @@ describe("OakUnitListItem", () => {
     const lessonCount = getByText("1 lesson");
     expect(lessonCount).toBeInTheDocument();
   });
+  it("applies shows expired lesson counts correctly - 0 lesson", () => {
+    const { getByText } = renderWithTheme(
+      <OakUnitListItem
+        data-testid="unit-card"
+        index={0}
+        title={""}
+        yearTitle={""}
+        lessonCount={1}
+        expiredLessonCount={2}
+        isLegacy={false}
+        href={""}
+        unavailable
+      />,
+    );
+
+    const lessonCount = getByText("0 lessons");
+    expect(lessonCount).toBeInTheDocument();
+  });
 });

--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
@@ -78,6 +78,7 @@ export type OakUnitListItemProps = {
   title: string;
   yearTitle?: string | null;
   lessonCount: number | null;
+  expiredLessonCount?: number | null;
   isLegacy: boolean;
   href: string;
   firstItemRef?: MutableRefObject<HTMLAnchorElement | null> | null | undefined;
@@ -91,6 +92,7 @@ export type OakUnitListItemProps = {
 export const OakUnitListItem = (props: OakUnitListItemProps) => {
   const {
     lessonCount,
+    expiredLessonCount,
     href,
     unavailable,
     onClick,
@@ -99,6 +101,21 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
     firstItemRef,
     ...rest
   } = props;
+
+  let unitLessonCount;
+
+  if (lessonCount) {
+    const expiredLessonsInUnitCount =
+      expiredLessonCount && lessonCount
+        ? lessonCount - expiredLessonCount
+        : null;
+    unitLessonCount =
+      expiredLessonsInUnitCount !== null
+        ? `${expiredLessonsInUnitCount}/${lessonCount} ${
+            lessonCount > 1 ? "lessons" : "lesson"
+          }`
+        : `${lessonCount} ${lessonCount > 1 ? "lessons" : "lesson"}`;
+  }
 
   return (
     <OakLI $listStyle={"none"} $width={"100%"}>
@@ -166,12 +183,13 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
                 {props.yearTitle}
               </OakP>
             </OakFlex>
+
             <OakFlex $alignItems={"center"}>
               <OakSpan
                 $font={"heading-light-7"}
                 $color={unavailable ? "text-disabled" : "text-primary"}
               >
-                {lessonCount} lessons
+                {unitLessonCount}
               </OakSpan>
               <OakIcon
                 $colorFilter={unavailable ? "text-disabled" : "text-primary"}

--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
@@ -115,6 +115,10 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
             lessonCount > 1 ? "lessons" : "lesson"
           }`
         : `${lessonCount} ${lessonCount > 1 ? "lessons" : "lesson"}`;
+
+    if (expiredLessonCount && expiredLessonCount > lessonCount) {
+      unitLessonCount = `0 lessons`;
+    }
   }
 
   return (

--- a/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -312,10 +312,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
           >
             <span
               className="c19"
-            >
-              0
-               lessons
-            </span>
+            />
             <div
               className="c20"
             >

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.tsx
@@ -137,6 +137,7 @@ export const OakUnitListOptionalityItem = (
     <OakFlex
       $flexDirection={["column", "row", "row"]}
       $width={"100%"}
+      as={"li"}
       {...rest}
     >
       <OakFlex $display={["flex", "none"]} $background={"white"}>

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.tsx
@@ -197,7 +197,7 @@ export const OakUnitListOptionalityItem = (
             unavailable={unavailable}
           />
         </OakFlex>
-        <OakGrid $rg={"space-between-xs"} $cg={"space-between-xs"} role="list">
+        <OakGrid $rg={"space-between-xs"} $cg={"space-between-xs"}>
           {optionalityUnits.map((unit, index) => (
             <OakGridArea key={`${unit.title}-${index}`} $colSpan={[12, 6]}>
               <OakUnitListOptionalityItemCard

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
@@ -551,7 +551,6 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
       </div>
       <div
         className="c17 c25"
-        role="list"
       />
     </div>
   </li>,

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
@@ -452,7 +452,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   }
 }
 
-<div
+<li
     className="c0 c1"
   >
     <div
@@ -554,7 +554,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
         role="list"
       />
     </div>
-  </div>,
+  </li>,
   ",",
 ]
 `;

--- a/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.stories.tsx
+++ b/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.stories.tsx
@@ -91,6 +91,17 @@ export const Default: Story = {
         isLegacy={false}
         href={"#"}
       />,
+      <OakUnitListItem
+        index={4}
+        title={
+          "Lesson 4 - English  - a lesson with a longer title, a lesson with a longer title"
+        }
+        yearTitle={"Year 11"}
+        lessonCount={3}
+        expiredLessonCount={2}
+        isLegacy={false}
+        href={"#"}
+      />,
     ],
     subject: "maths",
     phase: "secondary",

--- a/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.stories.tsx
+++ b/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.stories.tsx
@@ -36,7 +36,7 @@ export const Default: Story = {
       <OakUnitListItem
         index={1}
         title={"Lesson 1"}
-        lessonCount={null}
+        lessonCount={4}
         isLegacy={false}
         yearTitle={"Year 10"}
         href={"#"}
@@ -77,7 +77,7 @@ export const Default: Story = {
         index={3}
         yearTitle={"Year 11"}
         title={"Lesson 3"}
-        lessonCount={null}
+        lessonCount={2}
         isLegacy={false}
         href={"#"}
       />,
@@ -87,7 +87,7 @@ export const Default: Story = {
           "Lesson 4 - English  - a lesson with a longer title, a lesson with a longer title"
         }
         yearTitle={"Year 11"}
-        lessonCount={null}
+        lessonCount={3}
         isLegacy={false}
         href={"#"}
       />,

--- a/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
@@ -175,8 +175,8 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 .c7 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
-  font-size: 3rem;
-  line-height: 3.5rem;
+  font-size: 2rem;
+  line-height: 2.5rem;
   -webkit-letter-spacing: 0.0115rem;
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;
@@ -412,11 +412,11 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
       <div
         className="c2 c6"
       >
-        <h4
+        <h2
           className="c7"
         >
           Maths units
-        </h4>
+        </h2>
         <div
           className="c8 c9 c10"
         >

--- a/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
@@ -175,8 +175,8 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 .c7 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
-  font-size: 2rem;
-  line-height: 2.5rem;
+  font-size: 3rem;
+  line-height: 3.5rem;
   -webkit-letter-spacing: 0.0115rem;
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;

--- a/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
+++ b/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
@@ -56,7 +56,7 @@ const UnstyledComponent = (props: OakUnitsHeaderProps) => {
     >
       <OakFlex $gap="space-between-ssx" $flexDirection="column">
         <OakFlex $gap="space-between-ssx">
-          <OakHeading $font="heading-2" tag="h4">
+          <OakHeading $font="heading-4" tag="h2">
             {isLegacy
               ? "Units released in 2020-22"
               : `${sentenceCaseSubject} units`}

--- a/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
+++ b/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
@@ -56,7 +56,7 @@ const UnstyledComponent = (props: OakUnitsHeaderProps) => {
     >
       <OakFlex $gap="space-between-ssx" $flexDirection="column">
         <OakFlex $gap="space-between-ssx">
-          <OakHeading $font="heading-4" tag="h4">
+          <OakHeading $font="heading-2" tag="h4">
             {isLegacy
               ? "Units released in 2020-22"
               : `${sentenceCaseSubject} units`}

--- a/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
@@ -153,8 +153,8 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 .c4 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
-  font-size: 2rem;
-  line-height: 2.5rem;
+  font-size: 3rem;
+  line-height: 3.5rem;
   -webkit-letter-spacing: 0.0115rem;
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;

--- a/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
@@ -153,8 +153,8 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 .c4 {
   font-family: Lexend,sans-serif;
   font-weight: 600;
-  font-size: 3rem;
-  line-height: 3.5rem;
+  font-size: 2rem;
+  line-height: 2.5rem;
   -webkit-letter-spacing: 0.0115rem;
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;
@@ -364,11 +364,11 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
     <div
       className="c0 c3"
     >
-      <h4
+      <h2
         className="c4"
       >
         Maths units
-      </h4>
+      </h2>
       <div
         className="c5 c6 c7"
       >


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

-Fixes heading tag on container 
-Added expired lesson count
-Fixes li count for optionally cards

## Link to the design doc

## A link to the component in the deployment preview

https://deploy-preview-267--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-teacher-oakunitscontainer--docs

## Testing instructions


## ACs
