### PR TITLE
fix: remove state from pagination component

### DIFF
--- a/src/components/organisms/shared/OakPagination/OakPagination.stories.tsx
+++ b/src/components/organisms/shared/OakPagination/OakPagination.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta<typeof OakPagination> = {
     totalPages: { type: "number" },
     paginationHref: { type: "string" },
     pageName: { type: "string" },
+    currentPage: { type: "number" },
   },
   parameters: {
     controls: {
@@ -24,8 +25,7 @@ export default meta;
 type Story = StoryObj<typeof OakPagination>;
 
 const PaginationComponent = (args: OakPaginationProps) => {
-  const [currentPage, setCurrentPage] = useState(args.initialPage);
-
+  const [currentPage, setCurrentPage] = useState(1);
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
   };
@@ -33,7 +33,7 @@ const PaginationComponent = (args: OakPaginationProps) => {
   return (
     <OakPagination
       {...args}
-      initialPage={currentPage}
+      currentPage={currentPage}
       onPageChange={handlePageChange}
     />
   );
@@ -42,11 +42,11 @@ const PaginationComponent = (args: OakPaginationProps) => {
 export const Default: Story = {
   render: (args) => (
     <PaginationComponent
-      initialPage={1}
-      totalPages={args.totalPages}
+      totalPages={args.totalPages || 7}
       paginationHref="#"
       pageName={args.pageName}
-      onPageChange={() => {}}
+      onPageChange={args.onPageChange}
+      currentPage={args.currentPage}
     />
   ),
 };

--- a/src/components/organisms/shared/OakPagination/OakPagination.test.tsx
+++ b/src/components/organisms/shared/OakPagination/OakPagination.test.tsx
@@ -21,7 +21,7 @@ describe("OakPagination Component", () => {
         <OakPagination
           paginationHref={""}
           pageName={"test"}
-          initialPage={1}
+          currentPage={1}
           totalPages={8}
           onPageChange={() => {}}
         />
@@ -37,7 +37,7 @@ describe("OakPagination Component", () => {
         <OakPagination
           paginationHref={""}
           pageName={"test"}
-          initialPage={1}
+          currentPage={1}
           totalPages={1}
           onPageChange={() => {}}
         />
@@ -54,7 +54,7 @@ describe("OakPagination Component", () => {
           paginationHref={""}
           onPageChange={() => {}}
           pageName={"test"}
-          initialPage={1}
+          currentPage={1}
           totalPages={7}
         />
       </OakThemeProvider>,
@@ -69,7 +69,7 @@ describe("OakPagination Component", () => {
         <OakPagination
           paginationHref={""}
           pageName={"test"}
-          initialPage={1}
+          currentPage={1}
           onPageChange={() => {}}
           totalPages={7}
         />
@@ -84,7 +84,7 @@ describe("OakPagination Component", () => {
         <OakPagination
           paginationHref={""}
           pageName={"test"}
-          initialPage={7}
+          currentPage={7}
           onPageChange={() => {}}
           totalPages={7}
         />
@@ -98,12 +98,12 @@ describe("OakPagination Component", () => {
 
   it("changes the page back and forward buttons are clicked", () => {
     const onPageChangeMock = jest.fn();
-    const initialPage = 2;
+    const currentPage = 2;
 
     const { getByTestId } = renderWithTheme(
       <OakPagination
         totalPages={5}
-        initialPage={initialPage}
+        currentPage={currentPage}
         onPageChange={onPageChangeMock}
         paginationHref="/#"
         pageName="test"
@@ -114,20 +114,20 @@ describe("OakPagination Component", () => {
     const forwardsButton = getByTestId("forwards-button");
 
     fireEvent.click(backwardsButton);
-    expect(onPageChangeMock).toHaveBeenCalledWith(initialPage - 1);
+    expect(onPageChangeMock).toHaveBeenCalledWith(currentPage - 1);
 
     fireEvent.click(forwardsButton);
-    expect(onPageChangeMock).toHaveBeenCalledWith(initialPage);
+    expect(onPageChangeMock).toHaveBeenCalledWith(currentPage);
   });
 
   it("changes the page when page number is clicked", () => {
     const onPageChangeMock = jest.fn();
-    const initialPage = 2;
+    const currentPage = 2;
 
     const { getAllByTestId } = renderWithTheme(
       <OakPagination
         totalPages={5}
-        initialPage={initialPage}
+        currentPage={currentPage}
         onPageChange={onPageChangeMock}
         paginationHref="/#"
         pageName="test"
@@ -148,7 +148,7 @@ describe("OakPagination Component", () => {
         <OakPagination
           paginationHref={""}
           pageName={"test"}
-          initialPage={1}
+          currentPage={1}
           totalPages={7}
           onPageChange={() => {}}
         />

--- a/src/components/organisms/shared/OakPagination/OakPagination.test.tsx
+++ b/src/components/organisms/shared/OakPagination/OakPagination.test.tsx
@@ -96,7 +96,7 @@ describe("OakPagination Component", () => {
     expect(forwardsButton).toBeDisabled();
   });
 
-  it.only("changes the page back and forward buttons are clicked", () => {
+  it("changes the page back and forward buttons are clicked", () => {
     const onPageChangeMock = jest.fn();
     const currentPage = 2;
 

--- a/src/components/organisms/shared/OakPagination/OakPagination.test.tsx
+++ b/src/components/organisms/shared/OakPagination/OakPagination.test.tsx
@@ -96,7 +96,7 @@ describe("OakPagination Component", () => {
     expect(forwardsButton).toBeDisabled();
   });
 
-  it("changes the page back and forward buttons are clicked", () => {
+  it.only("changes the page back and forward buttons are clicked", () => {
     const onPageChangeMock = jest.fn();
     const currentPage = 2;
 
@@ -117,7 +117,7 @@ describe("OakPagination Component", () => {
     expect(onPageChangeMock).toHaveBeenCalledWith(currentPage - 1);
 
     fireEvent.click(forwardsButton);
-    expect(onPageChangeMock).toHaveBeenCalledWith(currentPage);
+    expect(onPageChangeMock).toHaveBeenCalledWith(currentPage + 1);
   });
 
   it("changes the page when page number is clicked", () => {

--- a/src/components/organisms/shared/OakPagination/OakPagination.tsx
+++ b/src/components/organisms/shared/OakPagination/OakPagination.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useState } from "react";
+import React, { RefObject } from "react";
 import styled, { css } from "styled-components";
 
 import { generatePageNumbers } from "./utils";
@@ -10,7 +10,7 @@ import { OakLink } from "@/components/molecules";
 import { typographyStyle } from "@/styles/utils/typographyStyle";
 
 export type OakPaginationProps = {
-  initialPage: number;
+  currentPage: number;
   totalPages: number;
   firstItemRef?: RefObject<HTMLAnchorElement> | null;
   nextHref?: string;
@@ -132,24 +132,21 @@ const OakEllipsis = () => {
 };
 
 export const OakPagination = ({
-  initialPage,
   totalPages,
   nextHref,
   prevHref,
   paginationHref,
   pageName,
   onPageChange,
+  currentPage,
 }: OakPaginationProps) => {
-  const [activePage, setActivePage] = useState(initialPage);
+  const pages = generatePageNumbers(currentPage, totalPages);
 
-  const pages = generatePageNumbers(activePage, totalPages);
-
-  const isFirstPage = activePage <= 1;
-  const isLastPage = activePage >= totalPages;
+  const isFirstPage = currentPage <= 1;
+  const isLastPage = currentPage >= totalPages;
 
   const handleNumberClick = (num: number, event: React.MouseEvent) => {
     event.preventDefault();
-    setActivePage(num);
     onPageChange(num);
   };
 
@@ -158,12 +155,11 @@ export const OakPagination = ({
     event: React.UIEvent,
   ) => {
     event.preventDefault();
-    const newPage = activePage + (direction === "backwards" ? -1 : 1);
+    const newPage = currentPage + (direction === "backwards" ? -1 : 1);
     onPageChange(newPage);
-    setActivePage(newPage);
   };
 
-  if (initialPage === 1 && totalPages < 2) {
+  if (currentPage === 1 && totalPages < 2) {
     return null;
   }
   return (
@@ -215,7 +211,7 @@ export const OakPagination = ({
                     pageName={pageName}
                     key={page}
                     pageNumber={page + 1}
-                    currentPage={activePage}
+                    currentPage={currentPage}
                     href={`${paginationHref}?page=${page + 1}`}
                     onClick={(e: React.MouseEvent) =>
                       handleNumberClick(page + 1, e)
@@ -278,7 +274,7 @@ export const OakPagination = ({
  * Pagination component for navigating through pages
  *
  * @param router - Next.js router object
- * @param initialPage - Current page number
+ * @param currentPage - Current page number
  * @param totalPages - Total number of pages
  * @param nextHref - URL for the next page
  * @param prevHref - URL for the previous page


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Removes state from Pagination component to utilise currentPage from router 