### PR TITLE
Fix/broken imports

### DIFF
--- a/src/components/atoms/InternalAccordion/InternalAccordion.tsx
+++ b/src/components/atoms/InternalAccordion/InternalAccordion.tsx
@@ -3,7 +3,8 @@ import styled from "styled-components";
 
 import useAccordionContext from "./useAccordionContext";
 
-import { OakBox, OakBoxProps, OakFlex, OakFlexProps } from "@/components/atoms";
+import { OakFlex, OakFlexProps } from "@/components/atoms/OakFlex";
+import { OakBox, OakBoxProps } from "@/components/atoms/OakBox";
 
 const FlexWithReset = styled(OakFlex)`
   font: inherit;

--- a/src/components/atoms/InternalCheckBox/InternalCheckBox.test.tsx
+++ b/src/components/atoms/InternalCheckBox/InternalCheckBox.test.tsx
@@ -6,7 +6,7 @@ import { fireEvent } from "@testing-library/react";
 import { InternalCheckBox } from "./InternalCheckBox";
 
 import renderWithTheme from "@/test-helpers/renderWithTheme";
-import { OakThemeProvider } from "@/components/atoms";
+import { OakThemeProvider } from "@/components/atoms/OakThemeProvider";
 import { oakDefaultTheme } from "@/styles";
 
 describe("InternalCheckBox", () => {

--- a/src/components/atoms/InternalCheckBoxLabel/InternalCheckBoxLabel.test.tsx
+++ b/src/components/atoms/InternalCheckBoxLabel/InternalCheckBoxLabel.test.tsx
@@ -5,7 +5,7 @@ import { create } from "react-test-renderer";
 import { InternalCheckBoxLabel } from "./InternalCheckBoxLabel";
 
 import renderWithTheme from "@/test-helpers/renderWithTheme";
-import { OakThemeProvider } from "@/components/atoms";
+import { OakThemeProvider } from "@/components/atoms/OakThemeProvider";
 import { oakDefaultTheme } from "@/styles";
 
 describe("InternalCheckBoxLabel", () => {

--- a/src/components/atoms/InternalCheckBoxLabel/InternalCheckBoxLabel.tsx
+++ b/src/components/atoms/InternalCheckBoxLabel/InternalCheckBoxLabel.tsx
@@ -1,6 +1,6 @@
 import styled, { CSSProperties } from "styled-components";
 
-import { OakLabel, OakLabelProps } from "@/components/atoms";
+import { OakLabel, OakLabelProps } from "@/components/atoms/OakLabel";
 import { responsiveStyle } from "@/styles/utils/responsiveStyle";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
 import { FlexStyleProps } from "@/styles/utils/flexStyle";

--- a/src/components/atoms/InternalCheckBoxWrapper/InternalCheckBoxWrapper.test.tsx
+++ b/src/components/atoms/InternalCheckBoxWrapper/InternalCheckBoxWrapper.test.tsx
@@ -5,7 +5,7 @@ import { create } from "react-test-renderer";
 import { InternalCheckBoxWrapper } from "./InternalCheckBoxWrapper";
 
 import renderWithTheme from "@/test-helpers/renderWithTheme";
-import { OakThemeProvider } from "@/components/atoms";
+import { OakThemeProvider } from "@/components/atoms/OakThemeProvider";
 import { oakDefaultTheme } from "@/styles";
 
 describe("InternalCheckBoxWrapper", () => {

--- a/src/components/atoms/InternalCheckBoxWrapper/InternalCheckBoxWrapper.tsx
+++ b/src/components/atoms/InternalCheckBoxWrapper/InternalCheckBoxWrapper.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
-import { OakBox, OakBoxProps, OakIcon } from "@/components/atoms";
+import { OakBox, OakBoxProps } from "@/components/atoms/OakBox";
+import { OakIcon } from "@/components/atoms/OakIcon";
 import { OakAllSpacingToken, OakInnerPaddingToken } from "@/styles";
 import { ResponsiveValues } from "@/styles/utils/responsiveStyle";
 

--- a/src/components/atoms/OakIcon/OakIcon.stories.tsx
+++ b/src/components/atoms/OakIcon/OakIcon.stories.tsx
@@ -3,7 +3,8 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import { OakIcon, OakIconProps, oakIconNames } from "./OakIcon";
 
-import { OakFlex, OakTypography } from "@/components/atoms";
+import { OakFlex } from "@/components/atoms/OakFlex";
+import { OakTypography } from "@/components/atoms/OakTypography";
 import { sizeArgTypes } from "@/storybook-helpers/sizeStyleHelpers";
 import { colorFilterArgTypes } from "@/storybook-helpers/colorFilterStyleHelpers";
 

--- a/src/components/atoms/OakKbd/OakKbd.test.tsx
+++ b/src/components/atoms/OakKbd/OakKbd.test.tsx
@@ -4,7 +4,7 @@ import { create } from "react-test-renderer";
 
 import { OakKbd } from "./OakKbd";
 
-import { OakThemeProvider } from "@/components/atoms";
+import { OakThemeProvider } from "@/components/atoms/OakThemeProvider";
 import { oakDefaultTheme } from "@/styles";
 
 describe(OakKbd, () => {

--- a/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
+++ b/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
@@ -30,6 +30,27 @@ exports[`OakCheckBox matches snapshot 1`] = `
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
+.c0 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  color: #222222;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 1rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c2 {
   position: relative;
   width: 1.5rem;
