### PR TITLE
fix: carousel stretches to fit container

### DIFF
--- a/src/components/molecules/OakCarousel/OakCarousel.tsx
+++ b/src/components/molecules/OakCarousel/OakCarousel.tsx
@@ -67,6 +67,8 @@ export const OakCarousel = ({
       $gap={"space-between-xl"}
       role="region"
       aria-label={containerLabel}
+      $height={"100%"}
+      $justifyContent={"space-between"}
     >
       <OakFlex $overflow={"hidden"}>
         <SlideContainer activeIndex={activeIndex} $transition={"standard-ease"}>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs

[x] - the carousel stretches to fill its conainer vertically and spreads it's internal elements to fit the space
