### PR TITLE
feat: add english language svg to image map

### DIFF
--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -89,6 +89,7 @@ export const icons = {
     "v1706616417/subject-icons/design-technology.svg",
   "subject-drama": "v1706616417/subject-icons/drama.svg",
   "subject-english": "v1706616417/subject-icons/english.svg",
+  "subject-english-language": "v1706616419/subject-icons/language.svg",
   "subject-english-grammar": "v1706616417/subject-icons/english-grammar.svg",
   "subject-english-handwriting": "v1706616419/subject-icons/handwriting.svg",
   "subject-english-reading-for-pleasure":


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Updated the image map to include the omitted english language SVG

## Link to the design doc

## A link to the component in the deployment preview

https://deploy-preview-374--lively-meringue-8ebd43.netlify.app/?path=/docs/components-atoms-oakicon--docs

## Testing instructions

Visit the OakIcon component on the deployment URL and you should see the newly updated icons added to the image map

## ACs
