### PR TITLE
[PUPIL-1226] add 'narrow' prop to OakLinkCard, fix type on OakTertiaryButton

### DIFF
--- a/src/components/molecules/OakLinkCard/OakLinkCard.stories.tsx
+++ b/src/components/molecules/OakLinkCard/OakLinkCard.stories.tsx
@@ -34,6 +34,11 @@ const meta: Meta<typeof OakLinkCard> = {
     iconFill: {
       options: controlIconFillNames,
     },
+    narrow: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
   parameters: {
     controls: {
@@ -44,6 +49,7 @@ const meta: Meta<typeof OakLinkCard> = {
         "iconColor",
         "iconFill",
         "iconAlt",
+        "narrow",
       ],
     },
   },
@@ -57,12 +63,7 @@ const meta: Meta<typeof OakLinkCard> = {
           A series of lessons offering practical knowledge and skills, developed
           independently of the national curriculum.
         </OakP>
-        <OakTertiaryButton
-          element="a"
-          href="https://www.example.com"
-          iconName="chevron-right"
-          isTrailingIcon
-        >
+        <OakTertiaryButton iconName="chevron-right" isTrailingIcon>
           Go to new finance lessons
         </OakTertiaryButton>
       </OakFlex>
@@ -73,6 +74,7 @@ const meta: Meta<typeof OakLinkCard> = {
     iconFill: "bg-decorative1-main",
     href: "https://www.example.com",
     showNew: true,
+    narrow: false,
   },
 };
 
@@ -86,6 +88,7 @@ export const WithDifferentIcon: Story = {
   args: {
     iconName: "bell",
     showNew: false,
+    narrow: false,
   },
 };
 
@@ -105,12 +108,7 @@ export const WithLongText: Story = {
           financial literacy program. Learn how to budget, save, and invest your
           money. Get started today!
         </OakP>
-        <OakTertiaryButton
-          element="a"
-          href="https://www.example.com"
-          iconName="chevron-right"
-          isTrailingIcon
-        >
+        <OakTertiaryButton iconName="chevron-right" isTrailingIcon>
           Start learning
         </OakTertiaryButton>
       </OakFlex>

--- a/src/components/molecules/OakLinkCard/OakLinkCard.test.tsx
+++ b/src/components/molecules/OakLinkCard/OakLinkCard.test.tsx
@@ -34,6 +34,7 @@ describe("OakLinkCard", () => {
     iconAlt: "Books icon",
     href: testData.href,
     showNew: false,
+    narrow: false,
   };
 
   it("matches snapshot", () => {
@@ -48,6 +49,16 @@ describe("OakLinkCard", () => {
 
   it("renders correctly with default props", () => {
     renderWithTheme(<OakLinkCard {...defaultProps} />);
+
+    expect(screen.getByText(testData.headingText)).toBeInTheDocument();
+    expect(screen.getByText(testData.paragraphText)).toBeInTheDocument();
+
+    const linkElement = screen.getByRole("link");
+    expect(linkElement).toHaveAttribute("href", "https://www.example.com");
+  });
+
+  it("renders correctly with narrow props", () => {
+    renderWithTheme(<OakLinkCard {...defaultProps} narrow />);
 
     expect(screen.getByText(testData.headingText)).toBeInTheDocument();
     expect(screen.getByText(testData.paragraphText)).toBeInTheDocument();

--- a/src/components/molecules/OakLinkCard/OakLinkCard.tsx
+++ b/src/components/molecules/OakLinkCard/OakLinkCard.tsx
@@ -46,6 +46,10 @@ export type OakLinkCardProps = {
    * Whether to display the "New" promo tag in the top-left corner.
    */
   showNew?: boolean;
+  /**
+   * Whether to display the card in a narrow layout.
+   */
+  narrow?: boolean;
 };
 
 /**
@@ -60,6 +64,7 @@ export type OakLinkCardProps = {
  * - **iconFill** - Optional fill color for the icon
  * - **href** - Destination URL when the card is clicked
  * - **showNew** - Whether to display the "New" promo tag
+ * - **narrow** - Whether to display the card in a narrow layout
  */
 export const OakLinkCard = ({
   mainSection,
@@ -69,13 +74,14 @@ export const OakLinkCard = ({
   iconFill = "bg-decorative1-main",
   href,
   showNew = false,
+  narrow = false,
 }: OakLinkCardProps) => {
   return (
     <StyledOakFlexAsLink
       as="a"
       href={href}
-      $flexDirection={["column-reverse", "row"]}
-      $alignItems={["flex-start", "center"]}
+      $flexDirection={narrow ? "column-reverse" : ["column-reverse", "row"]}
+      $alignItems={narrow ? "flex-start" : ["flex-start", "center"]}
       $justifyContent="space-between"
       $gap={"space-between-m2"}
       $background="bg-primary"
@@ -90,16 +96,30 @@ export const OakLinkCard = ({
         <OakHandDrawnCardWithIcon
           iconName={iconName}
           alt={iconAlt}
-          $width={["all-spacing-13", "all-spacing-17"]}
-          $height={["all-spacing-13", "all-spacing-17"]}
+          iconWidth={
+            narrow ? ["all-spacing-11"] : ["all-spacing-11", "all-spacing-15"]
+          }
+          iconHeight={
+            narrow ? ["all-spacing-11"] : ["all-spacing-11", "all-spacing-15"]
+          }
+          $width={
+            narrow ? ["all-spacing-13"] : ["all-spacing-13", "all-spacing-17"]
+          }
+          $height={
+            narrow ? ["all-spacing-13"] : ["all-spacing-13", "all-spacing-17"]
+          }
           fill={iconFill}
           iconColor={iconColor}
         />
         {showNew && (
           <OakBox
             $position={"absolute"}
-            $top={["all-spacing-0", "all-spacing-2"]}
-            $left={["all-spacing-0", "all-spacing-2"]}
+            $top={
+              narrow ? ["all-spacing-0"] : ["all-spacing-0", "all-spacing-2"]
+            }
+            $left={
+              narrow ? ["all-spacing-0"] : ["all-spacing-0", "all-spacing-2"]
+            }
             data-testid="oak-new-promo-tag"
             $zIndex="in-front"
             aria-hidden="true"

--- a/src/components/molecules/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
+++ b/src/components/molecules/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
@@ -152,25 +152,25 @@ exports[`OakLinkCard matches snapshot 1`] = `
 
 @media (min-width:750px) {
   .c14 {
-    width: 7.5rem;
+    width: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
   .c14 {
-    min-width: 7.5rem;
+    min-width: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
   .c14 {
-    height: 7.5rem;
+    height: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
   .c14 {
-    min-height: 7.5rem;
+    min-height: 6.25rem;
   }
 }
 

--- a/src/components/molecules/OakTertiaryButton/OakTertiaryButton.tsx
+++ b/src/components/molecules/OakTertiaryButton/OakTertiaryButton.tsx
@@ -1,7 +1,10 @@
 import React, { ElementType } from "react";
 
 import { OakRoundIconProps } from "@/components/molecules/OakRoundIcon";
-import { InternalShadowRoundButton } from "@/components/molecules/InternalShadowRoundButton";
+import {
+  InternalShadowRoundButton,
+  InternalShadowRoundButtonProps,
+} from "@/components/molecules/InternalShadowRoundButton";
 import { OakIconName } from "@/components/atoms";
 import { InternalButtonProps } from "@/components/atoms/InternalButton";
 import { PolymorphicPropsWithoutRef } from "@/components/polymorphic";
@@ -22,7 +25,9 @@ export const OakTertiaryButton = <C extends ElementType = "button">({
   iconName,
   children,
   ...props
-}: OakTertiaryButtonProps & PolymorphicPropsWithoutRef<C>) => {
+}: OakTertiaryButtonProps &
+  Partial<InternalShadowRoundButtonProps> &
+  PolymorphicPropsWithoutRef<C>) => {
   return (
     <InternalShadowRoundButton
       element={element ?? "button"}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Updating this component to allow it to be set as narrow and override the breakpoint behaviour.
Added extra types that are allowed on OakTertiaryButton as it passes props through to InternalShadowRoundButton
The icon size needed to be added in order for it to look correct in OWA 

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
