### PR TITLE
feat: add a configurable delay to OakLoadingSpinner

### DIFF
--- a/src/components/molecules/OakLoadingSpinner/OakLoadingSpinner.stories.tsx
+++ b/src/components/molecules/OakLoadingSpinner/OakLoadingSpinner.stories.tsx
@@ -13,10 +13,11 @@ const meta: Meta<typeof OakLoadingSpinner> = {
   argTypes: {
     ...sizeArgTypes,
     ...colorArgTypes,
+    $delay: { control: { type: "range", min: 0, max: 5000 } },
   },
   parameters: {
     controls: {
-      include: ["$width", "$color", "$background"],
+      include: ["$width", "$color", "$background", "$delay"],
     },
   },
 };

--- a/src/components/molecules/OakLoadingSpinner/OakLoadingSpinner.test.tsx
+++ b/src/components/molecules/OakLoadingSpinner/OakLoadingSpinner.test.tsx
@@ -25,4 +25,12 @@ describe("OakLoadingSpinner", () => {
     const { getByDisplayValue } = render(<OakLoadingSpinner />);
     expect(() => getByDisplayValue("accessible text")).toThrow();
   });
+
+  it("can have a delayed appearance", () => {
+    const { getByTestId } = render(
+      <OakLoadingSpinner data-testid="loader" $delay={300} />,
+    );
+
+    expect(getByTestId("loader")).toHaveStyleRule("animation-delay", "0.3s");
+  });
 });

--- a/src/components/molecules/OakLoadingSpinner/OakLoadingSpinner.tsx
+++ b/src/components/molecules/OakLoadingSpinner/OakLoadingSpinner.tsx
@@ -18,8 +18,25 @@ const SpinnerKeyframe = keyframes`
   }
 `;
 
+const DelayedShow = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
 export type OakLoadingSpinnerProps = Pick<SizeStyleProps, "$width"> &
-  ColorStyleProps & { loaderColor?: OakCombinedColorToken };
+  ColorStyleProps & {
+    loaderColor?: OakCombinedColorToken;
+    /**
+     * Delay the appearance of the spinner
+     *
+     * Accepts a number in milliseconds
+     */
+    $delay?: number;
+  };
 
 const StyledLoadingSpinner = styled.span<OakLoadingSpinnerProps>`
   ${(props) =>
@@ -28,6 +45,16 @@ const StyledLoadingSpinner = styled.span<OakLoadingSpinnerProps>`
       : css`
           --width: 1.25rem;
         `}
+  ${({ $delay }) => {
+    if ($delay) {
+      return css`
+        opacity: 0;
+        animation: ${DelayedShow} 0s;
+        animation-delay: ${$delay / 1000}s;
+        animation-fill-mode: forwards;
+      `;
+    }
+  }}
   --inner-width: calc(var(--width) / 10 * 8);
   --thickness: calc(var(--width) / 12);
 


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Adds `$delay` to `OakLoadingSpinner` can be used to defer rendering of the spinner for pending UI that might render with no perceptible delay. Extracted from https://github.com/oaknational/Oak-Web-Application/pull/2902 for reuse

## Link to the design doc

## A link to the component in the deployment preview

https://deploy-preview-313--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oakloadingspinner--docs

## Testing instructions

## ACs
