### PR TITLE
feat: add new looping line icon to image map

### DIFF
--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -171,6 +171,7 @@ export const icons = {
   "looping-line-2": "v1734536933/OWA/ui-graphics/looping-line-2_sdinei.svg",
   "looping-line-3": "v1734537015/OWA/ui-graphics/looping-line-3_b8dque.svg",
   "looping-line-4": "v1734537039/OWA/ui-graphics/looping-line-4_xtjj4r.svg",
+  "looping-line-5": "v1740665310/OWA/ui-graphics/looping-line-5_vdknco.svg",
   "speech-bubble": "v1734537300/OWA/ui-graphics/speech-bubble_magqjf.svg",
   "tag-promotional": "v1734537244/OWA/ui-graphics/tag-promotional_v4p3oa.svg",
   "tick-mark-happiness":


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

- Added a new looping-line icon to the image map

## Link to the design doc

[Ticket](https://www.notion.so/oaknationalacademy/Add-image-squiggle-to-landing-page-17326cc4e1b18032a475e08cbb32b684?pvs=4)

## A link to the component in the deployment preview

[Link](https://deploy-preview-386--lively-meringue-8ebd43.netlify.app/?path=/docs/components-atoms-oakicon--docs)

## Testing instructions

Check that looping-line-icon 5 appears under the OakIcon component in Storybook

## ACs
