### PR TITLE
Feat/modal right hand side

### DIFF
--- a/src/components/molecules/InternalModalTransition/InternalModalTransition.tsx
+++ b/src/components/molecules/InternalModalTransition/InternalModalTransition.tsx
@@ -14,6 +14,7 @@ type TransitionProps = {
   transitionRef: React.RefObject<HTMLDivElement>;
   finalZIndex: number | "modal-dialog";
   isModal: boolean;
+  isRightHandSide?: boolean;
 };
 
 const FadeOutBox = styled(OakBox)<{ $state: TransitionStatus }>`
@@ -39,6 +40,7 @@ const InternalModalTransition: FC<TransitionProps> = ({
   onClose,
   finalZIndex,
   isModal,
+  isRightHandSide,
   ...rest
 }) => {
   return (
@@ -64,6 +66,7 @@ const InternalModalTransition: FC<TransitionProps> = ({
             ref={transitionRef}
             $zIndex={finalZIndex}
             $state={state}
+            isRightHandSide={isRightHandSide}
             {...rest}
           >
             {children}

--- a/src/components/molecules/InternalSlideInFlex/InternalSlideInFlex.tsx
+++ b/src/components/molecules/InternalSlideInFlex/InternalSlideInFlex.tsx
@@ -11,23 +11,31 @@ type InternalSlideInFlexProps = {
   state: TransitionStatus;
   isModal: boolean;
   children: React.ReactNode;
+  isRightHandSide?: boolean;
 };
 
 const SlideInFlex = styled(OakFlex)<{
   $state: TransitionStatus;
   isModal: boolean;
+  isRightHandSide?: boolean;
 }>`
   max-width: ${({ isModal }) =>
     isModal ? `calc(100vw - ${parseSpacing("inner-padding-l")})` : "100vw"};
