### PR TITLE
Allow `<OakRadioAsButton/>` to accept `value` from `<OakRadioGroup/>`

### DIFF
--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.stories.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.stories.tsx
@@ -22,7 +22,11 @@ export default meta;
 type Story = StoryObj<typeof OakRadioAsButton>;
 
 export const Default: Story = {
-  render: (args) => <OakRadioAsButton {...args} />,
+  render: (args) => (
+    <OakRadioGroup name="test">
+      <OakRadioAsButton {...args} />
+    </OakRadioGroup>
+  ),
   args: {
     value: "a test value",
     displayValue: "Art and design",
@@ -36,7 +40,11 @@ export const Default: Story = {
 };
 
 export const NoIcon: Story = {
-  render: (args) => <OakRadioAsButton {...args} />,
+  render: (args) => (
+    <OakRadioGroup name="test">
+      <OakRadioAsButton {...args} />
+    </OakRadioGroup>
+  ),
   args: {
     value: "a test value",
     displayValue: "Art and design",
@@ -50,6 +58,11 @@ export const NoIcon: Story = {
 };
 
 export const WithAriaLabel: Story = {
+  render: (args) => (
+    <OakRadioGroup name="test">
+      <OakRadioAsButton {...args} />
+    </OakRadioGroup>
+  ),
   args: {
     name: "radio-1",
     value: "Option 1",
@@ -65,12 +78,12 @@ export const WithAriaLabelledBy: Story = {
       <h2 id="subject-label">Choose a subject</h2>
       <OakRadioGroup name="test" aria-labelledby="subject-label">
         <OakRadioAsButton
-          value="Option 1"
+          value="option_1"
           displayValue="Biology"
           icon="subject-biology"
         />
         <OakRadioAsButton
-          value="Option 1"
+          value="option_2"
           displayValue="Biology"
           icon="subject-biology"
         />
@@ -165,34 +178,36 @@ export const KeepIconColor: Story = {
           {...restArgs}
           displayValue="Art and design"
           icon="subject-art"
+          value="art"
         />
         <OakRadioAsButton
           {...restArgs}
           displayValue="Biology"
           icon="subject-biology"
+          value="biology"
         />
         <OakRadioAsButton
           {...restArgs}
           displayValue="Chemistry"
           icon="subject-chemistry"
+          value="chemistry"
         />
         <OakRadioAsButton
           {...restArgs}
           displayValue="Physics"
           icon="subject-physics"
+          value="physics"
         />
         <OakRadioAsButton
           {...restArgs}
           displayValue="Computing"
           icon="subject-computing"
+          value="computing"
         />
       </OakRadioGroup>
     );
   },
   args: {
-    value: "a test value",
-    displayValue: "Lessons",
-    icon: "teacher-unit",
     keepIconColor: true,
   },
   parameters: {

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.stories.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.stories.tsx
@@ -115,6 +115,43 @@ export const MultipleOptions: Story = {
   ),
 };
 
+export const MultipleOptionsWithInitialValueSet: Story = {
+  render: () => (
+    <OakRadioGroup
+      name="subjects"
+      aria-label="Choose a subject"
+      $flexWrap={"wrap"}
+      value={"physics"}
+    >
+      <OakRadioAsButton
+        value="art"
+        displayValue="Art and design"
+        icon="subject-art"
+      />
+      <OakRadioAsButton
+        value="biology"
+        displayValue="Biology"
+        icon="subject-biology"
+      />
+      <OakRadioAsButton
+        value="chemistry"
+        displayValue="Chemistry"
+        icon="subject-chemistry"
+      />
+      <OakRadioAsButton
+        value="physics"
+        displayValue="Physics"
+        icon="subject-physics"
+      />
+      <OakRadioAsButton
+        value="computing"
+        displayValue="Computing"
+        icon="subject-computing"
+      />
+    </OakRadioGroup>
+  ),
+};
+
 export const KeepIconColor: Story = {
   render: (args) => {
     const { "aria-labelledby": _, ...restArgs } = args;

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.test.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.test.tsx
@@ -149,9 +149,8 @@ describe("OakRadioAsButton", () => {
 
     fireEvent.click(radios[0]!);
     fireEvent.click(radios[1]!);
-
-    expect(radios[0]!.checked).toBe(false);
-    expect(radios[1]!.checked).toBe(true);
+    expect(radios[0]).not.toBeChecked();
+    expect(radios[1]).toBeChecked();
   });
 
   it("should maintain single value in group", () => {

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.test.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import React, { createRef } from "react";
+import React from "react";
 import { create } from "react-test-renderer";
 import { fireEvent } from "@testing-library/react";
 
@@ -214,6 +214,35 @@ describe("OakRadioAsButton", () => {
     expect(radios[1]).toHaveAttribute("name", "test");
   });
 
+  it("radio group value sets the correct input to checked", () => {
+    const { getAllByRole, getByRole } = renderWithTheme(
+      <OakRadioGroup name="test" value="option_2">
+        <OakRadioAsButton
+          value="option_1"
+          icon={"subject-history"}
+          displayValue="Option 1"
+        />
+        <OakRadioAsButton
+          value="option_2"
+          icon={"subject-biology"}
+          displayValue="Option 2"
+        />
+        <OakRadioAsButton
+          value="option_3"
+          icon={"subject-biology"}
+          displayValue="Option 3"
+        />
+      </OakRadioGroup>,
+    );
+    const radioGroup = getByRole("radiogroup");
+    const radios = getAllByRole("radio");
+    expect(radios).toHaveLength(3);
+    expect(radioGroup);
+    expect(radios[0]).not.toBeChecked();
+    expect(radios[1]).toBeChecked();
+    expect(radios[2]).not.toBeChecked();
+  });
+
   it("calls onFocus when focused", () => {
     const onFocus = jest.fn();
     const { getByRole } = renderWithTheme(
@@ -277,19 +306,34 @@ describe("OakRadioAsButton", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it("can be checked and unchecked using a ref", () => {
-    const ref = createRef<HTMLInputElement>();
-    const { getByRole } = renderWithTheme(
-      <OakRadioAsButton
-        name="radio-1"
-        value="Option 1"
-        innerRef={ref}
-        icon={"subject-history"}
-        displayValue="Option 1"
-      />,
+  it("clicking radio triggers onChange", async () => {
+    const onChange = jest.fn();
+    const { getAllByRole } = renderWithTheme(
+      <OakRadioGroup name="test" onChange={onChange}>
+        <OakRadioAsButton
+          value="option_1"
+          icon={"subject-history"}
+          displayValue="Option 1"
+        />
+        <OakRadioAsButton
+          value="option_2"
+          icon={"subject-biology"}
+          displayValue="Option 2"
+        />
+        <OakRadioAsButton
+          value="option_3"
+          icon={"subject-biology"}
+          displayValue="Option 3"
+        />
+      </OakRadioGroup>,
     );
-    ref.current?.click();
-    expect(getByRole("radio")).toBeChecked();
+    getAllByRole("radio")[1]?.click();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ value: "option_2" }),
+      }),
+    );
   });
 
   it("renders with aria-label attribute", () => {

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
@@ -146,8 +146,6 @@ export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
       >
         <StyledInternalRadio
           {...rest}
-          // This is a HACK to force a DOM update because of some chrome rendering issues
-          key={isChecked ? "checked" : "not-checked"}
           id={id}
           value={value}
           disabled={disabled}
@@ -157,7 +155,7 @@ export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
             onChange?.(e);
           }}
           name={name}
-          checked={isChecked}
+          defaultChecked={isChecked}
         />
         {icon && <StyledOakIcon alt="" iconName={icon} />}
         <InternalCheckBoxLabelHoverDecor

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
@@ -113,13 +113,22 @@ export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
   const id = useId();
   const { value, disabled, innerRef, displayValue, icon, onChange, ...rest } =
     props;
-  const { name, onValueUpdated } = useContext(RadioContext);
+  const { name, onValueUpdated, currentValue } = useContext(RadioContext);
 
   const defaultRef = useRef<HTMLInputElement>(null);
   const inputRef = innerRef ?? defaultRef;
 
-  const handleContainerClick = () => {
-    inputRef.current?.click();
+  const handleContainerClick = (
+    e:
+      | React.MouseEvent<HTMLDivElement>
+      | React.MouseEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLLabelElement>,
+  ) => {
+    const el = e.target as HTMLInputElement;
+
+    if (!el.isEqualNode(inputRef.current)) {
+      inputRef.current?.click();
+    }
   };
 
   return (
@@ -135,6 +144,7 @@ export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
         $gap={"space-between-sssx"}
       >
         <StyledInternalRadio
+          {...rest}
           id={id}
           value={value}
           disabled={disabled}
@@ -143,8 +153,8 @@ export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
             onValueUpdated?.(e);
             onChange?.(e);
           }}
-          {...rest}
           name={name}
+          checked={currentValue === value}
         />
         {icon && <StyledOakIcon alt="" iconName={icon} />}
         <InternalCheckBoxLabelHoverDecor

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
@@ -74,14 +74,13 @@ const StyledFlexBox = styled(OakFlex)`
 
 export type OakRadioAsButtonProps = Omit<
   BaseRadioProps,
-  "defaultChecked" | "id"
+  "defaultChecked" | "id" | "checked"
 > & {
   innerRef?: React.RefObject<HTMLInputElement>;
   displayValue: string;
   icon?: OakIconName;
   keepIconColor?: boolean;
   disabled?: HTMLInputElement["disabled"];
-  checked?: HTMLInputElement["checked"];
   value?: HTMLInputElement["value"];
   "aria-labelledby"?: React.AriaAttributes["aria-labelledby"];
   "aria-label"?: React.AriaAttributes["aria-label"];
@@ -131,6 +130,8 @@ export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
     }
   };
 
+  const isChecked = currentValue === value;
+
   return (
     <OakFlex $minHeight={"all-spacing-8"} $position={"relative"}>
       <StyledFlexBox
@@ -145,6 +146,8 @@ export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
       >
         <StyledInternalRadio
           {...rest}
+          // This is a HACK to force a DOM update because of some chrome rendering issues
+          key={isChecked ? "checked" : "not-checked"}
           id={id}
           value={value}
           disabled={disabled}
@@ -154,7 +157,7 @@ export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
             onChange?.(e);
           }}
           name={name}
-          checked={currentValue === value}
+          checked={isChecked}
         />
         {icon && <StyledOakIcon alt="" iconName={icon} />}
         <InternalCheckBoxLabelHoverDecor

--- a/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
@@ -168,8 +168,8 @@ exports[`OakRadioAsButton matches snapshot 1`] = `
       onClick={[Function]}
     >
       <input
-        checked={false}
         className="c5 c6"
+        defaultChecked={false}
         id=":r0:"
         name="default"
         onChange={[Function]}

--- a/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
@@ -168,6 +168,7 @@ exports[`OakRadioAsButton matches snapshot 1`] = `
       onClick={[Function]}
     >
       <input
+        checked={false}
         className="c5 c6"
         id=":r0:"
         name="default"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Allows `<OakRadioAsButton/>` to controlled by props from `<OakRadioGroup/>` for example

```jsx
<OakRadioGroup value={"two"}>
  <OakRadioAsButton value="one" />
  <OakRadioAsButton value="two" /> {/* <==== this will be checked */}
  <OakRadioAsButton value="three" />
</OakRadioGroup/>
```

## Testing instructions
Test that `<OakRadioAsButton/>` behaves as a dev would expect when wrapped in `<OakRadioGroup/>` 
