### PR TITLE
ENG-1129: Update the SonarQube action in GitHub workflows

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm run check-types
       - run: npm run test:ci
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Update the SonarQube action in GitHub workflows

The `SonarSource/sonarcloud-github-action` is deprecated. The newer, drop in replacement, `SonarSource/sonarqube-scan-action` is available.

- Moved from `sonarcloud-github-action` to `sonarqube-scan-action`
- Moved from using `master` as a version to a specific version (to stop any breaking changes immediately impacting project workflows)

## Issue(s)

Fixes ENG-1129

## How to test

1. Check SonarQube scans are running successfully.