### PR TITLE
[PUPIL-1220] Add 'non-curriculum' option to OakPupilJourneySubjectButton and update icon mapping

### DIFF
--- a/src/components/molecules/OakLinkCard/OakLinkCard.stories.tsx
+++ b/src/components/molecules/OakLinkCard/OakLinkCard.stories.tsx
@@ -67,7 +67,7 @@ const meta: Meta<typeof OakLinkCard> = {
         </OakTertiaryButton>
       </OakFlex>
     ),
-    iconName: "subject-finance",
+    iconName: "subject-financial-education",
     iconAlt: "Illustration of persons head with finance ideas",
     iconColor: "black",
     iconFill: "bg-decorative1-main",

--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/OakPupilJourneySubjectButton.stories.tsx
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/OakPupilJourneySubjectButton.stories.tsx
@@ -7,7 +7,10 @@ const meta: Meta<typeof OakPupilJourneySubjectButton> = {
   component: OakPupilJourneySubjectButton,
   tags: ["autodocs"],
   argTypes: {
-    phase: { control: { type: "radio" }, options: ["primary", "secondary"] },
+    phase: {
+      control: { type: "radio" },
+      options: ["primary", "secondary", "non-curriculum"],
+    },
     subjectIconName: { control: { type: "text" } },
     disabled: { control: { type: "boolean" } },
     subjectText: { control: { type: "text" } },

--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/OakPupilJourneySubjectButton.tsx
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/OakPupilJourneySubjectButton.tsx
@@ -6,9 +6,10 @@ import {
 } from "@/components/molecules/InternalShadowRectButton";
 import { PolymorphicPropsWithoutRef } from "@/components/polymorphic";
 import { OakIcon, OakIconName } from "@/components/atoms";
+import { OakCombinedColorToken } from "@/styles";
 
 export type OakPupilJourneySubjectButtonProps = {
-  phase: "primary" | "secondary";
+  phase: "primary" | "secondary" | "non-curriculum";
   subjectIconName: OakIconName;
 } & Omit<
   InternalShadowRectButtonProps,
@@ -47,16 +48,26 @@ export const OakPupilJourneySubjectButton = <C extends ElementType = "button">({
   subjectIconName,
   ...rest
 }: OakPupilJourneySubjectButtonProps & PolymorphicPropsWithoutRef<C>) => {
-  const defaultBackground =
-    phase === "primary"
-      ? "bg-decorative4-very-subdued"
-      : "bg-decorative3-very-subdued";
-  const hoverBackground =
-    phase === "primary" ? "bg-decorative4-main" : "bg-decorative3-main";
-  const borderColor =
-    phase === "primary"
-      ? "border-decorative4-stronger"
-      : "border-decorative3-stronger";
+  let defaultBackground: OakCombinedColorToken,
+    hoverBackground: OakCombinedColorToken,
+    borderColor: OakCombinedColorToken;
+  switch (phase) {
+    case "primary":
+      defaultBackground = "bg-decorative4-very-subdued";
+      hoverBackground = "bg-decorative4-main";
+      borderColor = "border-decorative4-stronger";
+      break;
+    case "non-curriculum":
+      defaultBackground = "bg-decorative1-very-subdued";
+      hoverBackground = "bg-decorative1-main";
+      borderColor = "border-decorative1-stronger";
+      break;
+    default:
+      defaultBackground = "bg-decorative3-very-subdued";
+      hoverBackground = "bg-decorative3-main";
+      borderColor = "border-decorative3-stronger";
+      break;
+  }
 
   const iconOverride = (
     <OakIcon

--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -100,7 +100,7 @@ export const icons = {
   "subject-english-vocabulary": "v1706616425/subject-icons/vocabulary.svg",
   "subject-expressive-arts-and-design":
     "v1706616415/subject-icons/creative-arts.svg",
-  "subject-finance": "v1729171111/subject-icons/finance.svg",
+  "subject-financial-education": "v1729171111/subject-icons/finance.svg",
   "subject-french": "v1729171111/subject-icons/french.svg",
   "subject-geography": "v1734523108/subject-icons/geography.svg",
   "subject-german": "v1734523165/subject-icons/german.svg",


### PR DESCRIPTION

# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

This adds in an extra option for the OakPupilJourneySubjectButton. 

I have also updated the finance icon mapping as the subject slug looks like it is going to be "financial-education"

## Link to the design doc

https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=8880-3396&m=dev

## A link to the component in the deployment preview

## Testing instructions

Check that colours match when the component is set to 'non-curriculum'

## ACs
