### PR TITLE
Replace `defaultChecked` with `checked` in `<OakRadioAsButton/>`

### DIFF
--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.test.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.test.tsx
@@ -349,4 +349,26 @@ describe("OakRadioAsButton", () => {
     const radioButton = getByRole("radio");
     expect(radioButton).toHaveAttribute("aria-label", "History");
   });
+
+  it("setting value should change selection", () => {
+    const { getAllByRole, rerender } = renderWithTheme(
+      <OakRadioGroup name="test-group" value="option1">
+        <OakRadioAsButton value="option1" displayValue="Option 1" />
+        <OakRadioAsButton value="option2" displayValue="Option 2" />
+      </OakRadioGroup>,
+    );
+
+    const radios1 = getAllByRole("radio") as HTMLInputElement[];
+    expect(radios1[0]).toBeChecked();
+
+    rerender(
+      <OakRadioGroup name="test-group" value="option2">
+        <OakRadioAsButton value="option1" displayValue="Option 1" />
+        <OakRadioAsButton value="option2" displayValue="Option 2" />
+      </OakRadioGroup>,
+    );
+
+    const radios2 = getAllByRole("radio") as HTMLInputElement[];
+    expect(radios2[1]).toBeChecked();
+  });
 });

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
@@ -155,7 +155,7 @@ export const OakRadioAsButton = (props: OakRadioAsButtonProps) => {
             onChange?.(e);
           }}
           name={name}
-          defaultChecked={isChecked}
+          checked={isChecked}
         />
         {icon && <StyledOakIcon alt="" iconName={icon} />}
         <InternalCheckBoxLabelHoverDecor

--- a/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
@@ -168,8 +168,8 @@ exports[`OakRadioAsButton matches snapshot 1`] = `
       onClick={[Function]}
     >
       <input
+        checked={false}
         className="c5 c6"
-        defaultChecked={false}
         id=":r0:"
         name="default"
         onChange={[Function]}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Replace `defaultChecked` with `checked` in `<OakRadioAsButton/>` to fix state issues with setting state with `<OakRadioGroup/>`

## Testing instructions
Check over the new test/assertions and check that setting `value` on the `<OakRadioGroup/>` does indeed change the currently checked item. 

## ACs

 - [ ] Changing the value of `<OakRadioGroup/>` changes the checked state of `<OakRadioAsButton/>`