### PR TITLE
CTC-57 Style updates for media page

### DIFF
--- a/src/components/molecules/OakSolidBorderAccordion/OakSolidBorderAccordion.tsx
+++ b/src/components/molecules/OakSolidBorderAccordion/OakSolidBorderAccordion.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from "react";
 import styled from "styled-components";
 
 import { InternalChevronAccordion } from "@/components/molecules/InternalChevronAccordion";
-import { OakBox, OakFlex } from "@/components/atoms";
+import { OakFlex } from "@/components/atoms";
 import { SizeStyleProps } from "@/styles/utils/sizeStyle";
 import { FlexStyleProps } from "@/styles/utils/flexStyle";
 import { SpacingStyleProps } from "@/styles/utils/spacingStyle";
@@ -33,16 +33,17 @@ const AccordionWrapper = styled(OakFlex)`
   border-width: 2px;
 `;
 
-const BottomBoxShadow = styled(OakBox)`
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  height: 50px;
-  z-index: 100;
-  -webkit-box-shadow: inset 0px -55px 30px -30px rgba(255, 255, 255, 1);
-  -moz-box-shadow: inset 0px -55px 30px -30px rgba(255, 255, 255, 1);
-  box-shadow: inset 0px -55px 30px -30px rgba(255, 255, 255, 1);
-`;
+// @todo only show shadow when there is are more items to scroll and remove once scrolled to the bottom
+// const BottomBoxShadow = styled(OakBox)`
+//   position: absolute;
+//   bottom: 0;
+//   width: 100%;
+//   height: 50px;
+//   z-index: 100;
+//   -webkit-box-shadow: inset 0px -55px 30px -30px rgba(255, 255, 255, 1);
+//   -moz-box-shadow: inset 0px -55px 30px -30px rgba(255, 255, 255, 1);
+//   box-shadow: inset 0px -55px 30px -30px rgba(255, 255, 255, 1);
+// `;
 
 /**
  * An accordion component that can be used to show/hide content
@@ -55,21 +56,18 @@ export const OakSolidBorderAccordion = ({
   ...styleProps
 }: OakSolidBorderAccordionProps) => {
   return (
-    <AccordionWrapper
-      $position={"relative"}
-      $flexDirection={"column"}
-      $borderStyle={"solid"}
-      $borderColor={"border-primary"}
-    >
+    <AccordionWrapper $position={"relative"} $flexDirection={"column"}>
       <InternalChevronAccordion
         header={header}
         id={id}
         initialOpen={initialOpen}
         $pv={"inner-padding-none"}
+        $borderStyle={"solid"}
+        $borderColor={"border-primary"}
+        $ba={"border-solid-m"}
         {...styleProps}
       >
         {children}
-        <BottomBoxShadow />
       </InternalChevronAccordion>
     </AccordionWrapper>
   );

--- a/src/components/molecules/OakSolidBorderAccordion/__snapshots__/OakSolidBorderAccordion.test.tsx.snap
+++ b/src/components/molecules/OakSolidBorderAccordion/__snapshots__/OakSolidBorderAccordion.test.tsx.snap
@@ -3,8 +3,6 @@
 exports[`OakSolidBorderAccordion matches snapshot 1`] = `
 .c0 {
   position: relative;
-  border-color: #222222;
-  border-style: solid;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -12,6 +10,9 @@ exports[`OakSolidBorderAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0rem;
   padding-bottom: 0rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-style: solid;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -79,7 +80,7 @@ exports[`OakSolidBorderAccordion matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -98,7 +99,7 @@ exports[`OakSolidBorderAccordion matches snapshot 1`] = `
   padding: 0;
 }
 
-.c18 {
+.c17 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
@@ -130,6 +131,9 @@ exports[`OakSolidBorderAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0rem;
   padding-bottom: 0rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-style: solid;
   font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
@@ -141,28 +145,17 @@ exports[`OakSolidBorderAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c5 .c17 {
+.c5 .c16 {
   visibility: hidden;
 }
 
-.c5 .c9:focus-visible ~ .c17 {
+.c5 .c9:focus-visible ~ .c16 {
   visibility: visible;
 }
 
 .c2 {
   position: relative;
   border-width: 2px;
-}
-
-.c15 {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  height: 50px;
-  z-index: 100;
-  -webkit-box-shadow: inset 0px -55px 30px -30px rgba(255,255,255,1);
-  -moz-box-shadow: inset 0px -55px 30px -30px rgba(255,255,255,1);
-  box-shadow: inset 0px -55px 30px -30px rgba(255,255,255,1);
 }
 
 <div
@@ -221,12 +214,9 @@ exports[`OakSolidBorderAccordion matches snapshot 1`] = `
       role="region"
     >
       Here it is
-      <div
-        className="c14 c15"
-      />
     </div>
     <div
-      className="c14 c16 c17 c18"
+      className="c14 c15 c16 c17"
     >
       <svg
         className=""

--- a/src/components/organisms/shared/OakMediaClipList/OakMediaClipList.stories.tsx
+++ b/src/components/organisms/shared/OakMediaClipList/OakMediaClipList.stories.tsx
@@ -39,7 +39,7 @@ export const Default: Story = {
   args: {
     lessonTitle: "Lesson title",
     currentClipCounter: 2,
-    totalClipCounter: 5,
+    totalClipCounter: 6,
     children: (
       <>
         <OakMediaClip
@@ -51,6 +51,15 @@ export const Default: Story = {
         />
         <OakMediaClip
           {...mediaClipArgs}
+          clipName="Played Clip Name"
+          muxPlayingState={"played"}
+          onClick={() => {
+            console.log(`Played video`);
+          }}
+        />
+        <OakMediaClip
+          {...mediaClipArgs}
+          clipName="Playing Clip Name"
           muxPlayingState={"playing"}
           onClick={() => {
             console.log(`Playing video`);
@@ -58,9 +67,23 @@ export const Default: Story = {
         />
         <OakMediaClip
           {...mediaClipArgs}
-          muxPlayingState={"played"}
+          muxPlayingState={"standard"}
           onClick={() => {
-            console.log(`Played video`);
+            console.log(`Standard video`);
+          }}
+        />
+        <OakMediaClip
+          {...mediaClipArgs}
+          muxPlayingState={"standard"}
+          onClick={() => {
+            console.log(`Standard video`);
+          }}
+        />
+        <OakMediaClip
+          {...mediaClipArgs}
+          muxPlayingState={"standard"}
+          onClick={() => {
+            console.log(`Standard video`);
           }}
         />
       </>

--- a/src/components/organisms/shared/OakMediaClipList/__snapshots__/OakMediaClipList.test.tsx.snap
+++ b/src/components/organisms/shared/OakMediaClipList/__snapshots__/OakMediaClipList.test.tsx.snap
@@ -4,8 +4,6 @@ exports[`OakMediaClipList matches snapshot 1`] = `
 [
   .c0 {
   position: relative;
-  border-color: #222222;
-  border-style: solid;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -14,6 +12,9 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   max-height: 30rem;
   padding-top: 0rem;
   padding-bottom: 0rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-style: solid;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -121,7 +122,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -176,7 +177,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   padding: 0;
 }
 
-.c25 {
+.c24 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
@@ -209,6 +210,9 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   max-height: 30rem;
   padding-top: 0rem;
   padding-bottom: 0rem;
+  border: 0.125rem solid;
+  border-color: #222222;
+  border-style: solid;
   font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
@@ -220,28 +224,17 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c5 .c24 {
+.c5 .c23 {
   visibility: hidden;
 }
 
-.c5 .c9:focus-visible ~ .c24 {
+.c5 .c9:focus-visible ~ .c23 {
   visibility: visible;
 }
 
 .c2 {
   position: relative;
   border-width: 2px;
-}
-
-.c22 {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  height: 50px;
-  z-index: 100;
-  -webkit-box-shadow: inset 0px -55px 30px -30px rgba(255,255,255,1);
-  -moz-box-shadow: inset 0px -55px 30px -30px rgba(255,255,255,1);
-  box-shadow: inset 0px -55px 30px -30px rgba(255,255,255,1);
 }
 
 <div
@@ -325,12 +318,9 @@ exports[`OakMediaClipList matches snapshot 1`] = `
         >
           children
         </ul>
-        <div
-          className="c21 c22"
-        />
       </div>
       <div
-        className="c21 c23 c24 c25"
+        className="c21 c22 c23 c24"
       >
         <svg
           className=""

--- a/src/components/organisms/shared/OakVideoTranscript/OakVideoTranscript.stories.tsx
+++ b/src/components/organisms/shared/OakVideoTranscript/OakVideoTranscript.stories.tsx
@@ -168,5 +168,6 @@ export const WithNoTranscript: Story = {
         onClick={() => console.log("Sign language clicked")}
       />
     ),
+    copyLinkControl: <OakCopyLinkButton href="/copy-this-link" />,
   },
 };

--- a/src/components/organisms/shared/OakVideoTranscript/OakVideoTranscript.test.tsx
+++ b/src/components/organisms/shared/OakVideoTranscript/OakVideoTranscript.test.tsx
@@ -1,22 +1,56 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { create } from "react-test-renderer";
+import { act, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "styled-components";
 
 import { OakVideoTranscript } from "./OakVideoTranscript";
 
 import { oakDefaultTheme } from "@/styles";
+import renderWithTheme from "@/test-helpers/renderWithTheme";
 
 describe(OakVideoTranscript, () => {
+  const copyLinkControl = <p>copy link control</p>;
+  const signLanguageControl = <p>sign language control</p>;
+
+  const defaultProps = {
+    id: "transcript-element",
+    copyLinkControl,
+    signLanguageControl,
+  };
+
   it("matches snapshot", () => {
     const tree = create(
       <ThemeProvider theme={oakDefaultTheme}>
-        <OakVideoTranscript id="transcript-element">
+        <OakVideoTranscript
+          id="transcript-element"
+          copyLinkControl={copyLinkControl}
+          signLanguageControl={signLanguageControl}
+        >
           Transcript goes here
         </OakVideoTranscript>
       </ThemeProvider>,
     ).toJSON();
 
     expect(tree).toMatchSnapshot();
+  });
+
+  it("handles transcript click correctly", () => {
+    const { getByAltText, getAllByText } = renderWithTheme(
+      <OakVideoTranscript {...defaultProps}>children</OakVideoTranscript>,
+    );
+
+    const transcriptButton = getAllByText("Show transcript")[0];
+    const chevronIcon = getByAltText("chevron-down");
+
+    expect(transcriptButton).toHaveTextContent("Show transcript");
+    expect(chevronIcon).toBeInTheDocument();
+
+    act(() => {
+      transcriptButton && fireEvent.click(transcriptButton);
+    });
+
+    expect(transcriptButton).toHaveTextContent("Hide transcript");
+    expect(chevronIcon).toHaveAttribute("alt", "chevron-up");
   });
 });

--- a/src/components/organisms/shared/OakVideoTranscript/OakVideoTranscript.tsx
+++ b/src/components/organisms/shared/OakVideoTranscript/OakVideoTranscript.tsx
@@ -52,14 +52,15 @@ export const OakVideoTranscript = ({
 
   return (
     <>
-      <OakFlex $flexDirection="row" $flexWrap={"wrap"}>
+      <OakFlex
+        $flexDirection="row"
+        $flexWrap={"wrap"}
+        $gap={["space-between-ssx", "space-between-s"]}
+      >
         {/* desktop */}
