### PR TITLE
CTC-155: align OakLink with icon

### DIFF
--- a/src/components/molecules/InternalLink/InternalLink.tsx
+++ b/src/components/molecules/InternalLink/InternalLink.tsx
@@ -23,7 +23,7 @@ const StyledLink = styled.a<{
   $activeColor: OakCombinedColorToken;
   $disabledColor: OakCombinedColorToken;
 }>`
-  display: inline-flex;
+  display: inline;
   align-items: center;
   gap: ${parseSpacing("space-between-sssx")};
   outline: none;
@@ -40,6 +40,8 @@ const StyledLink = styled.a<{
 
   ${StyledOakIcon} {
     filter: ${(props) => parseColorFilter(props.$color)};
+    display: inline-block;
+    vertical-align: bottom;
   }
 
   &:focus-visible {

--- a/src/components/molecules/InternalLink/InternalLink.tsx
+++ b/src/components/molecules/InternalLink/InternalLink.tsx
@@ -10,7 +10,7 @@ import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 import { parseBorderRadius } from "@/styles/helpers/parseBorderRadius";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
-import { OakFlex, OakIcon, OakIconProps, OakSpan } from "@/components/atoms";
+import { OakBox, OakIcon, OakIconProps, OakSpan } from "@/components/atoms";
 import { parseColorFilter } from "@/styles/helpers/parseColorFilter";
 import { OakAllSpacingToken, OakCombinedColorToken } from "@/styles";
 
@@ -141,17 +141,16 @@ export const InternalLink: InternalLinkComponent = forwardRef(
       switch (true) {
         case isLoading:
           return (
-            <OakFlex
+            <OakBox
               $width="all-spacing-6"
               $height="all-spacing-6"
-              $alignItems="center"
-              $justifyContent="center"
+              $display={"inline-block"}
             >
               <OakLoadingSpinner
                 $width="all-spacing-4"
                 $color="icon-inverted"
               />
-            </OakFlex>
+            </OakBox>
           );
         case !!iconName:
           return (

--- a/src/components/molecules/InternalLink/__snapshots__/InternalLink.test.tsx.snap
+++ b/src/components/molecules/InternalLink/__snapshots__/InternalLink.test.tsx.snap
@@ -6,10 +6,7 @@ exports[`InternalLink matches snapshot 1`] = `
 }
 
 .c0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/molecules/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
+++ b/src/components/molecules/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
@@ -283,10 +283,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
 }
 
 .c7 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -278,10 +278,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
 }
 
 .c21 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/molecules/OakLink/OakLink.stories.tsx
+++ b/src/components/molecules/OakLink/OakLink.stories.tsx
@@ -3,16 +3,33 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import { OakLink } from "./OakLink";
 
+import { oakIconNames } from "@/components/atoms";
+import { oakAllSpacingTokens } from "@/styles/theme/spacing";
+
+const controlIconNames = [...oakIconNames].sort((a, b) => a.localeCompare(b));
+
 const meta: Meta<typeof OakLink> = {
   component: OakLink,
   tags: ["autodocs"],
   title: "components/molecules/OakLink",
   argTypes: {
     children: { type: "string" },
+    iconName: {
+      options: controlIconNames,
+    },
+    isTrailingIcon: { type: "boolean" },
+    iconHeight: { options: [...Object.keys(oakAllSpacingTokens)] },
+    iconWidth: { options: [...Object.keys(oakAllSpacingTokens)] },
   },
   parameters: {
     controls: {
-      include: ["children", "iconName"],
+      include: [
+        "children",
+        "iconName",
+        "isTrailingIcon",
+        "iconHeight",
+        "iconWidth",
+      ],
     },
   },
   args: {
@@ -69,11 +86,11 @@ export const Loading: Story = {
 
 export const WithIconSizeProps: Story = {
   args: {
-    element: "button",
-    children: "External link with smaller icon",
+    element: "a",
+    children: "External link with icon size props",
     isTrailingIcon: true,
     iconName: "external",
-    iconHeight: "all-spacing-4",
-    iconWidth: "all-spacing-4",
+    iconHeight: "all-spacing-6",
+    iconWidth: "all-spacing-6",
   },
 };

--- a/src/components/molecules/OakLink/__snapshots__/OakLink.test.tsx.snap
+++ b/src/components/molecules/OakLink/__snapshots__/OakLink.test.tsx.snap
@@ -6,10 +6,7 @@ exports[`OakLink matches snapshot 1`] = `
 }
 
 .c0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/molecules/OakSecondaryLink/__snapshots__/OakSecondaryLink.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryLink/__snapshots__/OakSecondaryLink.test.tsx.snap
@@ -6,10 +6,7 @@ exports[`OakSecondaryLink matches snapshot 1`] = `
 }
 
 .c0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/organisms/shared/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
+++ b/src/components/organisms/shared/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
@@ -216,10 +216,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 .c10 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/organisms/shared/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
+++ b/src/components/organisms/shared/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
@@ -216,10 +216,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 .c10 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/organisms/shared/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
+++ b/src/components/organisms/shared/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
@@ -271,10 +271,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c8 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -66,10 +66,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
 }
 
 .c2 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
@@ -540,10 +540,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 }
 
 .c55 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
@@ -29,10 +29,7 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
 }
 
 .c4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

[CTC-155](https://www.notion.so/oaknationalacademy/Update-post-download-message-19826cc4e1b18026a54bcb8aae8c057c)

Amend alignment on `OakLink` when used with icon (didn't work when link was inside text and it wrapped in more than one line) - needed for a ticket in OWA

## Link to the design doc

## A link to the component in the deployment preview

https://deploy-preview-382--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oaklink--docs

## Testing instructions

1. Go to https://deploy-preview-382--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oaklink--docs
2. The `OakLink` should be aligned correctly with both icon and without it

## ACs
