### PR TITLE
LESQ-1008: Align yearTitle

### DIFF
--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.stories.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.stories.tsx
@@ -4,6 +4,7 @@ import { StoryObj, Meta } from "@storybook/react";
 import { OakUnitListOptionalityItem } from "./OakUnitListOptionalityItem";
 
 import { OakFlex } from "@/components/atoms";
+import { OakUnitListItem } from "@/components/organisms/teacher/OakUnitListItem";
 
 const meta: Meta<typeof OakUnitListOptionalityItem> = {
   title: "components/organisms/teacher/OakUnitListOptionalityItem",
@@ -59,6 +60,14 @@ const meta: Meta<typeof OakUnitListOptionalityItem> = {
           $pa={"inner-padding-xl"}
           role="list"
         >
+          <OakUnitListItem
+            index={1}
+            title={"Test lesson 1"}
+            lessonCount={8}
+            isLegacy={false}
+            href={"#"}
+            yearTitle={"Year 10"}
+          />
           {Story()}
           <OakUnitListOptionalityItem
             nullTitle={

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.tsx
@@ -1,4 +1,5 @@
 import React, { MutableRefObject } from "react";
+import styled from "styled-components";
 
 import { OakUnitListOptionalityItemCard } from "@/components/organisms/teacher/OakUnitListOptionalityItemCard";
 import {
@@ -12,6 +13,12 @@ import {
 } from "@/components/atoms";
 import { FlexStyleProps } from "@/styles/utils/flexStyle";
 
+const StyledYearAndOptionFlex = styled(OakFlex)`
+  @media (min-width: 356px) {
+    min-width: 260px;
+  }
+`;
+
 const UnitYearAndOptionCount = ({
   yearTitle,
   optionalityUnitsLength,
@@ -21,10 +28,13 @@ const UnitYearAndOptionCount = ({
   optionalityUnitsLength: number;
   unavailable: boolean | undefined;
 }) => (
-  <>
+  <StyledYearAndOptionFlex
+    $width={["100%", "all-spacing-19"]}
+    $justifyContent={["space-between"]}
+    $alignItems={"center"}
+  >
     <OakSpan
       $color={unavailable ? "text-disabled" : "text-primary"}
-      $mr={[null, "space-between-xxxl"]}
       $font={"heading-light-7"}
     >
       {yearTitle}
@@ -48,7 +58,7 @@ const UnitYearAndOptionCount = ({
         $color={unavailable ? "text-disabled" : "text-primary"}
       >{`${optionalityUnitsLength} unit options`}</OakLabel>
     </OakBox>
-  </>
+  </StyledYearAndOptionFlex>
 );
 
 const UnitIndex = ({
@@ -87,7 +97,10 @@ const StyledUnitHeading = ({
   unavailable: boolean | undefined;
 }) => {
   return (
-    <OakFlex $maxWidth={"all-spacing-21"}>
+    <OakFlex
+      $maxWidth={"all-spacing-21"}
+      $mr={["space-between-none", "space-between-s"]}
+    >
       <OakHeading
         $color={unavailable ? "text-disabled" : "text-primary"}
         $font={"heading-7"}
@@ -161,7 +174,7 @@ export const OakUnitListOptionalityItem = (
         <OakFlex
           $alignItems={"center"}
           $mb={"space-between-s"}
-          $display={["none", "none", "flex"]}
+          $display={["none", "flex"]}
         >
           <OakFlex
             $flexGrow={1}
@@ -180,17 +193,19 @@ export const OakUnitListOptionalityItem = (
             </OakFlex>
           </OakFlex>
         </OakFlex>
-        <OakBox $mb={"space-between-s"} $display={["none", "flex", "none"]}>
-          <StyledUnitHeading unavailable={unavailable}>
-            {nullTitle}
-          </StyledUnitHeading>
-        </OakBox>
         <OakFlex
-          $display={["flex", "flex", "none"]}
-          $mb={"space-between-s"}
-          $justifyContent={"space-between"}
           $alignItems={"center"}
+          $justifyContent={"space-between"}
+          $mb={"space-between-s"}
+          $display={["flex", "none", "none"]}
+          $width={"100%"}
         >
+          <OakBox $mb={"space-between-s"} $display={["none", "auto", "auto"]}>
+            <StyledUnitHeading unavailable={unavailable}>
+              {nullTitle}
+            </StyledUnitHeading>
+          </OakBox>
+
           <UnitYearAndOptionCount
             yearTitle={props.yearTitle}
             optionalityUnitsLength={optionalityUnits.length}

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 
 .c9 {
   max-width: 30rem;
+  margin-right: 0rem;
   font-family: Lexend,sans-serif;
 }
 
@@ -64,7 +65,12 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c20 {
+.c19 {
+  width: 100%;
+  font-family: Lexend,sans-serif;
+}
+
+.c23 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   padding-top: 0.25rem;
@@ -77,18 +83,19 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   font-family: Lexend,sans-serif;
 }
 
-.c22 {
-  margin-bottom: 1rem;
-  display: none;
-  font-family: Lexend,sans-serif;
-}
-
-.c23 {
+.c25 {
+  width: 100%;
   margin-bottom: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  font-family: Lexend,sans-serif;
+}
+
+.c27 {
+  margin-bottom: 1rem;
+  display: none;
   font-family: Lexend,sans-serif;
 }
 
@@ -181,7 +188,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c24 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -196,7 +203,22 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c25 {
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c28 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   width: 100%;
@@ -229,7 +251,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c19 {
+.c22 {
   color: #222222;
   font-family: Lexend,sans-serif;
   font-weight: 400;
@@ -241,7 +263,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c21 {
+.c24 {
   font-family: Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -280,6 +302,12 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 @media (min-width:1280px) {
   .c4 {
     height: auto;
+  }
+}
+
+@media (min-width:750px) {
+  .c9 {
+    margin-right: 1rem;
   }
 }
 
@@ -333,12 +361,6 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 
 @media (min-width:750px) {
   .c15 {
-    display: none;
-  }
-}
-
-@media (min-width:1280px) {
-  .c15 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -347,32 +369,32 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c22 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
+  .c19 {
+    width: 15rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c25 {
+    display: none;
   }
 }
 
 @media (min-width:1280px) {
-  .c22 {
+  .c25 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c23 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
+  .c27 {
+    display: auto;
   }
 }
 
 @media (min-width:1280px) {
-  .c23 {
-    display: none;
+  .c27 {
+    display: auto;
   }
 }
 
@@ -418,12 +440,6 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 
 @media (min-width:750px) {
   .c16 {
-    display: none;
-  }
-}
-
-@media (min-width:1280px) {
-  .c16 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -432,23 +448,20 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c24 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:1280px) {
-  .c24 {
+  .c26 {
     display: none;
   }
 }
 
-@media (min-width:750px) {
-  .c19 {
-    margin-right: 5rem;
+@media (min-width:1280px) {
+  .c26 {
+    display: none;
+  }
+}
+
+@media (min-width:356px) {
+  .c21 {
+    min-width: 260px;
   }
 }
 
@@ -507,50 +520,58 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
           <div
             className="c17 c8"
           >
-            <span
-              className="c19"
-            />
             <div
-              className="c20"
+              className="c19 c20 c21"
             >
-              <label
-                className="c21"
+              <span
+                className="c22"
+              />
+              <div
+                className="c23"
               >
-                0 unit options
-              </label>
+                <label
+                  className="c24"
+                >
+                  0 unit options
+                </label>
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
-        className="c22"
+        className="c25 c26"
       >
         <div
-          className="c9 c10"
+          className="c27"
         >
-          <h3
-            className="c11"
-          />
-        </div>
-      </div>
-      <div
-        className="c23 c24"
-      >
-        <span
-          className="c19"
-        />
-        <div
-          className="c20"
-        >
-          <label
-            className="c21"
+          <div
+            className="c9 c10"
           >
-            0 unit options
-          </label>
+            <h3
+              className="c11"
+            />
+          </div>
+        </div>
+        <div
+          className="c19 c20 c21"
+        >
+          <span
+            className="c22"
+          />
+          <div
+            className="c23"
+          >
+            <label
+              className="c24"
+            >
+              0 unit options
+            </label>
+          </div>
         </div>
       </div>
       <div
-        className="c17 c25"
+        className="c17 c28"
       />
     </div>
   </li>,


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Centre align yearTitle on unit cards
![Screenshot 2024-08-07 at 11 30 51](https://github.com/user-attachments/assets/ac87c7d7-cba8-498f-b94f-c2eebf07169e)

## A link to the component in the deployment preview

https://deploy-preview-270--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-teacher-oakunitlistoptionalityitem--docs

## ACs

Year title should be aligned with unit card