### PR TITLE
feat: add required prop to radio button

### DIFF
--- a/src/components/molecules/OakRadioButton/OakRadioButton.stories.tsx
+++ b/src/components/molecules/OakRadioButton/OakRadioButton.stories.tsx
@@ -146,3 +146,25 @@ export const Disabled: Story = {
   },
   args: {},
 };
+
+export const Required: Story = {
+  render: (args) => {
+    return (
+      <OakRadioGroup name="test">
+        <OakRadioButton
+          {...args}
+          id="option-1"
+          label={"Required option 1"}
+          value={"1"}
+          required
+        />
+        <OakRadioButton
+          {...args}
+          id="option-2"
+          label={"Option 2"}
+          value={"2"}
+        />
+      </OakRadioGroup>
+    );
+  },
+};

--- a/src/components/molecules/OakRadioButton/OakRadioButton.tsx
+++ b/src/components/molecules/OakRadioButton/OakRadioButton.tsx
@@ -106,6 +106,7 @@ export type OakRadioButtonProps = {
   tabIndex?: number;
   "data-testid"?: string;
   disabled?: boolean;
+  required?: boolean;
   /**
    * Allows the focus ring to be disabled. This is useful when focus is indicated
    * by other means, such as a border or background color change.
@@ -149,6 +150,7 @@ export const OakRadioButton = forwardRef<HTMLInputElement, OakRadioButtonProps>(
       value,
       tabIndex,
       disabled,
+      required,
       $labelGap = "space-between-ssx",
       $labelAlignItems = "center",
       $font = "body-1",
@@ -186,6 +188,7 @@ export const OakRadioButton = forwardRef<HTMLInputElement, OakRadioButtonProps>(
             tabIndex={tabIndex}
             disabled={anyDisabled}
             ref={ref}
+            required={required}
           />
           {!anyDisabled ? (
             <VisibleRadioButtonInput


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- adds the `required` prop to `OakRadioButton` 
- needed for[ this PR ](https://github.com/oaknational/Oak-Web-Application/pull/2691#pullrequestreview-2238108142)in OWA

## A link to the component in the deployment preview
https://deploy-preview-272--lively-meringue-8ebd43.netlify.app/?path=/story/components-molecules-oakradiobutton--required

## ACs
- radio button should accept a required prop and html should reflect that
