### PR TITLE
Fix/pupil 882/color contrast

### DIFF
--- a/src/components/organisms/pupil/quiz/OakQuizCounter/OakQuizCounter.tsx
+++ b/src/components/organisms/pupil/quiz/OakQuizCounter/OakQuizCounter.tsx
@@ -37,7 +37,7 @@ export const OakQuizCounter = (props: OakQuizCounterProps) => {
       $gap={"space-between-xs"}
       $alignItems={"end"}
     >
-      <OakSpan $font={"heading-light-4"} $color={"text-disabled"}>
+      <OakSpan $font={"heading-light-4"} $color={"text-subdued"}>
         <OakSpan $font={"heading-4"} $color={"text-primary"}>
           {counter}{" "}
         </OakSpan>

--- a/src/components/organisms/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`OakQuizCounter matches snapshot 1`] = `
 }
 
 .c2 {
-  color: #808080;
+  color: #575757;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 2rem;


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
quick color fix, one line

## Link to the design doc

## A link to the component in the deployment preview


## Testing instructions
check text color is text-subdued

## ACs