-  transform: ${({ $state, isModal }) => {
+  
+  transform: ${({ $state, isModal, isRightHandSide }) => {
     switch ($state) {
       case "entered":
       case "entering":
         return "translateX(0)";
       default:
-        return isModal ? "translateX(-100%)" : "translateX(100%)";
+        return isRightHandSide
+          ? "translateX(100%)"
+          : isModal
+          ? "translateX(-100%)"
+          : "translateX(-100%)";
     }
   }};
+  
   ${({ isModal }) =>
     !isModal &&
     `
@@ -43,14 +51,14 @@ const InternalSlideInFlex: FC<
   HTMLDivElement,
   InternalSlideInFlexProps & ComponentPropsWithRef<typeof OakFlex>
 >((props, ref) => {
-  const { finalZIndex, state, isModal, children, ...rest } = props;
+  const { finalZIndex, state, isModal, isRightHandSide, children, ...rest } = props;
 
   return (
     <SlideInFlex
       ref={ref}
       $background="bg-primary"
-      $right={!isModal ? "all-spacing-0" : null}
-      $left={isModal ? "all-spacing-0" : null}
+      $right={isRightHandSide ? "all-spacing-0" : null}
+      $left={!isRightHandSide ? "all-spacing-0" : null}
       $position="fixed"
       $bottom="all-spacing-0"
       $width={["all-spacing-22"]}
@@ -62,6 +70,7 @@ const InternalSlideInFlex: FC<
       $color="text-primary"
       role="dialog"
       isModal={isModal}
+      isRightHandSide={isRightHandSide}
       {...rest}
     >
       {children}

--- a/src/components/molecules/InternalSlideInFlex/InternalSlideInFlex.tsx
+++ b/src/components/molecules/InternalSlideInFlex/InternalSlideInFlex.tsx
@@ -21,7 +21,7 @@ const SlideInFlex = styled(OakFlex)<{
 }>`
   max-width: ${({ isModal }) =>
     isModal ? `calc(100vw - ${parseSpacing("inner-padding-l")})` : "100vw"};
-  
+
   transform: ${({ $state, isModal, isRightHandSide }) => {
     switch ($state) {
       case "entered":
@@ -31,11 +31,11 @@ const SlideInFlex = styled(OakFlex)<{
         return isRightHandSide
           ? "translateX(100%)"
           : isModal
-          ? "translateX(-100%)"
-          : "translateX(-100%)";
+            ? "translateX(-100%)"
+            : "translateX(-100%)";
     }
   }};
-  
+
   ${({ isModal }) =>
     !isModal &&
     `
@@ -51,7 +51,8 @@ const InternalSlideInFlex: FC<
   HTMLDivElement,
   InternalSlideInFlexProps & ComponentPropsWithRef<typeof OakFlex>
 >((props, ref) => {
-  const { finalZIndex, state, isModal, isRightHandSide, children, ...rest } = props;
+  const { finalZIndex, state, isModal, isRightHandSide, children, ...rest } =
+    props;
 
   return (
     <SlideInFlex

--- a/src/components/molecules/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
+++ b/src/components/molecules/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
@@ -13,8 +13,8 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
 .c2 {
   position: fixed;
   top: 0rem;
-  right: 0rem;
   bottom: 0rem;
+  left: 0rem;
   width: 40rem;
   color: #222222;
   background: #ffffff;

--- a/src/components/molecules/OakModal/OakModal.stories.tsx
+++ b/src/components/molecules/OakModal/OakModal.stories.tsx
@@ -24,11 +24,17 @@ const meta: Meta<typeof OakModal> = {
     },
     isRightHandSide: {
       control: "boolean",
-    }
+    },
   },
   parameters: {
     controls: {
-      include: ["children", "footerSlot", "isOpen", "onClose", "isRightHandSide"],
+      include: [
+        "children",
+        "footerSlot",
+        "isOpen",
+        "onClose",
+        "isRightHandSide",
+      ],
     },
   },
   args: {
@@ -55,7 +61,11 @@ const meta: Meta<typeof OakModal> = {
     return (
       <>
         <OakSecondaryButton onClick={onOpen}>Open modal</OakSecondaryButton>
-        <OakModal {...args} onClose={onClose} isRightHandSide={args.isRightHandSide} />
+        <OakModal
+          {...args}
+          onClose={onClose}
+          isRightHandSide={args.isRightHandSide}
+        />
       </>
     );
   },

--- a/src/components/molecules/OakModal/OakModal.stories.tsx
+++ b/src/components/molecules/OakModal/OakModal.stories.tsx
@@ -22,10 +22,13 @@ const meta: Meta<typeof OakModal> = {
     footerSlot: {
       control: "text",
     },
+    isRightHandSide: {
+      control: "boolean",
+    }
   },
   parameters: {
     controls: {
-      include: ["children", "footerSlot", "isOpen", "onClose"],
+      include: ["children", "footerSlot", "isOpen", "onClose", "isRightHandSide"],
     },
   },
   args: {
@@ -52,7 +55,7 @@ const meta: Meta<typeof OakModal> = {
     return (
       <>
         <OakSecondaryButton onClick={onOpen}>Open modal</OakSecondaryButton>
-        <OakModal {...args} onClose={onClose} />
+        <OakModal {...args} onClose={onClose} isRightHandSide={args.isRightHandSide} />
       </>
     );
   },

--- a/src/components/molecules/OakModal/OakModal.tsx
+++ b/src/components/molecules/OakModal/OakModal.tsx
@@ -70,7 +70,7 @@ export const OakModal = ({
   ...rest
 }: OakModalProps) => {
   const transitionRef = useRef<HTMLDivElement>(null);
-  
+
   const { isScrolled, ObserveScroll } = useIsScrolled();
 
   // `createPortal` is not supported in SSR so we can only render when mounted on the client

--- a/src/components/molecules/OakModal/OakModal.tsx
+++ b/src/components/molecules/OakModal/OakModal.tsx
@@ -43,6 +43,12 @@ export type OakModalProps = {
    * NB *The modal is rendered inside a portal so it will not respect the stacking context of its parent component*.
    */
   zIndex?: number;
+  /**
+   * Whether the modal should be right-aligned.
+   *
+   * Defaults to `false`
+   */
+  isRightHandSide?: boolean;
 } & Pick<
   HTMLAttributes<Element>,
   "aria-label" | "aria-description" | "aria-labelledby" | "aria-describedby"
@@ -59,11 +65,12 @@ export const OakModal = ({
   domContainer,
   isOpen,
   onClose,
+  isRightHandSide,
   zIndex,
   ...rest
 }: OakModalProps) => {
   const transitionRef = useRef<HTMLDivElement>(null);
-
+  
   const { isScrolled, ObserveScroll } = useIsScrolled();
 
   // `createPortal` is not supported in SSR so we can only render when mounted on the client
@@ -81,6 +88,7 @@ export const OakModal = ({
       transitionRef={transitionRef}
       onClose={onClose}
       finalZIndex={finalZIndex}
+      isRightHandSide={isRightHandSide}
       isModal={true}
       {...rest}
     >


### PR DESCRIPTION
# How to review this PR

This PR adds a toggle to the oak modal so that It can pull out from the right hand side, it defaults to the modal pulling out from the left hand side

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