@@ -60,27 +81,6 @@ exports[`OakCheckBox matches snapshot 1`] = `
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
-}
-
-.c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
-  color: #222222;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 1rem;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c9 {

--- a/src/components/molecules/OakCopyLinkButton/OakCopyLinkButton.tsx
+++ b/src/components/molecules/OakCopyLinkButton/OakCopyLinkButton.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { OakSmallSecondaryButton } from "@/components/molecules";
+import { OakSmallSecondaryButton } from "@/components/molecules/OakSmallSecondaryButton";
 import { OakBox } from "@/components/atoms";
 
 type OakCopyLinkButtonProps = {

--- a/src/components/molecules/OakFilterDrawer/OakFilterDrawer.tsx
+++ b/src/components/molecules/OakFilterDrawer/OakFilterDrawer.tsx
@@ -4,7 +4,8 @@ import styled from "styled-components";
 
 import { InternalShadowRoundButton } from "@/components/molecules/InternalShadowRoundButton";
 import { OakBox, OakFlex, OakHeading } from "@/components/atoms";
-import { OakModalProps, OakSecondaryLink } from "@/components/molecules";
+import { OakModalProps } from "@/components/molecules/OakModal";
+import { OakSecondaryLink } from "@/components/molecules/OakSecondaryLink";
 import useIsScrolled from "@/hooks/useIsScrolled";
 import useMounted from "@/hooks/useMounted";
 import InternalModalTransition from "@/components/molecules/InternalModalTransition/InternalModalTransition";

--- a/src/components/molecules/OakInlineBanner/OakInlineBanner.stories.tsx
+++ b/src/components/molecules/OakInlineBanner/OakInlineBanner.stories.tsx
@@ -4,9 +4,9 @@ import React from "react";
 
 import {
   OakInlineBanner,
-  OakSecondaryLink,
   bannerTypes,
-} from "@/components/molecules";
+} from "@/components/molecules/OakInlineBanner";
+import { OakSecondaryLink } from "@/components/molecules/OakSecondaryLink";
 import { oakIconNames } from "@/components/atoms";
 
 const meta: Meta<typeof OakInlineBanner> = {

--- a/src/components/molecules/OakInlineBanner/OakInlineBanner.test.tsx
+++ b/src/components/molecules/OakInlineBanner/OakInlineBanner.test.tsx
@@ -7,9 +7,9 @@ import { oakDefaultTheme } from "@/styles";
 import { OakThemeProvider } from "@/components/atoms";
 import {
   OakInlineBanner,
-  OakSecondaryLink,
   bannerTypes,
-} from "@/components/molecules";
+} from "@/components/molecules/OakInlineBanner";
+import { OakSecondaryLink } from "@/components/molecules/OakSecondaryLink";
 import { parseColor } from "@/styles/helpers/parseColor";
 
 jest.mock("react-dom", () => {

--- a/src/components/molecules/OakLessonInfoCard/OakLessonInfoCard.stories.tsx
+++ b/src/components/molecules/OakLessonInfoCard/OakLessonInfoCard.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from "./OakLessonInfoCard";
 
 import { OakFlex, OakP } from "@/components/atoms";
-import { OakPrimaryInvertedButton } from "@/components/molecules";
+import { OakPrimaryInvertedButton } from "@/components/molecules/OakPrimaryInvertedButton";
 
 const meta: Meta<typeof OakLessonInfoCard> = {
   component: OakLessonInfoCard,

--- a/src/components/molecules/OakModalCenter/OakModalCenter.stories.tsx
+++ b/src/components/molecules/OakModalCenter/OakModalCenter.stories.tsx
@@ -3,12 +3,12 @@ import { useArgs } from "@storybook/preview-api";
 import React, { Fragment } from "react";
 
 import { OakSecondaryButton } from "@/components/molecules/OakSecondaryButton";
+import { OakPrimaryButton } from "@/components/molecules/OakPrimaryButton";
+import { OakPrimaryInvertedButton } from "@/components/molecules/OakPrimaryInvertedButton";
 import {
   OakModalCenter,
   OakModalCenterBody,
-  OakPrimaryButton,
-  OakPrimaryInvertedButton,
-} from "@/components/molecules";
+} from "@/components/molecules/OakModalCenter";
 import { OakFlex, OakHeading, OakP } from "@/components/atoms";
 
 const meta: Meta<typeof OakModalCenter> = {

--- a/src/components/molecules/OakModalCenter/OakModalCenterBody.tsx
+++ b/src/components/molecules/OakModalCenter/OakModalCenterBody.tsx
@@ -1,3 +1,11 @@
+/*
+ *
+ * FIXME: This component should either live in its own folder or
+ * or be renamed to SubModalCenterBody and be excluded from the exports
+ * as per the rules stated in src/docs/namingConventions.mdx
+ *
+ */
+
 import React, { ReactNode } from "react";
 
 import {

--- a/src/components/molecules/OakSignLanguageButton/OakSignLanguageButton.tsx
+++ b/src/components/molecules/OakSignLanguageButton/OakSignLanguageButton.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { OakSmallSecondaryButton } from "@/components/molecules";
+import { OakSmallSecondaryButton } from "@/components/molecules/OakSmallSecondaryButton";
 import { OakBox } from "@/components/atoms";
 
 type OakSignLanguageButtonProps = {

--- a/src/components/organisms/pupil/browse/OakPupilJourneyListItemSubheading/OakPupilJourneyListItemSubheading.stories.tsx
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyListItemSubheading/OakPupilJourneyListItemSubheading.stories.tsx
@@ -3,7 +3,7 @@ import { StoryObj, Meta } from "@storybook/react";
 
 import { OakPupilJourneyListItemSubheading } from "./OakPupilJourneyListItemSubheading";
 
-import { OakPupilJourneyListCounter } from "@/components/organisms";
+import { OakPupilJourneyListCounter } from "@/components/organisms/pupil/browse/OakPupilJourneyListCounter";
 
 const meta: Meta<typeof OakPupilJourneyListItemSubheading> = {
   component: OakPupilJourneyListItemSubheading,


### PR DESCRIPTION

When importing a sibling component (eg.  another molecule from inside molecules) the full path must be specified. Otherwise if the imported sibling component is exported after the current component an initialisation error will occur in storybook.

I have corrected the lines where this has occurred but we should consider adding automation to the ci/cd to check for this issue as VS code is very fond of adding these imports.

