### PR TITLE
Feat/lesq 1284/unit title casing [LESQ-1284]

### DIFF
--- a/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
@@ -422,7 +422,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
         <h2
           className="c7"
         >
-          Maths units
+          maths units
         </h2>
         <div
           className="c8 c9 c10"

--- a/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
+++ b/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
@@ -37,9 +37,6 @@ const CurriculumDownloadButton = (
 const UnstyledComponent = (props: OakUnitsHeaderProps) => {
   const { subject, isLegacy, phase, curriculumHref: href, ...rest } = props;
 
-  const sentenceCaseSubject =
-    subject.slice(0, 1).toUpperCase() + subject.slice(1).toLowerCase();
-
   const subheading = isLegacy
     ? "Resources made during the pandemic to support remote teaching."
     : "Brand-new teaching resources, thoughtfully crafted by teachers for classroom needs.";
@@ -55,9 +52,7 @@ const UnstyledComponent = (props: OakUnitsHeaderProps) => {
       <OakFlex $gap="space-between-ssx" $flexDirection="column">
         <OakFlex $gap="space-between-ssx">
           <OakHeading $font="heading-5" tag="h2" $color={"text-primary"}>
-            {isLegacy
-              ? "Units released in 2020-22"
-              : `${sentenceCaseSubject} units`}
+            {isLegacy ? "Units released in 2020-22" : `${subject} units`}
           </OakHeading>
           {!isLegacy && <OakPromoTag />}
         </OakFlex>

--- a/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
@@ -373,7 +373,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
       <h2
         className="c4"
       >
-        Maths units
+        maths units
       </h2>
       <div
         className="c5 c6 c7"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- update OakUnitsHeader to remove manual conversion of subject to sentence case, the component should display the subject as passed in so that eg. RSHE can be rendered in all caps

## A link to the component in the deployment preview
https://deploy-preview-381--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-teacher-oakunitsheader--docs

## Testing instructions
Change the `subject` param in the preview, it should render the heading as written rather than converted to sentence case 

