### PR TITLE
Feat/pupil 855/scale image button

### DIFF
--- a/src/components/molecules/OakScaleImageButton/OakScaleImageButton.stories.tsx
+++ b/src/components/molecules/OakScaleImageButton/OakScaleImageButton.stories.tsx
@@ -41,8 +41,7 @@ export const Default: Story = {
 
 export const withImageScaleCallback: Story = {
   render: (args) => {
-    const [scaled, setScale] = useState(false);
-
+    const [scaled, setScale] = useState<boolean>(false);
     return (
       <OakFlex
         $width={"all-spacing-7"}
@@ -65,5 +64,11 @@ export const withImageScaleCallback: Story = {
         />
       </OakFlex>
     );
+  },
+  args: {},
+  parameters: {
+    controls: {
+      include: [],
+    },
   },
 };

--- a/src/components/molecules/OakScaleImageButton/OakScaleImageButton.stories.tsx
+++ b/src/components/molecules/OakScaleImageButton/OakScaleImageButton.stories.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakScaleImageButton } from "./OakScaleImageButton";
+
+import { OakFlex } from "@/components/atoms";
+
+const meta: Meta<typeof OakScaleImageButton> = {
+  component: OakScaleImageButton,
+  tags: ["autodocs"],
+  title: "components/molecules/OakScaleImageButton",
+  argTypes: {
+    onImageScaleCallback: {
+      options: ["expand", "minimise"],
+    },
+    isExpanded: {
+      control: "boolean",
+    },
+  },
+  parameters: {
+    controls: {
+      include: ["onImageScaleCallback", "isExpanded"],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof OakScaleImageButton>;
+
+export const Default: Story = {
+  render: (args) => (
+    <OakFlex
+      $width={"all-spacing-7"}
+      $height={"all-spacing-7"}
+      $pointerEvents={"auto"}
+    >
+      <OakScaleImageButton {...args} />
+    </OakFlex>
+  ),
+};

--- a/src/components/molecules/OakScaleImageButton/OakScaleImageButton.stories.tsx
+++ b/src/components/molecules/OakScaleImageButton/OakScaleImageButton.stories.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from "react";
+import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import { OakScaleImageButton } from "./OakScaleImageButton";
 
-import { OakCloudinaryImage, OakFlex } from "@/components/atoms";
+import { OakFlex } from "@/components/atoms";
 
 const meta: Meta<typeof OakScaleImageButton> = {
   component: OakScaleImageButton,
@@ -37,38 +37,4 @@ export const Default: Story = {
       <OakScaleImageButton {...args} />
     </OakFlex>
   ),
-};
-
-export const withImageScaleCallback: Story = {
-  render: (args) => {
-    const [scaled, setScale] = useState<boolean>(false);
-    return (
-      <OakFlex
-        $width={"all-spacing-7"}
-        $height={"all-spacing-7"}
-        $pointerEvents={"auto"}
-      >
-        <OakCloudinaryImage
-          alt={""}
-          cloudinaryId="v1705942058/test-images/Cat_August_2010-4_lklxsr.jpg"
-          width={scaled ? 7280 : 3640}
-          height={scaled ? 4452 : 2226}
-          $minWidth={scaled ? "all-spacing-22" : "all-spacing-11"}
-        />
-        <OakScaleImageButton
-          {...args}
-          onImageScaleCallback={() => {
-            setScale(!scaled);
-          }}
-          isExpanded={scaled}
-        />
-      </OakFlex>
-    );
-  },
-  args: {},
-  parameters: {
-    controls: {
-      include: [],
-    },
-  },
 };

--- a/src/components/molecules/OakScaleImageButton/OakScaleImageButton.stories.tsx
+++ b/src/components/molecules/OakScaleImageButton/OakScaleImageButton.stories.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import { OakScaleImageButton } from "./OakScaleImageButton";
 
-import { OakFlex } from "@/components/atoms";
+import { OakCloudinaryImage, OakFlex } from "@/components/atoms";
 
 const meta: Meta<typeof OakScaleImageButton> = {
   component: OakScaleImageButton,
@@ -37,4 +37,33 @@ export const Default: Story = {
       <OakScaleImageButton {...args} />
     </OakFlex>
   ),
+};
+
+export const withImageScaleCallback: Story = {
+  render: (args) => {
+    const [scaled, setScale] = useState(false);
+
+    return (
+      <OakFlex
+        $width={"all-spacing-7"}
+        $height={"all-spacing-7"}
+        $pointerEvents={"auto"}
+      >
+        <OakCloudinaryImage
+          alt={""}
+          cloudinaryId="v1705942058/test-images/Cat_August_2010-4_lklxsr.jpg"
+          width={scaled ? 7280 : 3640}
+          height={scaled ? 4452 : 2226}
+          $minWidth={scaled ? "all-spacing-22" : "all-spacing-11"}
+        />
+        <OakScaleImageButton
+          {...args}
+          onImageScaleCallback={() => {
+            setScale(!scaled);
+          }}
+          isExpanded={scaled}
+        />
+      </OakFlex>
+    );
+  },
 };

--- a/src/components/molecules/OakScaleImageButton/OakScaleImageButton.stories.tsx
+++ b/src/components/molecules/OakScaleImageButton/OakScaleImageButton.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import { OakScaleImageButton } from "./OakScaleImageButton";
 
-import { OakFlex } from "@/components/atoms";
+import { OakCloudinaryImage, OakFlex } from "@/components/atoms";
 
 const meta: Meta<typeof OakScaleImageButton> = {
   component: OakScaleImageButton,
@@ -37,4 +37,25 @@ export const Default: Story = {
       <OakScaleImageButton {...args} />
     </OakFlex>
   ),
+};
+
+export const withImage: Story = {
+  render: (args) => {
+    return (
+      <OakFlex
+        $width={"all-spacing-7"}
+        $height={"all-spacing-7"}
+        $pointerEvents={"auto"}
+      >
+        <OakCloudinaryImage
+          alt={""}
+          cloudinaryId="v1705942058/test-images/Cat_August_2010-4_lklxsr.jpg"
+          width={3640}
+          height={2226}
+          $minWidth={"all-spacing-21"}
+        />
+        <OakScaleImageButton {...args} />
+      </OakFlex>
+    );
+  },
 };

--- a/src/components/molecules/OakScaleImageButton/OakScaleImageButton.test.tsx
+++ b/src/components/molecules/OakScaleImageButton/OakScaleImageButton.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+import { ThemeProvider } from "styled-components";
+
+import {
+  OakScaleImageButton,
+  OakScaleImageButtonProps,
+} from "./OakScaleImageButton";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { oakDefaultTheme } from "@/styles";
+
+const defaultArgs: OakScaleImageButtonProps = {
+  onImageScaleCallback: jest.fn(),
+  isExpanded: false,
+};
+
+describe("OakScaleImageButton", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("renders", () => {
+    const { getByTestId } = renderWithTheme(
+      <OakScaleImageButton {...defaultArgs} />,
+    );
+    expect(getByTestId("expand-image-button")).toBeInTheDocument();
+  });
+
+  it("matches snapshot", () => {
+    const tree = create(
+      <ThemeProvider theme={oakDefaultTheme}>
+        <OakScaleImageButton {...defaultArgs}>Click Me</OakScaleImageButton>
+      </ThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("calls onImageScaleCallback method", () => {
+    const onImageScaleCallback = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OakScaleImageButton
+        {...defaultArgs}
+        onImageScaleCallback={onImageScaleCallback}
+      />,
+    );
+    getByTestId("expand-image-button").click();
+    expect(onImageScaleCallback).toHaveBeenCalled();
+  });
+});

--- a/src/components/molecules/OakScaleImageButton/OakScaleImageButton.tsx
+++ b/src/components/molecules/OakScaleImageButton/OakScaleImageButton.tsx
@@ -1,0 +1,70 @@
+import React, { ElementType } from "react";
+
+import {
+  InternalShadowRectButton,
+  InternalShadowRectButtonProps,
+} from "@/components/molecules/InternalShadowRectButton";
+import { PolymorphicPropsWithoutRef } from "@/components/polymorphic";
+
+export type OakScaleImageButtonProps = Omit<
+  InternalShadowRectButtonProps,
+  | "defaultTextColor"
+  | "hoverTextColor"
+  | "disabledTextColor"
+  | "defaultBackground"
+  | "defaultBorderColor"
+  | "hoverBackground"
+  | "hoverBorderColor"
+  | "disabledBackground"
+  | "disabledBorderColor"
+  | "iconGap"
+  | "pv"
+  | "ph"
+  | "$bblr"
+  | "$btlr"
+  | "width"
+> & {
+  onImageScaleCallback: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  isExpanded: boolean;
+};
+
+/**
+ *
+ * A specific implementation of InternalRectButton
+ *
+ * The following callback is available for tracking focus events:
+ *
+ * ### onImageScaleCallback
+ * `onImageScaleCallback: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;`
+ *
+ */
+
+export const OakScaleImageButton = <C extends ElementType = "button">({
+  onImageScaleCallback,
+  isExpanded,
+}: OakScaleImageButtonProps & PolymorphicPropsWithoutRef<C>) => {
+  return (
+    <InternalShadowRectButton
+      type="button"
+      onClick={onImageScaleCallback}
+      iconName={!isExpanded ? "expand" : "minimise"}
+      defaultTextColor={"text-primary"}
+      hoverTextColor={"text-primary"}
+      disabledTextColor={"text-primary"}
+      defaultBackground={"bg-neutral"}
+      defaultBorderColor={"bg-neutral"}
+      hoverBackground={"bg-neutral-stronger"}
+      hoverBorderColor={"bg-neutral-stronger"}
+      disabledBackground={"bg-btn-primary-disabled"}
+      disabledBorderColor={"bg-btn-primary-disabled"}
+      iconGap={"all-spacing-0"}
+      pv={"inner-padding-none"}
+      ph={"inner-padding-none"}
+      $bblr={"border-radius-square"}
+      $btlr={"border-radius-square"}
+      width={"100%"}
+      aria-label={!isExpanded ? "Expand Image" : "Minimise imagew"}
+      data-testid="expand-image-button"
+    />
+  );
+};

--- a/src/components/molecules/OakScaleImageButton/OakScaleImageButton.tsx
+++ b/src/components/molecules/OakScaleImageButton/OakScaleImageButton.tsx
@@ -64,7 +64,7 @@ export const OakScaleImageButton = <C extends ElementType = "button">({
       $bblr={"border-radius-square"}
       $btlr={"border-radius-square"}
       width={"100%"}
-      aria-label={!isExpanded ? "Expand Image" : "Minimise imagew"}
+      aria-label={!isExpanded ? "Expand Image" : "Minimise image"}
       data-testid="expand-image-button"
     />
   );

--- a/src/components/molecules/OakScaleImageButton/OakScaleImageButton.tsx
+++ b/src/components/molecules/OakScaleImageButton/OakScaleImageButton.tsx
@@ -23,6 +23,7 @@ export type OakScaleImageButtonProps = Omit<
   | "$bblr"
   | "$btlr"
   | "width"
+  | "onClick"
 > & {
   onImageScaleCallback: (event: React.MouseEvent<HTMLButtonElement>) => void;
   isExpanded: boolean;

--- a/src/components/molecules/OakScaleImageButton/__snapshots__/OakScaleImageButton.test.tsx.snap
+++ b/src/components/molecules/OakScaleImageButton/__snapshots__/OakScaleImageButton.test.tsx.snap
@@ -1,0 +1,205 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakScaleImageButton matches snapshot 1`] = `
+.c0 {
+  position: relative;
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c2 {
+  position: absolute;
+  top: 0rem;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c5 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c7 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c8 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  object-fit: contain;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0rem;
+}
+
+.c9 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  text-align: left;
+}
+
+.c3 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+  color: #222222;
+  background: #f2f2f2;
+  padding-left: 0rem;
+  padding-right: 0rem;
+  padding-top: 0rem;
+  padding-bottom: 0rem;
+  border: 0.125rem solid;
+  border-color: #f2f2f2;
+  border-radius: 0.25rem;
+  border-top-left-radius: 0rem;
+  border-bottom-left-radius: 0rem;
+}
+
+.c3:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: inline-block;
+}
+
+.c4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #222222;
+  background: #e4e4e4;
+  border-color: #e4e4e4;
+}
+
+.c4:active {
+  background: #f2f2f2;
+  border-color: #f2f2f2;
+  color: #222222;
+}
+
+.c4:disabled {
+  background: #808080;
+  border-color: #808080;
+  color: #222222;
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:focus-visible) {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:hover),
+.c1 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:hover) {
+  box-shadow: none;
+}
+
+.c1 .grey-shadow:has(+ * + .internal-button:active) {
+  box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
+}
+
+.c1 .yellow-shadow:has(+ .internal-button:active) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+<div
+  className="c0 c1"
+>
+  <div
+    className="c2 grey-shadow"
+  />
+  <div
+    className="c2 yellow-shadow"
+  />
+  <button
+    aria-label="Expand Image"
+    className="c3 c4 internal-button"
+    data-testid="expand-image-button"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    type="button"
+  >
+    <div
+      className="c5 c6"
+    >
+      <div
+        className="c7"
+      >
+        <img
+          alt="expand"
+          className="c8"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1730982187/Icon_Expand_arrktl.svg"
+          style={
+            {
+              "bottom": 0,
+              "color": "transparent",
+              "height": "100%",
+              "left": 0,
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": "100%",
+            }
+          }
+        />
+      </div>
+      <span
+        className="c9"
+      />
+    </div>
+  </button>
+</div>
+`;

--- a/src/components/molecules/OakScaleImageButton/index.ts
+++ b/src/components/molecules/OakScaleImageButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakScaleImageButton";

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -38,3 +38,4 @@ export * from "./OakSmallSecondaryButton";
 export * from "./OakTertiaryButton";
 export * from "./OakTextInput";
 export * from "./OakTooltip";
+export * from "./OakScaleImageButton";

--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -4,6 +4,8 @@ export const icons = {
   send: "v1699893673/icons/rmvytilpjgvh3pgwc8ph.svg",
   rocket: "v1699894015/icons/u26xm5hteot875ozfnk9.svg",
   edit: "v1699894149/icons/qxlunbg5tfrdherzsvlt.svg",
+  expand: "v1730982187/Icon_Expand_arrktl.svg",
+  minimise: "v1730982213/Icon_Minimise_btcdbz.svg",
   hamburger: "v1699895123/icons/jaqdnomtbhqvjcap962u.svg",
   cross: "v1699895179/icons/xigimrbivcaxt4omxamp.svg",
   copy: "v1727861316/icons/Icon_Copy_qxgynv.svg",


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
simple dumb button component to be used to resize images

## Link to the design doc
[designs](https://www.figma.com/design/G7z5ufo2T0CHk14CkadeuB/Pupil-Lesson?node-id=9998-12146&node-type=instance&m=dev)

## A link to the component in the deployment preview
[story](https://deploy-preview-323--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oakscaleimagebutton--docs)

## Testing instructions
go to story and check for style and a11y

## ACs
