### PR TITLE
Add typography props to code renderer

### DIFF
--- a/src/components/molecules/OakCodeRenderer/OakCodeRenderer.tsx
+++ b/src/components/molecules/OakCodeRenderer/OakCodeRenderer.tsx
@@ -3,12 +3,17 @@ import styled from "styled-components";
 
 import { OakBox, OakFlex, OakSpan } from "@/components/atoms";
 import { OakCombinedColorToken } from "@/styles";
+import { TypographyStyleProps } from "@/styles/utils/typographyStyle";
 
 const StyledCodeContainer = styled(OakBox)`
   font-family: "Roboto Mono", --font-roboto-mono, monospace;
 `;
 
-export const OakCodeRenderer = ({ string }: { string: string }) => {
+export type OakCodeRendererProps = {
+  string: string;
+} & TypographyStyleProps;
+
+export const OakCodeRenderer = ({ string, ...rest }: OakCodeRendererProps) => {
   const findAndStyleInlineCode = (text: string) => {
     const parts = text.split(/(`.*?`)/); // Matches text enclosed in backticks
     if (parts.length === 1 && !text.startsWith("`")) {
@@ -29,6 +34,7 @@ export const OakCodeRenderer = ({ string }: { string: string }) => {
                 $borderRadius={"border-radius-m2"}
                 $display={"inline-block"}
                 $font={["code-2", "code-1"]}
+                {...rest}
               >
                 {part.slice(1, -1)}
               </StyledCodeContainer>

--- a/src/components/organisms/pupil/lesson/OakLessonBottomNav/OakLessonBottomNav.stories.tsx
+++ b/src/components/organisms/pupil/lesson/OakLessonBottomNav/OakLessonBottomNav.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { OakLessonBottomNav } from "./OakLessonBottomNav";
 
 import { OakFlex } from "@/components/atoms";
-import { OakPrimaryButton } from "@/components/molecules";
+import { OakPrimaryButton, OakCodeRenderer } from "@/components/molecules";
 
 const meta: Meta<typeof OakLessonBottomNav> = {
   component: OakLessonBottomNav,
@@ -149,5 +149,28 @@ export const WithNoAnswerFeedbackAndButton: Story = {
   ),
   args: {
     feedback: "incorrect",
+  },
+};
+
+export const FeedbackWithCode: Story = {
+  render: (args) => (
+    <OakLessonBottomNav {...args}>
+      <OakPrimaryButton
+        iconName="arrow-right"
+        isTrailingIcon
+        width={["100%", "max-content"]}
+      >
+        Next question
+      </OakPrimaryButton>
+    </OakLessonBottomNav>
+  ),
+  args: {
+    feedback: "incorrect",
+    answerFeedback: (
+      <OakCodeRenderer
+        string={"Correct answer: Is it `true`?"}
+        $font={"code-3"}
+      />
+    ),
   },
 };

--- a/src/components/organisms/pupil/quiz/OakQuizHint/OakQuizHint.stories.tsx
+++ b/src/components/organisms/pupil/quiz/OakQuizHint/OakQuizHint.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import { OakQuizHint } from "./OakQuizHint";
 
+import { OakCodeRenderer } from "@/components/molecules";
 import { OakBox } from "@/components/atoms";
 
 const meta: Meta<typeof OakQuizHint> = {
@@ -34,4 +35,12 @@ type Story = StoryObj<typeof OakQuizHint>;
 
 export const Default: Story = {
   render: (args) => <OakQuizHint {...args} />,
+};
+
+const hintWithCode = (
+  <OakCodeRenderer string={"Is it `true`?"} $font={"code-3"} />
+);
+
+export const WithCode: Story = {
+  render: () => <OakQuizHint hint={hintWithCode} id="test-id" />,
 };


### PR DESCRIPTION
# How to review this PR

# Add your PR description below

Add typography props to code renderer (this needs to be done for the OWA PR for https://www.notion.so/oaknationalacademy/Oak-Components-Update-OakQuizFeedback-and-OakQuizHint-to-use-CodeRender-Code-in-quizzes-Pupil-view-17c26cc4e1b180afae83d4e4fad933aa)

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

Bottom example in storybook here:
https://deploy-preview-372--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-pupil-quiz-oakquizhint--docs

and bottom onein this one:
https://deploy-preview-372--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-pupil-lesson-oaklessonbottomnav--docs

## ACs
