### PR TITLE
PUPIL-1160 Changes needed to retire Svg component in OWA

### DIFF
--- a/src/components/atoms/OakFlex/OakFlex.tsx
+++ b/src/components/atoms/OakFlex/OakFlex.tsx
@@ -4,6 +4,7 @@ import { OakBox, OakBoxProps } from "@/components/atoms/OakBox";
 import { flexStyle, FlexStyleProps } from "@/styles/utils/flexStyle";
 
 export type OakFlexProps = FlexStyleProps & OakBoxProps;
+export const oakFlexCss = flexStyle;
 
 /**
  * Flex sets `display: flex;` and exposes various flex props, along with Box

--- a/src/components/atoms/OakImage/OakImage.tsx
+++ b/src/components/atoms/OakImage/OakImage.tsx
@@ -74,7 +74,9 @@ const StyledFillImage = styled(Image)<StyledImageProps>`
   ${colorFilterStyle}
   ${clickStyles}
   ${placeholderStyles}
-  object-fit: contain;
+  ${(props) => css`
+    object-fit: ${props.$objectFit ? props.$objectFit : "contain"};
+  `}
 `;
 
 const StyledResponsiveImage = styled(Image)<StyledImageProps>`
@@ -113,6 +115,7 @@ export const OakImage = <C extends ElementType = typeof Image>({
     placeholder = "oak",
     unoptimized,
     imageProps,
+    $objectFit,
     onLoad,
     onError,
     ...rest
@@ -138,6 +141,7 @@ export const OakImage = <C extends ElementType = typeof Image>({
           unoptimized={unoptimized}
           onLoad={handleComplete(onLoad)}
           onError={handleComplete(onError)}
+          $objectFit={$objectFit}
           {...imageProps}
         />
       </OakBox>

--- a/src/components/molecules/OakBackLink/OakBackLink.tsx
+++ b/src/components/molecules/OakBackLink/OakBackLink.tsx
@@ -77,6 +77,7 @@ export const OakBackLink = <C extends ElementType = "a">({
         alt=""
         iconName="chevron-left"
         $width="all-spacing-8"
+        $objectFit={"cover"}
         $height="all-spacing-8"
       />
     </StyledBackLink>

--- a/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
+++ b/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`OakBackLink matches snapshot 1`] = `
 }
 
 .c2 {
-  object-fit: contain;
+  object-fit: cover;
 }
 
 .c0 {

--- a/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -37,12 +37,16 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c14 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c5 {
+  object-fit: cover;
+}
+
+.c9 {
   object-fit: contain;
 }
 
@@ -69,7 +73,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   flex-grow: none;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -84,7 +88,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c9 {
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -95,7 +99,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c10 {
+.c11 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -166,31 +170,31 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c13 {
+  .c14 {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c10 {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c10 {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c10 {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c10 {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -199,7 +203,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c11 {
+  .c12 {
     display: none;
   }
 }
@@ -256,7 +260,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
       >
         <img
           alt="intro"
-          className="c5"
+          className="c9"
           data-nimg="fill"
           decoding="async"
           loading="lazy"
@@ -285,21 +289,21 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
     className="c0"
   >
     <h1
-      className="c9"
+      className="c10"
     >
       Intro
     </h1>
     <span
-      className="c10 c11"
+      className="c11 c12"
     >
       In progress&hellip;
     </span>
   </div>
   <div
-    className="c0 c12"
+    className="c0 c13"
   >
     <div
-      className="c13"
+      className="c14"
     />
   </div>
 </div>

--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -104,7 +104,7 @@ export const icons = {
   "subject-independent-living":
     "v1706616419/subject-icons/independent-living.svg",
   "subject-latin": "v1706616420/subject-icons/latin.svg",
-  "subject-literacy": "v1706616420/subject-icons/latin.svg",
+  "subject-literacy": "v1706616417/subject-icons/english.svg",
   "subject-maths": "v1706616421/subject-icons/maths.svg",
   "subject-music": "v1728570203/subject-icons/music-hollow.svg",
   "subject-numeracy": "v1706616422/subject-icons/numeracy.svg",

--- a/src/styles/theme/color.ts
+++ b/src/styles/theme/color.ts
@@ -83,6 +83,8 @@ export const oakColorFilterTokens = {
     "brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%)",
   mint: "brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%)",
   aqua: "brightness(0) saturate(100%) invert(100%) sepia(32%) saturate(3811%) hue-rotate(166deg) brightness(108%) contrast(77%)",
+  lavender:
+    "brightness(0) saturate(100%) invert(89%) sepia(20%) saturate(5630%) hue-rotate(186deg) brightness(95%) contrast(100%)",
 };
 
 export type OakColorFilterToken = keyof typeof oakColorFilterTokens;

--- a/src/styles/theme/color.ts
+++ b/src/styles/theme/color.ts
@@ -78,7 +78,6 @@ export const oakColorFilterTokens = {
     "brightness(0) saturate(100%) invert(57%) sepia(99%) saturate(395%) hue-rotate(330deg) brightness(102%) contrast(101%);",
   lemon:
     "invert(82%) sepia(25%) saturate(963%) hue-rotate(359deg) brightness(106%) contrast(101%)",
-  // @todo colour is off
   pink: "brightness(0) saturate(100%) invert(91%) sepia(5%) saturate(2279%) hue-rotate(278deg) brightness(89%) contrast(94%)",
   pink50:
     "brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%)",

--- a/src/styles/theme/color.ts
+++ b/src/styles/theme/color.ts
@@ -78,6 +78,12 @@ export const oakColorFilterTokens = {
     "brightness(0) saturate(100%) invert(57%) sepia(99%) saturate(395%) hue-rotate(330deg) brightness(102%) contrast(101%);",
   lemon:
     "invert(82%) sepia(25%) saturate(963%) hue-rotate(359deg) brightness(106%) contrast(101%)",
+  // @todo colour is off
+  pink: "brightness(0) saturate(100%) invert(91%) sepia(5%) saturate(2279%) hue-rotate(278deg) brightness(89%) contrast(94%)",
+  pink50:
+    "brightness(0) saturate(100%) invert(95%) sepia(3%) saturate(1596%) hue-rotate(279deg) brightness(95%) contrast(87%)",
+  mint: "brightness(0) saturate(100%) invert(85%) sepia(7%) saturate(1206%) hue-rotate(70deg) brightness(110%) contrast(90%)",
+  aqua: "brightness(0) saturate(100%) invert(100%) sepia(32%) saturate(3811%) hue-rotate(166deg) brightness(108%) contrast(77%)",
 };
 
 export type OakColorFilterToken = keyof typeof oakColorFilterTokens;

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -36,4 +36,6 @@ export type { OakTheme } from "./theme";
 export { oakFontTokens, oakFontSizeTokens } from "./typography";
 export type { OakFontToken, OakFontSizeToken } from "./typography";
 
+export { oakZIndexTokens } from "./zIndex";
+
 export { oakDefaultTheme } from "./default.theme";

--- a/src/styles/theme/spacing.ts
+++ b/src/styles/theme/spacing.ts
@@ -1,5 +1,6 @@
 export const oakAllSpacingTokens = {
   "all-spacing-0": 0,
+  "all-spacing-05": 2,
   "all-spacing-1": 4,
   "all-spacing-2": 8,
   "all-spacing-3": 12,


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Changes needed to retire Svg component in OWA:
- added new color filters
- added option to set `object-fit` in `OakImage` (no changes to default one)
- exported `oakZIndexTokens`

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

There is no visual changes to the project

## ACs
