### PR TITLE
fix: hard coded next js google font value

### DIFF
--- a/src/components/CopyPasteThisComponent/__snapshots__/CopyPasteThisComponent.test.tsx.snap
+++ b/src/components/CopyPasteThisComponent/__snapshots__/CopyPasteThisComponent.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CopyPasteThisComponent matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/CopyPasteThisComponent/__snapshots__/CopyPasteThisComponent.test.tsx.snap
+++ b/src/components/CopyPasteThisComponent/__snapshots__/CopyPasteThisComponent.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CopyPasteThisComponent matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/InternalAccordion/__snapshots__/InternalAccordion.test.tsx.snap
+++ b/src/components/atoms/InternalAccordion/__snapshots__/InternalAccordion.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`InternalAccordion matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2:hover {

--- a/src/components/atoms/InternalAccordion/__snapshots__/InternalAccordion.test.tsx.snap
+++ b/src/components/atoms/InternalAccordion/__snapshots__/InternalAccordion.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`InternalAccordion matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2:hover {

--- a/src/components/atoms/InternalButton/__snapshots__/InternalButton.test.tsx.snap
+++ b/src/components/atoms/InternalButton/__snapshots__/InternalButton.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`InternalButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c0:disabled {

--- a/src/components/atoms/InternalButton/__snapshots__/InternalButton.test.tsx.snap
+++ b/src/components/atoms/InternalButton/__snapshots__/InternalButton.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`InternalButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c0:disabled {

--- a/src/components/atoms/InternalCard/__snapshots__/InternalCard.test.tsx.snap
+++ b/src/components/atoms/InternalCard/__snapshots__/InternalCard.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
   position: relative;
   padding: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/InternalCard/__snapshots__/InternalCard.test.tsx.snap
+++ b/src/components/atoms/InternalCard/__snapshots__/InternalCard.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
   position: relative;
   padding: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/InternalCardWithBackgroundElement/__snapshots__/InternalCardWithBackgroundElement.test.tsx.snap
+++ b/src/components/atoms/InternalCardWithBackgroundElement/__snapshots__/InternalCardWithBackgroundElement.test.tsx.snap
@@ -4,18 +4,18 @@ exports[`InternalStyledSvg matches snapshot 1`] = `
 .c0 {
   position: relative;
   padding: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
   position: relative;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/InternalCardWithBackgroundElement/__snapshots__/InternalCardWithBackgroundElement.test.tsx.snap
+++ b/src/components/atoms/InternalCardWithBackgroundElement/__snapshots__/InternalCardWithBackgroundElement.test.tsx.snap
@@ -4,18 +4,18 @@ exports[`InternalStyledSvg matches snapshot 1`] = `
 .c0 {
   position: relative;
   padding: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
   position: relative;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/InternalCheckBoxLabel/__snapshots__/InternalCheckBoxLabel.test.tsx.snap
+++ b/src/components/atoms/InternalCheckBoxLabel/__snapshots__/InternalCheckBoxLabel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InternalCheckBoxLabel matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/InternalCheckBoxLabel/__snapshots__/InternalCheckBoxLabel.test.tsx.snap
+++ b/src/components/atoms/InternalCheckBoxLabel/__snapshots__/InternalCheckBoxLabel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InternalCheckBoxLabel matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/InternalCheckBoxWrapper/__snapshots__/InternalCheckBoxWrapper.test.tsx.snap
+++ b/src/components/atoms/InternalCheckBoxWrapper/__snapshots__/InternalCheckBoxWrapper.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`InternalCheckBoxWrapper matches snapshot 1`] = `
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,7 +16,7 @@ exports[`InternalCheckBoxWrapper matches snapshot 1`] = `
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {

--- a/src/components/atoms/InternalCheckBoxWrapper/__snapshots__/InternalCheckBoxWrapper.test.tsx.snap
+++ b/src/components/atoms/InternalCheckBoxWrapper/__snapshots__/InternalCheckBoxWrapper.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`InternalCheckBoxWrapper matches snapshot 1`] = `
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,7 +16,7 @@ exports[`InternalCheckBoxWrapper matches snapshot 1`] = `
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {

--- a/src/components/atoms/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
+++ b/src/components/atoms/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`InternalTooltip matches snapshot 1`] = `
   max-width: 22.5rem;
   color: #ffffff;
   background: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
+++ b/src/components/atoms/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`InternalTooltip matches snapshot 1`] = `
   max-width: 22.5rem;
   color: #ffffff;
   background: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakBox/__snapshots__/OakBox.test.tsx.snap
+++ b/src/components/atoms/OakBox/__snapshots__/OakBox.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <div

--- a/src/components/atoms/OakBox/__snapshots__/OakBox.test.tsx.snap
+++ b/src/components/atoms/OakBox/__snapshots__/OakBox.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <div

--- a/src/components/atoms/OakCloudinaryImage/__snapshots__/OakCloudinaryImage.test.tsx.snap
+++ b/src/components/atoms/OakCloudinaryImage/__snapshots__/OakCloudinaryImage.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakCloudinaryImage matches snapshot 1`] = `
 .c0 {
   position: relative;
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakCloudinaryImage/__snapshots__/OakCloudinaryImage.test.tsx.snap
+++ b/src/components/atoms/OakCloudinaryImage/__snapshots__/OakCloudinaryImage.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakCloudinaryImage matches snapshot 1`] = `
 .c0 {
   position: relative;
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakFlex/__snapshots__/OakFlex.test.tsx.snap
+++ b/src/components/atoms/OakFlex/__snapshots__/OakFlex.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakFlex/__snapshots__/OakFlex.test.tsx.snap
+++ b/src/components/atoms/OakFlex/__snapshots__/OakFlex.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakForm/__snapshots__/OakForm.test.tsx.snap
+++ b/src/components/atoms/OakForm/__snapshots__/OakForm.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <form

--- a/src/components/atoms/OakForm/__snapshots__/OakForm.test.tsx.snap
+++ b/src/components/atoms/OakForm/__snapshots__/OakForm.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <form

--- a/src/components/atoms/OakGrid/__snapshots__/OakGrid.test.tsx.snap
+++ b/src/components/atoms/OakGrid/__snapshots__/OakGrid.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakGrid matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakGrid/__snapshots__/OakGrid.test.tsx.snap
+++ b/src/components/atoms/OakGrid/__snapshots__/OakGrid.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakGrid matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakGridArea/__snapshots__/OakGridArea.test.tsx.snap
+++ b/src/components/atoms/OakGridArea/__snapshots__/OakGridArea.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakGrid matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/atoms/OakGridArea/__snapshots__/OakGridArea.test.tsx.snap
+++ b/src/components/atoms/OakGridArea/__snapshots__/OakGridArea.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakGrid matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/atoms/OakHeading/OakHeading.test.tsx
+++ b/src/components/atoms/OakHeading/OakHeading.test.tsx
@@ -47,7 +47,9 @@ describe("Heading", () => {
         />,
       );
 
-      expect(getByTestId("test")).toHaveStyle("font-family: Lexend,sans-serif");
+      expect(getByTestId("test")).toHaveStyle(
+        "font-family:__Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif",
+      );
       expect(getByTestId("test")).toHaveStyle(
         `font-size: ${parseFontSize(font as OakFontToken)}`,
       );

--- a/src/components/atoms/OakHeading/OakHeading.test.tsx
+++ b/src/components/atoms/OakHeading/OakHeading.test.tsx
@@ -48,7 +48,7 @@ describe("Heading", () => {
       );
 
       expect(getByTestId("test")).toHaveStyle(
-        "font-family:__Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif",
+        "font-family:--var(google-font),Lexend,sans-serif",
       );
       expect(getByTestId("test")).toHaveStyle(
         `font-size: ${parseFontSize(font as OakFontToken)}`,

--- a/src/components/atoms/OakHeading/__snapshots__/OakHeading.test.tsx.snap
+++ b/src/components/atoms/OakHeading/__snapshots__/OakHeading.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Heading matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <h1

--- a/src/components/atoms/OakHeading/__snapshots__/OakHeading.test.tsx.snap
+++ b/src/components/atoms/OakHeading/__snapshots__/OakHeading.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Heading matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <h1

--- a/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
+++ b/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakIcon matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
+++ b/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakIcon matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakImage/__snapshots__/OakImage.test.tsx.snap
+++ b/src/components/atoms/OakImage/__snapshots__/OakImage.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakImage matches snapshot 1`] = `
 .c0 {
   position: relative;
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakImage/__snapshots__/OakImage.test.tsx.snap
+++ b/src/components/atoms/OakImage/__snapshots__/OakImage.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakImage matches snapshot 1`] = `
 .c0 {
   position: relative;
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakKbd/__snapshots__/OakKbd.test.tsx.snap
+++ b/src/components/atoms/OakKbd/__snapshots__/OakKbd.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`OakKbd matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/atoms/OakKbd/__snapshots__/OakKbd.test.tsx.snap
+++ b/src/components/atoms/OakKbd/__snapshots__/OakKbd.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`OakKbd matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/atoms/OakLI/__snapshots__/OakLI.test.tsx.snap
+++ b/src/components/atoms/OakLI/__snapshots__/OakLI.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`Component OakLI matches snapshot 1`] = `
 .c0 {
   display: revert;
-  font-family: Lexend,sans-serif;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   display: revert;
   display: revert;
 }

--- a/src/components/atoms/OakLI/__snapshots__/OakLI.test.tsx.snap
+++ b/src/components/atoms/OakLI/__snapshots__/OakLI.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`Component OakLI matches snapshot 1`] = `
 .c0 {
   display: revert;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   display: revert;
   display: revert;
 }

--- a/src/components/atoms/OakLabel/__snapshots__/OakLabel.test.tsx.snap
+++ b/src/components/atoms/OakLabel/__snapshots__/OakLabel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakLabel matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <label

--- a/src/components/atoms/OakLabel/__snapshots__/OakLabel.test.tsx.snap
+++ b/src/components/atoms/OakLabel/__snapshots__/OakLabel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakLabel matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <label

--- a/src/components/atoms/OakMaxWidth/__snapshots__/OakMaxWidth.test.tsx.snap
+++ b/src/components/atoms/OakMaxWidth/__snapshots__/OakMaxWidth.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OakMaxWidth matches snapshot 1`] = `
   padding-right: 0rem;
   margin-left: auto;
   margin-right: auto;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakMaxWidth/__snapshots__/OakMaxWidth.test.tsx.snap
+++ b/src/components/atoms/OakMaxWidth/__snapshots__/OakMaxWidth.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OakMaxWidth matches snapshot 1`] = `
   padding-right: 0rem;
   margin-left: auto;
   margin-right: auto;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/atoms/OakOL/__snapshots__/OakOL.test.tsx.snap
+++ b/src/components/atoms/OakOL/__snapshots__/OakOL.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Component OakOL matches snapshot 1`] = `
 .c0 {
   counter-reset: item;
   padding: 0;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c0 li {

--- a/src/components/atoms/OakOL/__snapshots__/OakOL.test.tsx.snap
+++ b/src/components/atoms/OakOL/__snapshots__/OakOL.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Component OakOL matches snapshot 1`] = `
 .c0 {
   counter-reset: item;
   padding: 0;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c0 li {

--- a/src/components/atoms/OakP/OakP.test.tsx
+++ b/src/components/atoms/OakP/OakP.test.tsx
@@ -12,7 +12,7 @@ describe("P", () => {
       <OakP data-testid="paragraph">Here is some paragraph text</OakP>,
     );
     expect(getByTestId("paragraph")).toHaveStyle(
-      "font-family:__Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif",
+      "font-family:--var(google-font),Lexend,sans-serif",
     );
   });
 

--- a/src/components/atoms/OakP/OakP.test.tsx
+++ b/src/components/atoms/OakP/OakP.test.tsx
@@ -12,7 +12,7 @@ describe("P", () => {
       <OakP data-testid="paragraph">Here is some paragraph text</OakP>,
     );
     expect(getByTestId("paragraph")).toHaveStyle(
-      "font-family: Lexend,sans-serif",
+      "font-family:__Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif",
     );
   });
 

--- a/src/components/atoms/OakP/__snapshots__/OakP.test.tsx.snap
+++ b/src/components/atoms/OakP/__snapshots__/OakP.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`P matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <p

--- a/src/components/atoms/OakP/__snapshots__/OakP.test.tsx.snap
+++ b/src/components/atoms/OakP/__snapshots__/OakP.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`P matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <p

--- a/src/components/atoms/OakSpan/OakSpan.test.tsx
+++ b/src/components/atoms/OakSpan/OakSpan.test.tsx
@@ -23,7 +23,7 @@ describe("OakSpan", () => {
   //       <OakSpan $font="body-1">Test</OakSpan>,
   //     );
   //     const span = getByText("Test");
-  //     expect(span).toHaveStyle("font-family: Lexend,sans-serif");
+  //     expect(span).toHaveStyle(font-family:__Lexend_866216,__Lexend_Fallback_86621, Lexend,sans-serif");
   //     expect(span).toHaveStyle(`font-size: 1.125rem`);
   //     expect(span).toHaveStyle(`line-height: 1.75rem`);
   //     expect(span).toHaveStyle(`font-weight: 300`);

--- a/src/components/atoms/OakSpan/__snapshots__/OakSpan.test.tsx.snap
+++ b/src/components/atoms/OakSpan/__snapshots__/OakSpan.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakSpan matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <span

--- a/src/components/atoms/OakSpan/__snapshots__/OakSpan.test.tsx.snap
+++ b/src/components/atoms/OakSpan/__snapshots__/OakSpan.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakSpan matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <span

--- a/src/components/atoms/OakTypography/OakTypography.test.tsx
+++ b/src/components/atoms/OakTypography/OakTypography.test.tsx
@@ -28,7 +28,7 @@ describe("OakTypography", () => {
   //       const { getByTestId } = renderWithTheme(
   //         <Typography data-testid="test" $font={font as FontVariant} />,
   //       );
-  //       expect(getByTestId("test")).toHaveStyle("font-family: Lexend,sans-serif");
+  //       expect(getByTestId("test")).toHaveStyle(font-family:__Lexend_866216,__Lexend_Fallback_86621, Lexend,sans-serif");
   //       expect(getByTestId("test")).toHaveStyle(
   //         `font-size: ${Number((fontSize / 16).toFixed(REM_DP))}rem`,
   //       );

--- a/src/components/atoms/OakTypography/__snapshots__/OakTypography.test.tsx.snap
+++ b/src/components/atoms/OakTypography/__snapshots__/OakTypography.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`OakTypography matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <div

--- a/src/components/atoms/OakTypography/__snapshots__/OakTypography.test.tsx.snap
+++ b/src/components/atoms/OakTypography/__snapshots__/OakTypography.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`OakTypography matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <div

--- a/src/components/atoms/OakUL/__snapshots__/OakUL.test.tsx.snap
+++ b/src/components/atoms/OakUL/__snapshots__/OakUL.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Component OakUL matches snapshot 1`] = `
 .c0 {
   margin: 0;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <ul

--- a/src/components/atoms/OakUL/__snapshots__/OakUL.test.tsx.snap
+++ b/src/components/atoms/OakUL/__snapshots__/OakUL.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Component OakUL matches snapshot 1`] = `
 .c0 {
   margin: 0;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <ul

--- a/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
+++ b/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3:hover {
@@ -22,11 +22,11 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -94,7 +94,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7:hover {
@@ -106,7 +106,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
+++ b/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3:hover {
@@ -22,11 +22,11 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
@@ -94,7 +94,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7:hover {
@@ -106,7 +106,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/components/molecules/InternalLink/__snapshots__/InternalLink.test.tsx.snap
+++ b/src/components/molecules/InternalLink/__snapshots__/InternalLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InternalLink matches snapshot 1`] = `
 .c1 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c0 {

--- a/src/components/molecules/InternalLink/__snapshots__/InternalLink.test.tsx.snap
+++ b/src/components/molecules/InternalLink/__snapshots__/InternalLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InternalLink matches snapshot 1`] = `
 .c1 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c0 {

--- a/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -55,7 +55,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -76,7 +76,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #ebfbeb;
   background: #bef2bd;
   padding-left: 1rem;

--- a/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -55,7 +55,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -76,7 +76,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #ebfbeb;
   background: #bef2bd;
   padding-left: 1rem;

--- a/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -21,7 +21,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   color: #ebfbeb;
   background: #bef2bd;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
@@ -30,7 +30,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
@@ -39,7 +39,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -88,7 +88,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -108,7 +108,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #ebfbeb;
 }
 

--- a/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -21,7 +21,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   color: #ebfbeb;
   background: #bef2bd;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -30,7 +30,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -39,7 +39,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -88,7 +88,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -108,7 +108,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #ebfbeb;
 }
 

--- a/src/components/molecules/OakAccordion/__snapshots__/OakAccordion.test.tsx.snap
+++ b/src/components/molecules/OakAccordion/__snapshots__/OakAccordion.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakAccordion matches snapshot 1`] = `
   background: #f2f2f2;
   border: 0.063rem solid;
   border-color: #cacaca;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -23,7 +23,7 @@ exports[`OakAccordion matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3:hover {
@@ -37,16 +37,16 @@ exports[`OakAccordion matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   margin-right: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
   margin-left: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {

--- a/src/components/molecules/OakAccordion/__snapshots__/OakAccordion.test.tsx.snap
+++ b/src/components/molecules/OakAccordion/__snapshots__/OakAccordion.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakAccordion matches snapshot 1`] = `
   background: #f2f2f2;
   border: 0.063rem solid;
   border-color: #cacaca;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -23,7 +23,7 @@ exports[`OakAccordion matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3:hover {
@@ -37,16 +37,16 @@ exports[`OakAccordion matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   margin-right: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
   margin-left: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {

--- a/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
+++ b/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakBackLink matches snapshot 1`] = `
   min-width: 2.5rem;
   height: 2.5rem;
   min-height: 2.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
+++ b/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakBackLink matches snapshot 1`] = `
   min-width: 2.5rem;
   height: 2.5rem;
   min-height: 2.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/molecules/OakBulletList/__snapshots__/OakBulletList.test.tsx.snap
+++ b/src/components/molecules/OakBulletList/__snapshots__/OakBulletList.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakBulletList matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <span

--- a/src/components/molecules/OakBulletList/__snapshots__/OakBulletList.test.tsx.snap
+++ b/src/components/molecules/OakBulletList/__snapshots__/OakBulletList.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakBulletList matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <span

--- a/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -10,7 +10,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -19,7 +19,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -50,7 +50,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -71,7 +71,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -10,7 +10,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -19,7 +19,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -50,7 +50,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -71,7 +71,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/molecules/OakCardWithHandDrawnBorder/__snapshots__/OakCardWithHandDrawnBorder.test.tsx.snap
+++ b/src/components/molecules/OakCardWithHandDrawnBorder/__snapshots__/OakCardWithHandDrawnBorder.test.tsx.snap
@@ -7,18 +7,18 @@ exports[`OakCardWithHandDrawnBorder matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakCardWithHandDrawnBorder/__snapshots__/OakCardWithHandDrawnBorder.test.tsx.snap
+++ b/src/components/molecules/OakCardWithHandDrawnBorder/__snapshots__/OakCardWithHandDrawnBorder.test.tsx.snap
@@ -7,18 +7,18 @@ exports[`OakCardWithHandDrawnBorder matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
+++ b/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -44,7 +44,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
@@ -53,7 +53,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -63,7 +63,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
 }
 
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
+++ b/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -44,7 +44,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -53,7 +53,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -63,7 +63,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
 }
 
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/molecules/OakCollapsibleContent/__snapshots__/OakCollapsibleContent.test.tsx.snap
+++ b/src/components/molecules/OakCollapsibleContent/__snapshots__/OakCollapsibleContent.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakCollapsibleContent matches snapshot 1`] = `
 .c0 {
   display: block;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -13,7 +13,7 @@ exports[`OakCollapsibleContent matches snapshot 1`] = `
   padding-bottom: 1.5rem;
   background: #e4e4e4;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -21,7 +21,7 @@ exports[`OakCollapsibleContent matches snapshot 1`] = `
   width: 100%;
   max-height: 100%;
   padding-right: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/molecules/OakCollapsibleContent/__snapshots__/OakCollapsibleContent.test.tsx.snap
+++ b/src/components/molecules/OakCollapsibleContent/__snapshots__/OakCollapsibleContent.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakCollapsibleContent matches snapshot 1`] = `
 .c0 {
   display: block;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -13,7 +13,7 @@ exports[`OakCollapsibleContent matches snapshot 1`] = `
   padding-bottom: 1.5rem;
   background: #e4e4e4;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -21,7 +21,7 @@ exports[`OakCollapsibleContent matches snapshot 1`] = `
   width: 100%;
   max-height: 100%;
   padding-right: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
+++ b/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakDragAndDropInstructions matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -11,11 +11,11 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -57,7 +57,7 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
+++ b/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakDragAndDropInstructions matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -11,11 +11,11 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -57,7 +57,7 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/molecules/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
+++ b/src/components/molecules/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
@@ -10,11 +10,11 @@ exports[`OakDraggable matches snapshot 1`] = `
   color: #222222;
   background: #ffffff;
   border-radius: 0.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -23,11 +23,11 @@ exports[`OakDraggable matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/molecules/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
+++ b/src/components/molecules/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
@@ -10,11 +10,11 @@ exports[`OakDraggable matches snapshot 1`] = `
   color: #222222;
   background: #ffffff;
   border-radius: 0.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
@@ -23,11 +23,11 @@ exports[`OakDraggable matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/molecules/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
+++ b/src/components/molecules/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
@@ -12,11 +12,11 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
   border: 0.25rem solid;
   border-color: #287c34;
   border-radius: 0.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -25,11 +25,11 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/molecules/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
+++ b/src/components/molecules/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
@@ -12,11 +12,11 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
   border: 0.25rem solid;
   border-color: #287c34;
   border-radius: 0.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
@@ -25,11 +25,11 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/molecules/OakDroppable/__snapshots__/OakDroppable.test.tsx.snap
+++ b/src/components/molecules/OakDroppable/__snapshots__/OakDroppable.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakDroppable matches snapshot 1`] = `
   padding: 1rem;
   background: #cee7e5;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,12 +13,12 @@ exports[`OakDroppable matches snapshot 1`] = `
   padding: 0.25rem;
   background: #f2f2f2;
   border-radius: 0.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakDroppable/__snapshots__/OakDroppable.test.tsx.snap
+++ b/src/components/molecules/OakDroppable/__snapshots__/OakDroppable.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakDroppable matches snapshot 1`] = `
   padding: 1rem;
   background: #cee7e5;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,12 +13,12 @@ exports[`OakDroppable matches snapshot 1`] = `
   padding: 0.25rem;
   background: #f2f2f2;
   border-radius: 0.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakHandDrawnCard/__snapshots__/OakHandDrawnCard.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnCard/__snapshots__/OakHandDrawnCard.test.tsx.snap
@@ -7,18 +7,18 @@ exports[`OakHandDrawnCard matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakHandDrawnCard/__snapshots__/OakHandDrawnCard.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnCard/__snapshots__/OakHandDrawnCard.test.tsx.snap
@@ -7,18 +7,18 @@ exports[`OakHandDrawnCard matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
@@ -6,18 +6,18 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
   width: 5rem;
   height: 5rem;
   padding: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -26,7 +26,7 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
   min-width: 4rem;
   height: 4rem;
   min-height: 4rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
@@ -6,18 +6,18 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
   width: 5rem;
   height: 5rem;
   padding: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -26,7 +26,7 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
   min-width: 4rem;
   height: 4rem;
   min-height: 4rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakHandDrawnFocusUnderline/__snapshots__/OakHandDrawnFocusUnderline.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnFocusUnderline/__snapshots__/OakHandDrawnFocusUnderline.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakHandDrawnFocusUnderline matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakHandDrawnFocusUnderline/__snapshots__/OakHandDrawnFocusUnderline.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnFocusUnderline/__snapshots__/OakHandDrawnFocusUnderline.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakHandDrawnFocusUnderline matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakHandDrawnHR matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakHandDrawnHR matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -11,16 +11,16 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
@@ -29,11 +29,11 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -48,7 +48,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c16 {
@@ -59,7 +59,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c18 {
@@ -68,7 +68,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c19 {
@@ -77,7 +77,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -184,7 +184,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -195,7 +195,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
 }
 
 .c20 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -206,7 +206,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
 }
 
 .c22 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c13 {
@@ -219,7 +219,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: transparent;
 }
 

--- a/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -11,16 +11,16 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -29,11 +29,11 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -48,7 +48,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -59,7 +59,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c18 {
@@ -68,7 +68,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -77,7 +77,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -184,7 +184,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -195,7 +195,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
 }
 
 .c20 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -206,7 +206,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
 }
 
 .c22 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -219,7 +219,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: transparent;
 }
 

--- a/src/components/molecules/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
+++ b/src/components/molecules/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`OakjauntyAngleLabel matches snapshot 1`] = `
   -webkit-transform: rotate(-1.5deg);
   -ms-transform: rotate(-1.5deg);
   transform: rotate(-1.5deg);
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/molecules/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
+++ b/src/components/molecules/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`OakjauntyAngleLabel matches snapshot 1`] = `
   -webkit-transform: rotate(-1.5deg);
   -ms-transform: rotate(-1.5deg);
   transform: rotate(-1.5deg);
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
+++ b/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -18,7 +18,7 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -49,7 +49,7 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;

--- a/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
+++ b/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -18,7 +18,7 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
@@ -49,7 +49,7 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;

--- a/src/components/molecules/OakLink/__snapshots__/OakLink.test.tsx.snap
+++ b/src/components/molecules/OakLink/__snapshots__/OakLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakLink matches snapshot 1`] = `
 .c1 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c0 {

--- a/src/components/molecules/OakLink/__snapshots__/OakLink.test.tsx.snap
+++ b/src/components/molecules/OakLink/__snapshots__/OakLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakLink matches snapshot 1`] = `
 .c1 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c0 {

--- a/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
+++ b/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   opacity: 0.25;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -22,20 +22,20 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   background: #ffffff;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   z-index: 300;
 }
 
 .c5 {
   margin: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
   position: relative;
   width: 2rem;
   height: 2.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
@@ -43,11 +43,11 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c16 {
@@ -58,7 +58,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c18 {
@@ -67,7 +67,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c19 {
@@ -76,14 +76,14 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c22 {
   overflow: auto;
   border-top: 0.063rem solid;
   border-color: transparent;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c20 {
@@ -182,7 +182,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
 }
 
 .c21 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -202,7 +202,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: transparent;
 }
 

--- a/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
+++ b/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   opacity: 0.25;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -22,20 +22,20 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   background: #ffffff;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   z-index: 300;
 }
 
 .c5 {
   margin: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
   position: relative;
   width: 2rem;
   height: 2.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -43,11 +43,11 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -58,7 +58,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c18 {
@@ -67,7 +67,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -76,14 +76,14 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c22 {
   overflow: auto;
   border-top: 0.063rem solid;
   border-color: transparent;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c20 {
@@ -182,7 +182,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
 }
 
 .c21 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -202,7 +202,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: transparent;
 }
 

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
 .c0 {
   position: fixed;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -12,7 +12,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   position: fixed;
   inset: 0rem;
   background: #22222240;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   z-index: -1;
 }
 
@@ -20,7 +20,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   width: 100%;
   max-width: 60rem;
   padding: 1.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,20 +30,20 @@ exports[`OakModalCenter matches snapshot 1`] = `
   border: 0.25rem solid;
   border-color: #93e892;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
   position: relative;
   min-height: 3.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -51,11 +51,11 @@ exports[`OakModalCenter matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c16 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c18 {
@@ -66,7 +66,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c19 {
@@ -75,7 +75,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c20 {
@@ -84,7 +84,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c23 {
@@ -94,7 +94,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   border-top: 0rem solid;
   border-bottom: 0rem solid;
   border-color: #cacaca;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c21 {
@@ -155,7 +155,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
 }
 
 .c22 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -175,7 +175,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: transparent;
 }
 
@@ -234,7 +234,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
 
 .c6 {
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
 .c0 {
   position: fixed;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -12,7 +12,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   position: fixed;
   inset: 0rem;
   background: #22222240;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   z-index: -1;
 }
 
@@ -20,7 +20,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   width: 100%;
   max-width: 60rem;
   padding: 1.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,20 +30,20 @@ exports[`OakModalCenter matches snapshot 1`] = `
   border: 0.25rem solid;
   border-color: #93e892;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
   position: relative;
   min-height: 3.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -51,11 +51,11 @@ exports[`OakModalCenter matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c16 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c18 {
@@ -66,7 +66,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -75,7 +75,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c20 {
@@ -84,7 +84,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c23 {
@@ -94,7 +94,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   border-top: 0rem solid;
   border-bottom: 0rem solid;
   border-color: #cacaca;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c21 {
@@ -155,7 +155,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
 }
 
 .c22 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -175,7 +175,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: transparent;
 }
 
@@ -234,7 +234,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
 
 .c6 {
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
 .c0 {
   width: 100%;
   padding-bottom: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -14,7 +14,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
   height: 6.25rem;
   min-height: 6.25rem;
   margin-bottom: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -40,7 +40,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
 .c0 {
   width: 100%;
   padding-bottom: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -14,7 +14,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
   height: 6.25rem;
   min-height: 6.25rem;
   margin-bottom: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -40,7 +40,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -3,22 +3,22 @@
 exports[`OakOutlineAccordion matches snapshot 1`] = `
 .c0 {
   position: relative;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8:hover {
@@ -31,7 +31,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14 {
@@ -109,7 +109,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c12:hover {
@@ -121,7 +121,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -3,22 +3,22 @@
 exports[`OakOutlineAccordion matches snapshot 1`] = `
 .c0 {
   position: relative;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8:hover {
@@ -31,7 +31,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -109,7 +109,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c12:hover {
@@ -121,7 +121,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -57,7 +57,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -57,7 +57,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -57,7 +57,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -57,7 +57,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/molecules/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
+++ b/src/components/molecules/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`OakPromoTag matches snapshot 1`] = `
 .c0 {
   position: relative;
   width: 2.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
   position: absolute;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -30,7 +30,7 @@ exports[`OakPromoTag matches snapshot 1`] = `
 
 .c5 {
   color: #ffe555;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/molecules/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
+++ b/src/components/molecules/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`OakPromoTag matches snapshot 1`] = `
 .c0 {
   position: relative;
   width: 2.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
   position: absolute;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -30,7 +30,7 @@ exports[`OakPromoTag matches snapshot 1`] = `
 
 .c5 {
   color: #ffe555;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/molecules/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
+++ b/src/components/molecules/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`RadioGroup matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -16,7 +16,7 @@ exports[`RadioGroup matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -50,7 +50,7 @@ exports[`RadioGroup matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/molecules/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
+++ b/src/components/molecules/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`RadioGroup matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -16,7 +16,7 @@ exports[`RadioGroup matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -50,7 +50,7 @@ exports[`RadioGroup matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/molecules/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`RadioGroup matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -16,7 +16,7 @@ exports[`RadioGroup matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -50,7 +50,7 @@ exports[`RadioGroup matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/molecules/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`RadioGroup matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -16,7 +16,7 @@ exports[`RadioGroup matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -50,7 +50,7 @@ exports[`RadioGroup matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
+++ b/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakRoundIcon matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -16,7 +16,7 @@ exports[`OakRoundIcon matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
+++ b/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakRoundIcon matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -16,7 +16,7 @@ exports[`OakRoundIcon matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -57,7 +57,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -57,7 +57,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/molecules/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -42,7 +42,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -63,7 +63,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/molecules/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -42,7 +42,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -63,7 +63,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/molecules/OakSecondaryLink/__snapshots__/OakSecondaryLink.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryLink/__snapshots__/OakSecondaryLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakSecondaryLink matches snapshot 1`] = `
 .c1 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c0 {

--- a/src/components/molecules/OakSecondaryLink/__snapshots__/OakSecondaryLink.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryLink/__snapshots__/OakSecondaryLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakSecondaryLink matches snapshot 1`] = `
 .c1 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c0 {

--- a/src/components/molecules/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -57,7 +57,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 0.5rem;

--- a/src/components/molecules/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -57,7 +57,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 0.5rem;

--- a/src/components/molecules/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -57,7 +57,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 0.5rem;

--- a/src/components/molecules/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -57,7 +57,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 0.5rem;

--- a/src/components/molecules/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/molecules/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -40,7 +40,7 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -60,7 +60,7 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/molecules/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/molecules/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -40,7 +40,7 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -60,7 +60,7 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/molecules/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/molecules/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`OakTextInput matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c0:hover {
@@ -69,7 +69,7 @@ exports[`OakTextInput matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/molecules/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`OakTextInput matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c0:hover {
@@ -69,7 +69,7 @@ exports[`OakTextInput matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
+++ b/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakTooltip matches snapshot 1`] = `
   .c0 {
   position: fixed;
   pointer-events: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -22,7 +22,7 @@ exports[`OakTooltip matches snapshot 1`] = `
   -webkit-transform: translateY(calc(100% + 1rem));
   -ms-transform: translateY(calc(100% + 1rem));
   transform: translateY(calc(100% + 1rem));
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -36,7 +36,7 @@ exports[`OakTooltip matches snapshot 1`] = `
   background: #ffe555;
   border-radius: 0.375rem;
   border-top-left-radius: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
+++ b/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakTooltip matches snapshot 1`] = `
   .c0 {
   position: fixed;
   pointer-events: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -22,7 +22,7 @@ exports[`OakTooltip matches snapshot 1`] = `
   -webkit-transform: translateY(calc(100% + 1rem));
   -ms-transform: translateY(calc(100% + 1rem));
   transform: translateY(calc(100% + 1rem));
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -36,7 +36,7 @@ exports[`OakTooltip matches snapshot 1`] = `
   background: #ffe555;
   border-radius: 0.375rem;
   border-top-left-radius: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -15,12 +15,12 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -29,11 +29,11 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c21 {
@@ -57,7 +57,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c23 {
@@ -66,7 +66,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c28 {
@@ -75,7 +75,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -206,7 +206,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -217,7 +217,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c27 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -229,7 +229,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -240,7 +240,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -260,7 +260,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -15,12 +15,12 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -29,11 +29,11 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c21 {
@@ -57,7 +57,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c23 {
@@ -66,7 +66,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c28 {
@@ -75,7 +75,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -206,7 +206,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -217,7 +217,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c27 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -229,7 +229,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -240,7 +240,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -260,7 +260,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneyHeader/__snapshots__/OakPupilJourneyHeader.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyHeader/__snapshots__/OakPupilJourneyHeader.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
 [
   " ",
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -12,18 +12,18 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
   width: 4rem;
   height: 4rem;
   padding: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
   position: absolute;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
   position: relative;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -32,7 +32,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
   min-width: 3rem;
   height: 3rem;
   min-height: 3rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
@@ -86,7 +86,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -97,7 +97,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 > * {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyHeader/__snapshots__/OakPupilJourneyHeader.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyHeader/__snapshots__/OakPupilJourneyHeader.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
 [
   " ",
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -12,18 +12,18 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
   width: 4rem;
   height: 4rem;
   padding: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
   position: absolute;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
   position: relative;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -32,7 +32,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
   min-width: 3rem;
   height: 3rem;
   min-height: 3rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -86,7 +86,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -97,7 +97,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 > * {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
@@ -4,19 +4,19 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
 .c0 {
   width: 100%;
   background: #f5e9f2;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   padding-top: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
   padding: 1rem;
   background: #e5d1e0;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
@@ -4,19 +4,19 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
 .c0 {
   width: 100%;
   background: #f5e9f2;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   padding-top: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
   padding: 1rem;
   background: #e5d1e0;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 [
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -13,12 +13,12 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   border: 0rem solid;
   border-color: transparent;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -32,7 +32,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 
 .c8 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -48,7 +48,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -57,7 +57,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 [
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -13,12 +13,12 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   border: 0rem solid;
   border-color: transparent;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -32,7 +32,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 
 .c8 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -48,7 +48,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c13 {
@@ -57,7 +57,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14 {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyListItemSubheading/__snapshots__/OakPupilJourneyListItemSubheading.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyListItemSubheading/__snapshots__/OakPupilJourneyListItemSubheading.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
 [
   " ",
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -30,7 +30,7 @@ exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -41,7 +41,7 @@ exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -60,11 +60,11 @@ exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
   border: 0.063rem solid;
   border-color: #ffe555;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 @media (min-width:750px) {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyListItemSubheading/__snapshots__/OakPupilJourneyListItemSubheading.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyListItemSubheading/__snapshots__/OakPupilJourneyListItemSubheading.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
 [
   " ",
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -30,7 +30,7 @@ exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -41,7 +41,7 @@ exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -60,11 +60,11 @@ exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
   border: 0.063rem solid;
   border-color: #ffe555;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 @media (min-width:750px) {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   .c0 {
   color: #222222;
   background: #ffffff;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -14,27 +14,27 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: absolute;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
   position: relative;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -46,7 +46,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
 
 .c13 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -62,7 +62,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   padding: 0.25rem;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -71,7 +71,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c16 {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   .c0 {
   color: #222222;
   background: #ffffff;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -14,27 +14,27 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   position: absolute;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
   position: relative;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -46,7 +46,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
 
 .c13 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -62,7 +62,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   padding: 0.25rem;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c15 {
@@ -71,7 +71,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c16 {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -28,7 +28,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 
 .c6 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -41,7 +41,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 .c8 {
   color: #222222;
   background: #ffffff;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -50,23 +50,23 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c13 {
   position: absolute;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c16 {
   position: relative;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c18 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 
 .c20 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -94,7 +94,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   padding: 0.25rem;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c22 {
@@ -103,7 +103,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c23 {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -28,7 +28,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 
 .c6 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -41,7 +41,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 .c8 {
   color: #222222;
   background: #ffffff;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -50,23 +50,23 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
   position: absolute;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c16 {
   position: relative;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c18 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 
 .c20 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -94,7 +94,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   padding: 0.25rem;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c22 {
@@ -103,7 +103,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c23 {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyProgrammeOptions/__snapshots__/OakPupilJourneyProgrammeOptions.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyProgrammeOptions/__snapshots__/OakPupilJourneyProgrammeOptions.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
 .c0 {
   width: 100%;
   background: #f5e9f2;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,17 +13,17 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #e5d1e0;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyProgrammeOptions/__snapshots__/OakPupilJourneyProgrammeOptions.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyProgrammeOptions/__snapshots__/OakPupilJourneyProgrammeOptions.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
 .c0 {
   width: 100%;
   background: #f5e9f2;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,17 +13,17 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #e5d1e0;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,12 +15,12 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   width: 7.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -29,7 +29,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
   min-width: 4.5rem;
   height: 2rem;
   min-height: 4.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -56,7 +56,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -77,7 +77,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #f5e9f2;
   padding-left: 0.75rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,12 +15,12 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   width: 7.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -29,7 +29,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
   min-width: 4.5rem;
   height: 2rem;
   min-height: 4.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -56,7 +56,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -77,7 +77,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #f5e9f2;
   padding-left: 0.75rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -4,27 +4,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 [
   .c0 {
   display: block;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: relative;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10:hover {
@@ -37,7 +37,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -45,7 +45,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c21 {
@@ -54,7 +54,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -143,7 +143,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 .c15 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -154,7 +154,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 .c25 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -175,7 +175,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;
@@ -202,7 +202,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -330,7 +330,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14:hover {
@@ -342,7 +342,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -660,7 +660,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
     </div>
   </div>,
   .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -668,7 +668,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -677,12 +677,12 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c0 {
   display: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -728,7 +728,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -749,7 +749,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;
@@ -776,7 +776,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -4,27 +4,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 [
   .c0 {
   display: block;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   position: relative;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10:hover {
@@ -37,7 +37,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c19 {
@@ -45,7 +45,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c21 {
@@ -54,7 +54,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c17 {
@@ -143,7 +143,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 .c15 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -154,7 +154,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 .c25 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -175,7 +175,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;
@@ -202,7 +202,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -330,7 +330,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14:hover {
@@ -342,7 +342,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -660,7 +660,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
     </div>
   </div>,
   .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -668,7 +668,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -677,12 +677,12 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c0 {
   display: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -728,7 +728,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -749,7 +749,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;
@@ -776,7 +776,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneyYearButton/__snapshots__/OakPupilJourneyYearButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyYearButton/__snapshots__/OakPupilJourneyYearButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -42,7 +42,7 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -63,7 +63,7 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #f5e9f2;
   padding-left: 1.5rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneyYearButton/__snapshots__/OakPupilJourneyYearButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyYearButton/__snapshots__/OakPupilJourneyYearButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -42,7 +42,7 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -63,7 +63,7 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #f5e9f2;
   padding-left: 1.5rem;

--- a/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
 [
   .c0 {
   padding-top: 1.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -12,11 +12,11 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -27,7 +27,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   color: #222222;
   background: #222222;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c13 {
@@ -36,7 +36,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14 {
@@ -45,7 +45,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c15 {
@@ -114,7 +114,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -134,7 +134,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
 }
 
@@ -191,7 +191,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5:hover {
@@ -276,7 +276,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
     </div>
   </div>,
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -288,7 +288,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   margin-top: 1.5rem;
   background: #ffffff;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {

--- a/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
 [
   .c0 {
   padding-top: 1.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -12,11 +12,11 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -27,7 +27,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   color: #222222;
   background: #222222;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -36,7 +36,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -45,7 +45,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -114,7 +114,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -134,7 +134,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 
@@ -191,7 +191,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5:hover {
@@ -276,7 +276,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
     </div>
   </div>,
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -288,7 +288,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   margin-top: 1.5rem;
   background: #ffffff;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {

--- a/src/components/organisms/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   .c0 {
   min-height: 3rem;
   padding: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   display: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -22,7 +22,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -33,7 +33,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -42,7 +42,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -51,7 +51,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -59,7 +59,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -148,7 +148,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 .c18 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -168,7 +168,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 
@@ -341,11 +341,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   .c0 {
   min-height: 3rem;
   padding: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -353,7 +353,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -362,7 +362,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   padding: 0rem;
   background: #287c34;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -371,7 +371,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -430,7 +430,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c9 {
   color: #287c34;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -442,7 +442,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c10 {
   margin-top: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -544,11 +544,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   .c0 {
   min-height: 3rem;
   padding: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -556,7 +556,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -565,7 +565,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -574,7 +574,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   padding: 0rem;
   background: #dd0035;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -633,7 +633,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c9 {
   color: #dd0035;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -645,7 +645,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c10 {
   margin-top: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -747,11 +747,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   .c0 {
   min-height: 3rem;
   padding: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -759,7 +759,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -768,7 +768,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   padding: 0rem;
   background: #287c34;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -777,7 +777,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -836,7 +836,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c9 {
   color: #287c34;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -848,7 +848,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c10 {
   margin-top: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   .c0 {
   min-height: 3rem;
   padding: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   display: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -22,7 +22,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c13 {
@@ -33,7 +33,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c15 {
@@ -42,7 +42,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c16 {
@@ -51,7 +51,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c19 {
@@ -59,7 +59,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c17 {
@@ -148,7 +148,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 .c18 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -168,7 +168,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
 }
 
@@ -341,11 +341,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   .c0 {
   min-height: 3rem;
   padding: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -353,7 +353,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -362,7 +362,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   padding: 0rem;
   background: #287c34;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -371,7 +371,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -430,7 +430,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c9 {
   color: #287c34;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -442,7 +442,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c10 {
   margin-top: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -544,11 +544,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   .c0 {
   min-height: 3rem;
   padding: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -556,7 +556,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -565,7 +565,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -574,7 +574,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   padding: 0rem;
   background: #dd0035;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -633,7 +633,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c9 {
   color: #dd0035;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -645,7 +645,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c10 {
   margin-top: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -747,11 +747,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   .c0 {
   min-height: 3rem;
   padding: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -759,7 +759,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -768,7 +768,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   padding: 0rem;
   background: #287c34;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -777,7 +777,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -836,7 +836,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c9 {
   color: #287c34;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -848,7 +848,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c10 {
   margin-top: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -12,12 +12,12 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #7cd8d0;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
   width: 5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -26,16 +26,16 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   min-width: 3.5rem;
   height: 3.5rem;
   min-height: 3.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -46,7 +46,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -62,7 +62,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -71,7 +71,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {

--- a/src/components/organisms/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -12,12 +12,12 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #7cd8d0;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
   width: 5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
@@ -26,16 +26,16 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   min-width: 3.5rem;
   height: 3.5rem;
   min-height: 3.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -46,7 +46,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -62,7 +62,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14 {
@@ -71,7 +71,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {

--- a/src/components/organisms/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #b0e2de;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -24,7 +24,7 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   padding: 0.25rem;
   background: #b0e2de;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -33,12 +33,12 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #b0e2de;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
@@ -24,7 +24,7 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   padding: 0.25rem;
   background: #b0e2de;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -33,12 +33,12 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #b0e2de;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -20,7 +20,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   padding: 0.25rem;
   background: #b0e2de;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -29,16 +29,16 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #b0e2de;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -20,7 +20,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   padding: 0.25rem;
   background: #b0e2de;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -29,16 +29,16 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #ffe555;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
@@ -24,7 +24,7 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -33,12 +33,12 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #ffe555;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -24,7 +24,7 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -33,12 +33,12 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`OakLessonTopNav matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   padding-left: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -16,7 +16,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   min-width: 2.5rem;
   height: 2.5rem;
   min-height: 2.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -25,7 +25,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   padding: 0.25rem;
   background: #7cd8d0;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -34,12 +34,12 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
   display: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -85,7 +85,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -96,7 +96,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`OakLessonTopNav matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   padding-left: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -16,7 +16,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   min-width: 2.5rem;
   height: 2.5rem;
   min-height: 2.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -25,7 +25,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   padding: 0.25rem;
   background: #7cd8d0;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -34,12 +34,12 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c13 {
   display: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
@@ -85,7 +85,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -96,7 +96,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakLessonVideoTranscript matches snapshot 1`] = `
 [
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -11,7 +11,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -22,7 +22,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   color: #222222;
   background: #222222;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -31,7 +31,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -40,7 +40,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -105,7 +105,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -125,7 +125,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   margin-bottom: 1.5rem;
 }
@@ -254,7 +254,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   </div>,
   .c0 {
   display: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -266,7 +266,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   color: #222222;
   background: #e4e4e4;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -281,7 +281,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   width: 100%;
   max-height: 100%;
   padding-right: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakLessonVideoTranscript matches snapshot 1`] = `
 [
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -11,7 +11,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
@@ -22,7 +22,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   color: #222222;
   background: #222222;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -31,7 +31,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c12 {
@@ -40,7 +40,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c13 {
@@ -105,7 +105,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -125,7 +125,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   margin-bottom: 1.5rem;
 }
@@ -254,7 +254,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   </div>,
   .c0 {
   display: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -266,7 +266,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   color: #222222;
   background: #e4e4e4;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -281,7 +281,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   width: 100%;
   max-height: 100%;
   padding-right: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/organisms/pupil/quiz/InternalDroppableHoldingPen/__snapshots__/InternalDroppableHoldingPen.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/InternalDroppableHoldingPen/__snapshots__/InternalDroppableHoldingPen.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`InternalDroppableHoldingPen matches snapshot 1`] = `
 .c0 {
   margin-bottom: 2rem;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   min-height: 5rem;
   padding: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {

--- a/src/components/organisms/pupil/quiz/InternalDroppableHoldingPen/__snapshots__/InternalDroppableHoldingPen.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/InternalDroppableHoldingPen/__snapshots__/InternalDroppableHoldingPen.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`InternalDroppableHoldingPen matches snapshot 1`] = `
 .c0 {
   margin-bottom: 2rem;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   min-height: 5rem;
   padding: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {

--- a/src/components/organisms/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakHintButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -21,7 +21,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
@@ -30,7 +30,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -39,7 +39,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c12 {
@@ -88,7 +88,7 @@ exports[`OakHintButton matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -108,7 +108,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/organisms/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakHintButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -21,7 +21,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -30,7 +30,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -39,7 +39,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -88,7 +88,7 @@ exports[`OakHintButton matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -108,7 +108,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/organisms/pupil/quiz/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   .c0 {
   position: relative;
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,7 +13,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   background: #ffffff;
   border-color: #222222;
   border-radius: 0.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2:hover {
@@ -24,7 +24,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   position: relative;
   width: 2rem;
   height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c13 {
@@ -34,14 +34,14 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   width: 2rem;
   height: 2rem;
   padding: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c15 {
   width: 100%;
   height: 100%;
   background: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c16 {
@@ -49,7 +49,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   height: 100%;
   border: 0.125rem solid;
   border-color: #ffffff;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -71,7 +71,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/organisms/pupil/quiz/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   .c0 {
   position: relative;
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,7 +13,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   background: #ffffff;
   border-color: #222222;
   border-radius: 0.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2:hover {
@@ -24,7 +24,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   position: relative;
   width: 2rem;
   height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -34,14 +34,14 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   width: 2rem;
   height: 2rem;
   padding: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c15 {
   width: 100%;
   height: 100%;
   background: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -49,7 +49,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   height: 100%;
   border: 0.125rem solid;
   border-color: #ffffff;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -71,7 +71,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/organisms/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakQuizCounter matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -33,7 +33,7 @@ exports[`OakQuizCounter matches snapshot 1`] = `
 
 .c2 {
   color: #808080;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -45,7 +45,7 @@ exports[`OakQuizCounter matches snapshot 1`] = `
 
 .c3 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;

--- a/src/components/organisms/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakQuizCounter matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -33,7 +33,7 @@ exports[`OakQuizCounter matches snapshot 1`] = `
 
 .c2 {
   color: #808080;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -45,7 +45,7 @@ exports[`OakQuizCounter matches snapshot 1`] = `
 
 .c3 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;

--- a/src/components/organisms/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakQuizFeedback matches snapshot 1`] = `
 [
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -12,7 +12,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   padding: 0rem;
   background: #287c34;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -21,7 +21,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -40,7 +40,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c5 {
   color: #287c34;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -52,7 +52,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c6 {
   margin-top: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -114,7 +114,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
     </p>
   </div>,
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -123,7 +123,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -132,7 +132,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   padding: 0rem;
   background: #dd0035;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -151,7 +151,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c5 {
   color: #dd0035;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -163,7 +163,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c6 {
   margin-top: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -225,7 +225,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
     </p>
   </div>,
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -234,7 +234,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   padding: 0rem;
   background: #287c34;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -243,7 +243,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -262,7 +262,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c5 {
   color: #287c34;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -274,7 +274,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c6 {
   margin-top: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakQuizFeedback matches snapshot 1`] = `
 [
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -12,7 +12,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   padding: 0rem;
   background: #287c34;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -21,7 +21,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -40,7 +40,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c5 {
   color: #287c34;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -52,7 +52,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c6 {
   margin-top: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -114,7 +114,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
     </p>
   </div>,
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -123,7 +123,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -132,7 +132,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   padding: 0rem;
   background: #dd0035;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -151,7 +151,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c5 {
   color: #dd0035;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -163,7 +163,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c6 {
   margin-top: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -225,7 +225,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
     </p>
   </div>,
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -234,7 +234,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   padding: 0rem;
   background: #287c34;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -243,7 +243,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -262,7 +262,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c5 {
   color: #287c34;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -274,7 +274,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c6 {
   margin-top: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
 [
   .c0 {
   display: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <div
@@ -18,11 +18,11 @@ exports[`OakQuizHint matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -33,7 +33,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
@@ -42,7 +42,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -51,7 +51,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c12 {
@@ -100,7 +100,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -120,7 +120,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/organisms/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
 [
   .c0 {
   display: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <div
@@ -18,11 +18,11 @@ exports[`OakQuizHint matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -33,7 +33,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -42,7 +42,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -51,7 +51,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -100,7 +100,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -120,7 +120,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/organisms/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`OakQuizMatch matches snapshot 1`] = `
 [
   .c0 {
   margin-bottom: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -17,11 +17,11 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -63,7 +63,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -164,7 +164,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
     </div>
   </div>,
   .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
@@ -173,19 +173,19 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c0 {
   margin-bottom: 2rem;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   min-height: 5rem;
   padding: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -197,11 +197,11 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   color: #ffffff;
   background: #222222;
   border-radius: 0.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -499,14 +499,14 @@ exports[`OakQuizMatch matches snapshot 1`] = `
     </div>
   </div>,
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   padding: 1rem;
   background: #cee7e5;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -514,12 +514,12 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   padding: 0.25rem;
   background: #cee7e5;
   border-radius: 0.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -531,7 +531,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   padding-bottom: 0.25rem;
   background: #e7f6f5;
   border-radius: 0.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/organisms/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`OakQuizMatch matches snapshot 1`] = `
 [
   .c0 {
   margin-bottom: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -17,11 +17,11 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -63,7 +63,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -164,7 +164,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
     </div>
   </div>,
   .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -173,19 +173,19 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c0 {
   margin-bottom: 2rem;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   min-height: 5rem;
   padding: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -197,11 +197,11 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   color: #ffffff;
   background: #222222;
   border-radius: 0.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -499,14 +499,14 @@ exports[`OakQuizMatch matches snapshot 1`] = `
     </div>
   </div>,
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   padding: 1rem;
   background: #cee7e5;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -514,12 +514,12 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   padding: 0.25rem;
   background: #cee7e5;
   border-radius: 0.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -531,7 +531,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   padding-bottom: 0.25rem;
   background: #e7f6f5;
   border-radius: 0.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/organisms/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`OakQuizOrder matches snapshot 1`] = `
 [
   .c0 {
   margin-bottom: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -17,11 +17,11 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -63,7 +63,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -164,7 +164,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
     </div>
   </div>,
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -173,14 +173,14 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   padding: 1rem;
   background: #cee7e5;
   border-radius: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -188,12 +188,12 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   padding: 0.25rem;
   background: #f2f2f2;
   border-radius: 0.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -205,11 +205,11 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   color: #222222;
   background: #ffffff;
   border-radius: 0.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/organisms/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`OakQuizOrder matches snapshot 1`] = `
 [
   .c0 {
   margin-bottom: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -17,11 +17,11 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -63,7 +63,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -164,7 +164,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
     </div>
   </div>,
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c12 {
@@ -173,14 +173,14 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   padding: 1rem;
   background: #cee7e5;
   border-radius: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -188,12 +188,12 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   padding: 0.25rem;
   background: #f2f2f2;
   border-radius: 0.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -205,11 +205,11 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   color: #222222;
   background: #ffffff;
   border-radius: 0.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/organisms/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
   padding: 1.25rem;
   background: #ffffff;
   border-radius: 0.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c0:hover {
@@ -14,7 +14,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -23,7 +23,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -63,7 +63,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/organisms/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
   padding: 1.25rem;
   background: #ffffff;
   border-radius: 0.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c0:hover {
@@ -14,7 +14,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
@@ -23,7 +23,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -63,7 +63,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/organisms/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakQuizResultItem matches snapshot 1`] = `
 [
   .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -12,12 +12,12 @@ exports[`OakQuizResultItem matches snapshot 1`] = `
   width: fit-content;
   padding: 0.5rem;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -60,7 +60,7 @@ exports[`OakQuizResultItem matches snapshot 1`] = `
 
 .c6 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakQuizResultItem matches snapshot 1`] = `
 [
   .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -12,12 +12,12 @@ exports[`OakQuizResultItem matches snapshot 1`] = `
   width: fit-content;
   padding: 0.5rem;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -60,7 +60,7 @@ exports[`OakQuizResultItem matches snapshot 1`] = `
 
 .c6 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/organisms/pupil/quiz/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c0:hover {
@@ -22,7 +22,7 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/organisms/pupil/quiz/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c0:hover {
@@ -22,7 +22,7 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/organisms/shared/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
+++ b/src/components/organisms/shared/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   background: #f2f2f2;
   border-top: 0.063rem solid;
   border-color: #808080;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
   margin-left: auto;
   margin-right: auto;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -20,11 +20,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   padding-bottom: 1.5rem;
   margin-left: 1rem;
   margin-right: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -35,11 +35,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -55,7 +55,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -64,7 +64,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -135,7 +135,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -146,11 +146,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c18 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -171,7 +171,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -198,7 +198,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/organisms/shared/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
+++ b/src/components/organisms/shared/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   background: #f2f2f2;
   border-top: 0.063rem solid;
   border-color: #808080;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
   margin-left: auto;
   margin-right: auto;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -20,11 +20,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   padding-bottom: 1.5rem;
   margin-left: 1rem;
   margin-right: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -35,11 +35,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -55,7 +55,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14 {
@@ -64,7 +64,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -135,7 +135,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -146,11 +146,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c18 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -171,7 +171,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -198,7 +198,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/organisms/shared/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
+++ b/src/components/organisms/shared/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   background: #f2f2f2;
   border-top: 0.063rem solid;
   border-color: #808080;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
   margin-left: auto;
   margin-right: auto;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -20,11 +20,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   padding-bottom: 1.5rem;
   margin-left: 1rem;
   margin-right: 1rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -35,11 +35,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -55,7 +55,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14 {
@@ -64,7 +64,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -135,7 +135,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -146,11 +146,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c18 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -171,7 +171,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -198,7 +198,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/organisms/shared/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
+++ b/src/components/organisms/shared/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   background: #f2f2f2;
   border-top: 0.063rem solid;
   border-color: #808080;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
   margin-left: auto;
   margin-right: auto;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -20,11 +20,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   padding-bottom: 1.5rem;
   margin-left: 1rem;
   margin-right: 1rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -35,11 +35,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -55,7 +55,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -64,7 +64,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -135,7 +135,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -146,11 +146,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c18 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -171,7 +171,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -198,7 +198,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/organisms/shared/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
+++ b/src/components/organisms/shared/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   overflow-x: hidden;
   width: 100%;
   background: #a0b6f2;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -15,56 +15,56 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   padding-right: 0rem;
   margin-left: auto;
   margin-right: auto;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
   min-width: 100%;
   min-height: 22.5rem;
   background: #a0b6f2;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   z-index: 0;
 }
 
 .c5 {
   height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   display: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
   max-width: 40rem;
   min-height: 0rem;
   margin-bottom: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
   margin-bottom: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c15 {
   position: relative;
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c18 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c22 {
   position: relative;
   min-height: 11.25rem;
   margin-bottom: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c24 {
@@ -75,7 +75,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   -webkit-transform: rotate(-2.025deg);
   -ms-transform: rotate(-2.025deg);
   transform: rotate(-2.025deg);
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   z-index: 1;
 }
 
@@ -84,7 +84,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   top: 0rem;
   bottom: 0rem;
   width: 22.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c27 {
@@ -93,14 +93,14 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c28 {
   padding-top: 1.5rem;
   margin-left: 1.5rem;
   display: block;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -210,7 +210,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -223,11 +223,11 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c19 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -238,7 +238,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c20 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -249,7 +249,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c21 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/organisms/shared/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
+++ b/src/components/organisms/shared/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   overflow-x: hidden;
   width: 100%;
   background: #a0b6f2;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -15,56 +15,56 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   padding-right: 0rem;
   margin-left: auto;
   margin-right: auto;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
   min-width: 100%;
   min-height: 22.5rem;
   background: #a0b6f2;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   z-index: 0;
 }
 
 .c5 {
   height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   display: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
   max-width: 40rem;
   min-height: 0rem;
   margin-bottom: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c13 {
   margin-bottom: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c15 {
   position: relative;
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c18 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c22 {
   position: relative;
   min-height: 11.25rem;
   margin-bottom: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c24 {
@@ -75,7 +75,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   -webkit-transform: rotate(-2.025deg);
   -ms-transform: rotate(-2.025deg);
   transform: rotate(-2.025deg);
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   z-index: 1;
 }
 
@@ -84,7 +84,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   top: 0rem;
   bottom: 0rem;
   width: 22.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c27 {
@@ -93,14 +93,14 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   min-width: 100%;
   height: 100%;
   min-height: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c28 {
   padding-top: 1.5rem;
   margin-left: 1.5rem;
   display: block;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c17 {
@@ -210,7 +210,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -223,11 +223,11 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c19 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -238,7 +238,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c20 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -249,7 +249,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c21 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakPagination Component matches snapshot 1`] = `
 .c0 {
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -12,7 +12,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -36,15 +36,15 @@ exports[`OakPagination Component matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
   margin-left: 0.25rem;
   margin-right: 0.25rem;
   display: revert;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   display: revert;
   display: revert;
 }
@@ -57,7 +57,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -134,7 +134,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   justify-content: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -175,7 +175,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   justify-content: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakPagination Component matches snapshot 1`] = `
 .c0 {
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
@@ -12,7 +12,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
@@ -36,15 +36,15 @@ exports[`OakPagination Component matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
   margin-left: 0.25rem;
   margin-right: 0.25rem;
   display: revert;
-  font-family: Lexend,sans-serif;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   display: revert;
   display: revert;
 }
@@ -57,7 +57,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -134,7 +134,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   justify-content: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -175,7 +175,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   justify-content: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/shared/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
+++ b/src/components/organisms/shared/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   margin-right: 0rem;
   margin-top: 0rem;
   margin-bottom: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c3 {
@@ -16,7 +16,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
@@ -25,11 +25,11 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -63,7 +63,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -76,8 +76,8 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
 
 .c2 {
   display: revert;
-  font-family: Lexend,sans-serif;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   list-style: none;
   display: revert;
   display: revert;
@@ -93,7 +93,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -120,7 +120,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/organisms/shared/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
+++ b/src/components/organisms/shared/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   margin-right: 0rem;
   margin-top: 0rem;
   margin-bottom: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -16,7 +16,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -25,11 +25,11 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -63,7 +63,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -76,8 +76,8 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
 
 .c2 {
   display: revert;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   list-style: none;
   display: revert;
   display: revert;
@@ -93,7 +93,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -120,7 +120,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/organisms/shared/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
+++ b/src/components/organisms/shared/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -42,7 +42,7 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -63,7 +63,7 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/organisms/shared/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
+++ b/src/components/organisms/shared/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,11 +15,11 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
@@ -42,7 +42,7 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -63,7 +63,7 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/organisms/shared/Oakinfo/__snapshots__/OakInfo.test.tsx.snap
+++ b/src/components/organisms/shared/Oakinfo/__snapshots__/OakInfo.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakInfo matches snapshot 1`] = `
 [
   .c0 {
   display: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 <div
@@ -18,11 +18,11 @@ exports[`OakInfo matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -33,7 +33,7 @@ exports[`OakInfo matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
@@ -42,7 +42,7 @@ exports[`OakInfo matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -51,7 +51,7 @@ exports[`OakInfo matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c12 {
@@ -102,7 +102,7 @@ exports[`OakInfo matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -122,7 +122,7 @@ exports[`OakInfo matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/organisms/shared/Oakinfo/__snapshots__/OakInfo.test.tsx.snap
+++ b/src/components/organisms/shared/Oakinfo/__snapshots__/OakInfo.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakInfo matches snapshot 1`] = `
 [
   .c0 {
   display: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <div
@@ -18,11 +18,11 @@ exports[`OakInfo matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -33,7 +33,7 @@ exports[`OakInfo matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -42,7 +42,7 @@ exports[`OakInfo matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -51,7 +51,7 @@ exports[`OakInfo matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -102,7 +102,7 @@ exports[`OakInfo matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -122,7 +122,7 @@ exports[`OakInfo matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/organisms/shared/OakinfoButton/__snapshots__/OakInfoButton.test.tsx.snap
+++ b/src/components/organisms/shared/OakinfoButton/__snapshots__/OakInfoButton.test.tsx.snap
@@ -7,11 +7,11 @@ exports[`OakInfoButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -22,7 +22,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -31,7 +31,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -40,7 +40,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -91,7 +91,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -111,7 +111,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/organisms/shared/OakinfoButton/__snapshots__/OakInfoButton.test.tsx.snap
+++ b/src/components/organisms/shared/OakinfoButton/__snapshots__/OakInfoButton.test.tsx.snap
@@ -7,11 +7,11 @@ exports[`OakInfoButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -22,7 +22,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
@@ -31,7 +31,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -40,7 +40,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c12 {
@@ -91,7 +91,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -111,7 +111,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/organisms/teacher/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
+++ b/src/components/organisms/teacher/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
   .c0 {
   position: relative;
   min-height: 2.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -17,7 +17,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
   border: 0.063rem solid;
   border-color: #cacaca;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2:hover {
@@ -30,7 +30,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
@@ -53,7 +53,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/teacher/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
+++ b/src/components/organisms/teacher/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
   .c0 {
   position: relative;
   min-height: 2.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -17,7 +17,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
   border: 0.063rem solid;
   border-color: #cacaca;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2:hover {
@@ -30,7 +30,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -53,7 +53,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
 [
   .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
   display: revert;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -16,7 +16,7 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;
   letter-spacing: 0.0115rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
 [
   .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
   display: revert;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -16,7 +16,7 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;
   letter-spacing: 0.0115rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -5,36 +5,36 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   .c1 {
   background: #ffffff;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   min-width: 4rem;
   background: #a0b6f2;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
   width: 100%;
   height: 100%;
   padding: 1.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
   max-width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c13 {
   width: 100%;
   min-width: 5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   white-space: nowrap;
 }
 
 .c16 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c20 {
@@ -43,7 +43,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c21 {
@@ -127,7 +127,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -140,7 +140,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 
 .c19 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -153,15 +153,15 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 .c0 {
   width: 100%;
   display: revert;
-  font-family: Lexend,sans-serif;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   list-style: none;
   display: revert;
   display: revert;
 }
 
 .c12 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -173,7 +173,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 .c18 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -5,36 +5,36 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   .c1 {
   background: #ffffff;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   min-width: 4rem;
   background: #a0b6f2;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
   width: 100%;
   height: 100%;
   padding: 1.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
   max-width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
   width: 100%;
   min-width: 5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   white-space: nowrap;
 }
 
 .c16 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c20 {
@@ -43,7 +43,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c21 {
@@ -127,7 +127,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -140,7 +140,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 
 .c19 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -153,15 +153,15 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 .c0 {
   width: 100%;
   display: revert;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   list-style: none;
   display: revert;
   display: revert;
 }
 
 .c12 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -173,7 +173,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 .c18 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 [
   .c0 {
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,7 +13,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -23,18 +23,18 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   background: #a0b6f2;
   border-top-left-radius: 0.25rem;
   border-bottom-left-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
   margin: 0.75rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
   max-width: 30rem;
   margin-right: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -45,29 +45,29 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   border-top-left-radius: 0.25rem;
   border-bottom-left-radius: 0.25rem;
   display: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {
   width: 100%;
   padding: 1rem;
   background: #ffffff;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c15 {
   margin-bottom: 1rem;
   display: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c17 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c19 {
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c23 {
@@ -80,7 +80,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   border: 0.063rem solid;
   border-color: #deb7d5;
   border-radius: 0.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c25 {
@@ -90,13 +90,13 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c27 {
   margin-bottom: 1rem;
   display: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -228,7 +228,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -241,7 +241,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 
 .c6 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -253,7 +253,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 
 .c22 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -264,7 +264,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 .c24 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 [
   .c0 {
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,7 +13,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
@@ -23,18 +23,18 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   background: #a0b6f2;
   border-top-left-radius: 0.25rem;
   border-bottom-left-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c7 {
   margin: 0.75rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
   max-width: 30rem;
   margin-right: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c12 {
@@ -45,29 +45,29 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   border-top-left-radius: 0.25rem;
   border-bottom-left-radius: 0.25rem;
   display: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14 {
   width: 100%;
   padding: 1rem;
   background: #ffffff;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c15 {
   margin-bottom: 1rem;
   display: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c17 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c19 {
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c23 {
@@ -80,7 +80,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   border: 0.063rem solid;
   border-color: #deb7d5;
   border-radius: 0.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c25 {
@@ -90,13 +90,13 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c27 {
   margin-bottom: 1rem;
   display: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c1 {
@@ -228,7 +228,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -241,7 +241,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 
 .c6 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -253,7 +253,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 
 .c22 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -264,7 +264,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 .c24 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #a0b6f2;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -29,7 +29,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -83,7 +83,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -97,7 +97,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
 
 .c8 {
   color: #222222;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #a0b6f2;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
@@ -29,7 +29,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   min-width: 2rem;
   height: 2rem;
   min-height: 2rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c10 {
@@ -83,7 +83,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -97,7 +97,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
 
 .c8 {
   color: #222222;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
@@ -5,27 +5,27 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   padding: 1rem;
   background: #e3e9fb;
   border-radius: 0.375rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c8 {
   position: relative;
   width: 2.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c12 {
   position: absolute;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -40,7 +40,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c23 {
@@ -51,7 +51,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   color: #222222;
   background: #222222;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c24 {
@@ -60,7 +60,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c25 {
@@ -69,7 +69,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c26 {
@@ -173,7 +173,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -185,7 +185,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 
 .c13 {
   color: #ffe555;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -196,7 +196,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 }
 
 .c22 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -207,7 +207,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 }
 
 .c15 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -222,7 +222,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   padding: 0;
   margin: 0;
   width: 100%;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -239,7 +239,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   padding-top: 0.5rem;
 }

--- a/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
@@ -5,27 +5,27 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   padding: 1rem;
   background: #e3e9fb;
   border-radius: 0.375rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c8 {
   position: relative;
   width: 2.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c12 {
   position: absolute;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c14 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -40,7 +40,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c23 {
@@ -51,7 +51,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   color: #222222;
   background: #222222;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c24 {
@@ -60,7 +60,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c25 {
@@ -69,7 +69,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c26 {
@@ -173,7 +173,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -185,7 +185,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 
 .c13 {
   color: #ffe555;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -196,7 +196,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 }
 
 .c22 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -207,7 +207,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 }
 
 .c15 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -222,7 +222,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   padding: 0;
   margin: 0;
   width: 100%;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
@@ -239,7 +239,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   padding-top: 0.5rem;
 }

--- a/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
@@ -2,23 +2,23 @@
 
 exports[`OakUnitsHeader matches snapshot 1`] = `
 .c0 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
   width: 2.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c9 {
   position: absolute;
   inset: 0rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c11 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -33,7 +33,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c20 {
@@ -44,7 +44,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   color: #222222;
   background: #222222;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c21 {
@@ -53,7 +53,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c22 {
@@ -62,7 +62,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
 }
 
 .c23 {
@@ -151,7 +151,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -163,7 +163,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 
 .c10 {
   color: #ffe555;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -174,7 +174,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 }
 
 .c19 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -185,7 +185,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -209,7 +209,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: Lexend,sans-serif;
+  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
   color: #222222;
   padding-top: 0.5rem;
 }

--- a/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
@@ -2,23 +2,23 @@
 
 exports[`OakUnitsHeader matches snapshot 1`] = `
 .c0 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
   width: 2.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c9 {
   position: absolute;
   inset: 0rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c11 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -33,7 +33,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c20 {
@@ -44,7 +44,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   color: #222222;
   background: #222222;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c21 {
@@ -53,7 +53,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c22 {
@@ -62,7 +62,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   min-width: 1.5rem;
   height: 1.5rem;
   min-height: 1.5rem;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c23 {
@@ -151,7 +151,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -163,7 +163,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 
 .c10 {
   color: #ffe555;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -174,7 +174,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 }
 
 .c19 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -185,7 +185,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -209,7 +209,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif;
+  font-family: --var(google-font),Lexend,sans-serif;
   color: #222222;
   padding-top: 0.5rem;
 }

--- a/src/styles/global/oak.styles.ts
+++ b/src/styles/global/oak.styles.ts
@@ -13,7 +13,7 @@ export const oakGlobalCss = css`
   body {
     padding: 0;
     margin: 0;
-    font-family: Lexend, sans-serif;
+    font-family: __Lexend_866216, __Lexend_Fallback_866216, Lexend, sans-serif;
     font-weight: 300;
     line-height: 1.4;
   }

--- a/src/styles/utils/typographyStyle.test.tsx
+++ b/src/styles/utils/typographyStyle.test.tsx
@@ -15,7 +15,7 @@ describe("typographyStyle", () => {
     );
     expect(getByTestId("test")).toHaveStyle("font-weight: 600");
     expect(getByTestId("test")).toHaveStyle(
-      "font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif",
+      "font-family: --var(google-font),Lexend,sans-serif",
     );
     expect(getByTestId("test")).toHaveStyle("line-height: 4rem");
     expect(getByTestId("test")).toHaveStyle("letter-spacing:0.0115rem");

--- a/src/styles/utils/typographyStyle.test.tsx
+++ b/src/styles/utils/typographyStyle.test.tsx
@@ -14,7 +14,9 @@ describe("typographyStyle", () => {
       <StyledComponent data-testid="test" $font={"heading-1"} />,
     );
     expect(getByTestId("test")).toHaveStyle("font-weight: 600");
-    expect(getByTestId("test")).toHaveStyle("font-family: Lexend,sans-serif");
+    expect(getByTestId("test")).toHaveStyle(
+      "font-family: __Lexend_866216,__Lexend_Fallback_866216,Lexend,sans-serif",
+    );
     expect(getByTestId("test")).toHaveStyle("line-height: 4rem");
     expect(getByTestId("test")).toHaveStyle("letter-spacing:0.0115rem");
     expect(getByTestId("test")).toHaveStyle("font-size: 3.5rem");

--- a/src/styles/utils/typographyStyle.ts
+++ b/src/styles/utils/typographyStyle.ts
@@ -58,7 +58,7 @@ export type TypographyStyleProps = {
 };
 
 export const typographyStyle = css<TypographyStyleProps>`
-  font-family: __Lexend_866216, __Lexend_Fallback_866216, Lexend, sans-serif; //  FIXME: this should be a css variable ?
+  font-family: --var(google-font), Lexend, sans-serif; //  FIXME: this should be a css variable ?
   ${responsiveStyle("font-weight", (props) => props.$font, parseFontWeight)}
   ${responsiveStyle("font-size", (props) => props.$font, parseFontSize)}
   ${responsiveStyle("line-height", (props) => props.$font, parseLineHeight)}

--- a/src/styles/utils/typographyStyle.ts
+++ b/src/styles/utils/typographyStyle.ts
@@ -58,7 +58,7 @@ export type TypographyStyleProps = {
 };
 
 export const typographyStyle = css<TypographyStyleProps>`
-  font-family: Lexend, sans-serif;
+  font-family: __Lexend_866216, __Lexend_Fallback_866216, Lexend, sans-serif; //  FIXME: this should be a css variable ?
   ${responsiveStyle("font-weight", (props) => props.$font, parseFontWeight)}
   ${responsiveStyle("font-size", (props) => props.$font, parseFontSize)}
   ${responsiveStyle("line-height", (props) => props.$font, parseLineHeight)}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Change font-family to allow the use of optimized next js google fonts


## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
