### PR TITLE
Fix OakRadioAsButton state handling

### DIFF
--- a/src/components/atoms/InternalRadio/InternalRadio.test.tsx
+++ b/src/components/atoms/InternalRadio/InternalRadio.test.tsx
@@ -20,7 +20,11 @@ describe("InternalRadio", () => {
   it("matches snapshot", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
-        <InternalRadio id="radio-1" value="Option 1" />
+        <InternalRadio
+          id="radio-1"
+          name="internal-radio-group"
+          value="Option 1"
+        />
       </OakThemeProvider>,
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/src/components/atoms/InternalRadio/InternalRadio.tsx
+++ b/src/components/atoms/InternalRadio/InternalRadio.tsx
@@ -70,7 +70,6 @@ const BaseRadio = forwardRef(
         type="radio"
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        name={props.id}
         {...rest}
       />
     );

--- a/src/components/atoms/InternalRadio/__snapshots__/InternalRadio.test.tsx.snap
+++ b/src/components/atoms/InternalRadio/__snapshots__/InternalRadio.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`InternalRadio matches snapshot 1`] = `
 <input
   className="c0"
   id="radio-1"
-  name="radio-1"
+  name="internal-radio-group"
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
   type="radio"

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.test.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.test.tsx
@@ -123,6 +123,82 @@ describe("OakRadioAsButton", () => {
     expect(onChange).toHaveBeenCalledTimes(2);
   });
 
+  it("should update checked attribute in DOM", () => {
+    const { getAllByRole } = renderWithTheme(
+      <OakRadioGroup name="test-group" value="option1">
+        <OakRadioAsButton value="option1" displayValue="Option 1" />
+        <OakRadioAsButton value="option2" displayValue="Option 2" />
+      </OakRadioGroup>,
+    );
+
+    const radios = getAllByRole("radio") as HTMLInputElement[];
+    fireEvent.click(radios[0]!);
+
+    console.log("DOM checked states:", [radios[0]!.checked]);
+    expect(radios[0]!.checked).toBe(true);
+  });
+
+  it("should uncheck previous selection", () => {
+    const { getAllByRole } = renderWithTheme(
+      <OakRadioGroup name="test-group">
+        <OakRadioAsButton value="option1" displayValue="Option 1" />
+        <OakRadioAsButton value="option2" displayValue="Option 2" />
+      </OakRadioGroup>,
+    );
+
+    const radios = getAllByRole("radio") as HTMLInputElement[];
+
+    fireEvent.click(radios[0]!);
+    console.log("After first click:", [radios[0]!.checked, radios[1]!.checked]);
+
+    fireEvent.click(radios[1]!);
+    console.log("After second click:", [
+      radios[0]!.checked,
+      radios[1]!.checked,
+    ]);
+
+    expect(radios[0]!.checked).toBe(false);
+    expect(radios[1]!.checked).toBe(true);
+  });
+
+  it("should maintain single value in group", () => {
+    let groupValue = "";
+    const { getAllByRole } = renderWithTheme(
+      <OakRadioGroup
+        name="test-group"
+        onChange={(e) => (groupValue = e.target.value)}
+      >
+        <OakRadioAsButton value="option1" displayValue="Option 1" />
+        <OakRadioAsButton value="option2" displayValue="Option 2" />
+      </OakRadioGroup>,
+    );
+
+    fireEvent.click(getAllByRole("radio")[0]!);
+    console.log("Group value after first click:", groupValue);
+
+    fireEvent.click(getAllByRole("radio")[1]!);
+    console.log("Group value after second click:", groupValue);
+
+    expect(groupValue).toBe("option2");
+  });
+
+  it("should pass the correct value in onChange", () => {
+    let lastValue = "";
+    const { getAllByRole } = renderWithTheme(
+      <OakRadioGroup
+        name="test-group"
+        onChange={(e) => (lastValue = e.target.value)}
+      >
+        <OakRadioAsButton value="option1" displayValue="Option 1" />
+        <OakRadioAsButton value="option2" displayValue="Option 2" />
+      </OakRadioGroup>,
+    );
+
+    fireEvent.click(getAllByRole("radio")[1]!);
+    console.log("Last received value:", lastValue);
+    expect(lastValue).toBe("option2");
+  });
+
   it("inputs to have name of radio group", () => {
     const onChange = jest.fn();
     const { getAllByRole, getByRole } = renderWithTheme(

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.test.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.test.tsx
@@ -134,7 +134,6 @@ describe("OakRadioAsButton", () => {
     const radios = getAllByRole("radio") as HTMLInputElement[];
     fireEvent.click(radios[0]!);
 
-    console.log("DOM checked states:", [radios[0]!.checked]);
     expect(radios[0]!.checked).toBe(true);
   });
 
@@ -149,13 +148,7 @@ describe("OakRadioAsButton", () => {
     const radios = getAllByRole("radio") as HTMLInputElement[];
 
     fireEvent.click(radios[0]!);
-    console.log("After first click:", [radios[0]!.checked, radios[1]!.checked]);
-
     fireEvent.click(radios[1]!);
-    console.log("After second click:", [
-      radios[0]!.checked,
-      radios[1]!.checked,
-    ]);
 
     expect(radios[0]!.checked).toBe(false);
     expect(radios[1]!.checked).toBe(true);
@@ -174,10 +167,7 @@ describe("OakRadioAsButton", () => {
     );
 
     fireEvent.click(getAllByRole("radio")[0]!);
-    console.log("Group value after first click:", groupValue);
-
     fireEvent.click(getAllByRole("radio")[1]!);
-    console.log("Group value after second click:", groupValue);
 
     expect(groupValue).toBe("option2");
   });
@@ -195,11 +185,10 @@ describe("OakRadioAsButton", () => {
     );
 
     fireEvent.click(getAllByRole("radio")[1]!);
-    console.log("Last received value:", lastValue);
     expect(lastValue).toBe("option2");
   });
 
-  it("inputs to have name of radio group", () => {
+  it("inputs to all have name of radio group", () => {
     const onChange = jest.fn();
     const { getAllByRole, getByRole } = renderWithTheme(
       <OakRadioGroup name="test">

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
@@ -88,7 +88,7 @@ export type OakRadioAsButtonProps = Omit<
 };
 
 /**
- * A radio input styled as a button, to be used within `<RadioGroup/>` this is
+ * A radio input styled as a button, to be used within `<OakRadioGroup/>` this is
  * the radio inputs version of `<OakSearchFilterCheckBox/>`
  *
  * ## Events

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
@@ -85,6 +85,7 @@ export type OakRadioAsButtonProps = Omit<
   value?: HTMLInputElement["value"];
   "aria-labelledby"?: React.AriaAttributes["aria-labelledby"];
   "aria-label"?: React.AriaAttributes["aria-label"];
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 /**
@@ -110,8 +111,9 @@ export type OakRadioAsButtonProps = Omit<
  */
 export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
   const id = useId();
-  const { value, disabled, innerRef, displayValue, icon, ...rest } = props;
-  const { name } = useContext(RadioContext);
+  const { value, disabled, innerRef, displayValue, icon, onChange, ...rest } =
+    props;
+  const { name, onValueUpdated } = useContext(RadioContext);
 
   const defaultRef = useRef<HTMLInputElement>(null);
   const inputRef = innerRef ?? defaultRef;
@@ -137,6 +139,10 @@ export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
           value={value}
           disabled={disabled}
           ref={inputRef}
+          onChange={(e) => {
+            onValueUpdated?.(e);
+            onChange?.(e);
+          }}
           {...rest}
           name={name}
         />

--- a/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
@@ -171,6 +171,7 @@ exports[`OakRadioAsButton matches snapshot 1`] = `
         className="c5 c6"
         id=":r0:"
         name="default"
+        onChange={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         type="radio"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

The radio button group was not maintaining correct state when individual radio buttons were selected, leading to behaviour to onChange behaviour not working.

To resolve this I properly connected the individual radio buttons (`OakRadioAsButton`) to the radio group's context management system by:
1. Consuming the `RadioContext` in `OakRadioAsButton`
2. Implementing a chained onChange handler that updates both group and component state
3. Maintaining correct execution order of event handlers

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