-        <OakBox
-          $mr={"space-between-s"}
-          $mb="space-between-m2"
-          $display={["none", "block"]}
-        >
-          {children && (
+
+        {children && (
+          <OakBox $display={["none", "block"]}>
             <OakSmallSecondaryButton
               onClick={handleClick}
               iconName={showTranscript ? "chevron-up" : "chevron-down"}
@@ -69,15 +70,11 @@ export const OakVideoTranscript = ({
             >
               {label}
             </OakSmallSecondaryButton>
-          )}
-        </OakBox>
+          </OakBox>
+        )}
 
         {/* mobile */}
-        <OakBox
-          $mr={"space-between-ssx"}
-          $mb="space-between-s"
-          $display={["block", "none"]}
-        >
+        <OakBox $display={["block", "none"]}>
           {children && (
             <OakSmallSecondaryButton
               onClick={handleClick}
@@ -88,19 +85,8 @@ export const OakVideoTranscript = ({
             </OakSmallSecondaryButton>
           )}
         </OakBox>
-        {copyLinkControl && (
-          <OakBox
-            $mr={["space-between-ssx", "space-between-s"]}
-            $mb={["space-between-s", "space-between-m2"]}
-          >
-            {copyLinkControl}
-          </OakBox>
-        )}
-        {signLanguageControl && (
-          <OakBox $mb={["space-between-s", "space-between-m2"]}>
-            {signLanguageControl}
-          </OakBox>
-        )}
+        {copyLinkControl && <OakBox>{copyLinkControl}</OakBox>}
+        {signLanguageControl && <OakBox>{signLanguageControl}</OakBox>}
       </OakFlex>
       {children && (
         <OakCollapsibleContent
@@ -110,6 +96,7 @@ export const OakVideoTranscript = ({
           $font="body-2"
           $color="text-primary"
           $pa={"space-between-xs"}
+          $mt={["space-between-s", "space-between-m2"]}
           aria-live="polite"
         >
           {children}

--- a/src/components/organisms/shared/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/shared/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
@@ -7,8 +7,6 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
 }
 
 .c2 {
-  margin-right: 1rem;
-  margin-bottom: 2rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -40,8 +38,6 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
 }
 
 .c12 {
-  margin-right: 0.5rem;
-  margin-bottom: 1rem;
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -63,6 +59,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .c8 {
@@ -187,6 +184,16 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   }
 }
 
+@media (min-width:750px) {
+
+}
+
+@media (min-width:750px) {
+  .c1 {
+    gap: 1rem;
+  }
+}
+
 <div
     className="c0 c1"
   >
@@ -295,6 +302,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   padding-right: 1rem;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
+  margin-top: 1rem;
   color: #222222;
   background: #e4e4e4;
   border-radius: 0.375rem;
@@ -342,6 +350,16 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
 
 @media (min-width:750px) {
 
+}
+
+@media (min-width:750px) {
+
+}
+
+@media (min-width:750px) {
+  .c1 {
+    margin-top: 2rem;
+  }
 }
 
 @media (min-width:750px) {

--- a/src/components/organisms/shared/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/shared/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
@@ -289,6 +289,20 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
         </button>
       </div>
     </div>
+    <div
+      className="c0"
+    >
+      <p>
+        copy link control
+      </p>
+    </div>
+    <div
+      className="c0"
+    >
+      <p>
+        sign language control
+      </p>
+    </div>
   </div>,
   .c0 {
   display: none;


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

What changed (no visible changes, only code tweaks):
- `OakVideoTranscript` can display 'Copy button' when there is no transcript with correct spacing
- removed shadow from `OakMediaClipList` as its causing issues and will add it back in a separate ticket making sure it only shows where there is a scroll bar and disappears after scrolling to the end of a list

## Link to the design doc

OakMediaClipList:
https://deploy-preview-333--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-teacher-oakmediacliplist--docs

OakVideoTranscript
https://deploy-preview-333--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-shared-oakvideotranscript--docs (bottom example in storybook)

## A link to the component in the deployment preview

## Testing instructions

## ACs
