### PR TITLE
Feat/pupil 837/make transcript accessible

### DIFF
--- a/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/OakLessonVideoTranscript.tsx
+++ b/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/OakLessonVideoTranscript.tsx
@@ -71,6 +71,7 @@ export const OakLessonVideoTranscript = ({
           isOpen={showTranscript}
           $font="body-1"
           $color="text-primary"
+          aria-live="polite"
         >
           {children}
         </OakCollapsibleContent>

--- a/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
@@ -316,6 +316,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
     id="transcript-element"
   >
     <div
+      aria-live="polite"
       className="c1 c2"
     >
       <div


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
simply add aria= polite to transcripts d=so they are read out when toggle is opened

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions
go to [transcript component](https://deploy-preview-321--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-pupil-lesson-oaklessonvideotranscript--docs)
tab to toggle open button with chrome screen reader and the transcript will be read automatically
already focusable

## ACs
