### PR TITLE
Feat/curr get cloudinary url

### DIFF
--- a/src/components/atoms/OakIcon/OakIcon.test.tsx
+++ b/src/components/atoms/OakIcon/OakIcon.test.tsx
@@ -75,6 +75,17 @@ describe("generateOakIconURL", () => {
     expect(generateOakIconURL("home")).toBe(
       "https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699887218/icons/gvqxjxcw07ei2kkmwnes.svg",
     );
-    expect(generateOakIconURL("banana-sandwich")).toBe(undefined);
+  });
+
+  it("is returns url for question mark when the string is not a valid icon name", () => {
+    expect(generateOakIconURL("banana-sandwich")).toBe(
+      "https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1706872277/icons/question-mark.svg",
+    );
+  });
+
+  it("is returns url for books when the string is not a valid subject icon name", () => {
+    expect(generateOakIconURL("subject-potions")).toBe(
+      "https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953657/icons/hz4l3iq6i68kazvkvorq.svg",
+    );
   });
 });

--- a/src/components/atoms/OakIcon/OakIcon.test.tsx
+++ b/src/components/atoms/OakIcon/OakIcon.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import { create } from "react-test-renderer";
 
-import { OakIcon, isValidIconName } from "./OakIcon";
+import { OakIcon, generateOakIconURL, isValidIconName } from "./OakIcon";
 
 describe("OakIcon", () => {
   it("renders", () => {
@@ -67,5 +67,14 @@ describe("isValidIconName", () => {
   it("is true when the string is a valid icon name", () => {
     expect(isValidIconName("home")).toBe(true);
     expect(isValidIconName("banana-sandwich")).toBe(false);
+  });
+});
+
+describe("generateOakIconURL", () => {
+  it("is valid url when the string is a valid icon name", () => {
+    expect(generateOakIconURL("home")).toBe(
+      "https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699887218/icons/gvqxjxcw07ei2kkmwnes.svg",
+    );
+    expect(generateOakIconURL("banana-sandwich")).toBe(undefined);
   });
 });

--- a/src/components/atoms/OakIcon/OakIcon.tsx
+++ b/src/components/atoms/OakIcon/OakIcon.tsx
@@ -26,6 +26,15 @@ export function isValidIconName(iconName: string): iconName is OakIconName {
 }
 
 /**
+ * returns a Icon URL from Cloudinary if is a valid icon, otherwise returns undefined
+ */
+export function generateOakIconURL(iconName: string) {
+  if (isValidIconName(iconName)) {
+    return `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/${icons[iconName]}`;
+  }
+}
+
+/**
  * A wrapper around OakImage which uses the image-map.json file to map icon names to image paths.
  */
 export const OakIcon = (props: OakIconProps) => {

--- a/src/components/atoms/OakIcon/OakIcon.tsx
+++ b/src/components/atoms/OakIcon/OakIcon.tsx
@@ -29,8 +29,13 @@ export function isValidIconName(iconName: string): iconName is OakIconName {
  * returns a Icon URL from Cloudinary if is a valid icon, otherwise returns undefined
  */
 export function generateOakIconURL(iconName: string) {
+  const urlPath = `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}`;
   if (isValidIconName(iconName)) {
-    return `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/${icons[iconName]}`;
+    return `${urlPath}/${icons[iconName]}`;
+  } else if (iconName.includes("subject")) {
+    return `${urlPath}/${icons["books"]}`;
+  } else {
+    return `${urlPath}/${icons["question-mark"]}`;
   }
 }
 
@@ -51,7 +56,7 @@ export const OakIcon = (props: OakIconProps) => {
 
   return (
     <OakImage
-      src={`https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/${icons[iconName]}`}
+      src={generateOakIconURL(iconName)}
       alt={alt ?? iconName}
       $width={$width}
       $height={$height}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Adding a function to export the URL for subject icons for use in the curriculum docx download. Ticket here: https://www.notion.so/oaknationalacademy/docx-pull-through-subject-icons-from-Cloudinary-12026cc4e1b180d8b741c38d327dd744?pvs=4
