### PR TITLE
fix: adjust max-width for OakDownloadsJourneyChildSubjectTierSelector component

### DIFF
--- a/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/OakDownloadsJourneyChildSubjectTierSelector.tsx
+++ b/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/OakDownloadsJourneyChildSubjectTierSelector.tsx
@@ -67,6 +67,7 @@ const UnstyledComponent = (
         message={`Before downloading, choose ${
           childSubjectsAvailable && tiersAvailable ? "options" : "an option"
         } for KS4. The document will still display both KS3 and KS4.`}
+        $maxWidth={"all-spacing-22"}
       />
 
       {childSubjectsAvailable && (

--- a/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c2 {
+  max-width: 40rem;
   padding: 0.75rem;
   background: #e3e9fb;
   border: 0.063rem solid;


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
