### PR TITLE
feat: OakUnitsContainer amendments

### DIFF
--- a/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.stories.tsx
+++ b/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.stories.tsx
@@ -21,10 +21,22 @@ const meta: Meta<typeof OakUnitsContainer> = {
       options: ["Url", "Null"],
       mapping: { Url: "https://www.thenational.academy", Null: null },
     },
+    isCustomUnit: { type: "boolean" },
+    customHeadingText: { type: "string" },
+    bannerText: { type: "string" },
   },
   parameters: {
     controls: {
-      include: ["isLegacy", "showHeader", "subject", "phase", "curriculumHref"],
+      include: [
+        "isLegacy",
+        "showHeader",
+        "subject",
+        "phase",
+        "curriculumHref",
+        "isCustomUnit",
+        "customHeadingText",
+        "bannerText",
+      ],
     },
   },
 };

--- a/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.tsx
+++ b/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.tsx
@@ -19,6 +19,7 @@ export type OakUnitsContainerProps = OakUnitsHeaderProps & {
   unitCards: Array<React.ReactNode>;
   isCustomUnit?: boolean;
   customHeadingText?: string;
+  bannerText?: string;
 };
 
 const OakUnitsContainerCss = css<OakUnitsContainerProps>``;
@@ -33,6 +34,7 @@ const UnstyledComponent = (props: OakUnitsContainerProps) => {
     subject,
     isCustomUnit,
     customHeadingText,
+    bannerText,
     ...rest
   } = props;
   return (
@@ -54,6 +56,7 @@ const UnstyledComponent = (props: OakUnitsContainerProps) => {
           $width="100%"
           isCustomUnit={isCustomUnit}
           customHeadingText={customHeadingText}
+          bannerText={bannerText}
         />
       )}
       <OakULFlex aria-label="A list of units" $reset $width="100%">

--- a/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.tsx
+++ b/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.tsx
@@ -17,6 +17,8 @@ const OakULFlex = styled(OakUL)`
 export type OakUnitsContainerProps = OakUnitsHeaderProps & {
   showHeader: boolean;
   unitCards: Array<React.ReactNode>;
+  isCustomUnit?: boolean;
+  customHeadingText?: string;
 };
 
 const OakUnitsContainerCss = css<OakUnitsContainerProps>``;
@@ -29,6 +31,8 @@ const UnstyledComponent = (props: OakUnitsContainerProps) => {
     curriculumHref,
     phase,
     subject,
+    isCustomUnit,
+    customHeadingText,
     ...rest
   } = props;
   return (
@@ -48,6 +52,8 @@ const UnstyledComponent = (props: OakUnitsContainerProps) => {
           phase={phase}
           subject={subject}
           $width="100%"
+          isCustomUnit={isCustomUnit}
+          customHeadingText={customHeadingText}
         />
       )}
       <OakULFlex aria-label="A list of units" $reset $width="100%">

--- a/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
+++ b/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import styled, { css } from "styled-components";
 
 import { OakFlex, OakHeading, OakTypography } from "@/components/atoms";
-import { OakPromoTag, OakTertiaryButton } from "@/components/molecules";
+import {
+  OakInlineBanner,
+  OakPromoTag,
+  OakTertiaryButton,
+} from "@/components/molecules";
 import { SizeStyleProps, sizeStyle } from "@/styles/utils/sizeStyle";
 
 export type OakUnitsHeaderProps = {
@@ -10,6 +14,8 @@ export type OakUnitsHeaderProps = {
   subject: string;
   phase: string;
   curriculumHref: string | null;
+  isCustomUnit?: boolean;
+  customHeadingText?: string;
 } & SizeStyleProps;
 
 const OakUnitsHeaderCss = css<OakUnitsHeaderProps>`
@@ -41,33 +47,57 @@ const UnstyledComponent = (props: OakUnitsHeaderProps) => {
     ? "Resources made during the pandemic to support remote teaching."
     : "Brand-new teaching resources, thoughtfully crafted by teachers for classroom needs.";
 
+  const isCustomUnit = props.isCustomUnit;
+  const standardHeadingText = isLegacy
+    ? "Units released in 2020-22"
+    : `${subject} units`;
+  const customHeadingText = props.customHeadingText;
+
   return (
-    <OakFlex
-      $gap="space-between-sssx"
-      $alignItems={["flex-start", "center"]}
-      $justifyContent="space-between"
-      $flexDirection={["column", "row"]}
-      {...rest}
-    >
-      <OakFlex $gap="space-between-ssx" $flexDirection="column">
-        <OakFlex $gap="space-between-ssx">
-          <OakHeading $font="heading-5" tag="h2" $color={"text-primary"}>
-            {isLegacy ? "Units released in 2020-22" : `${subject} units`}
-          </OakHeading>
-          {!isLegacy && <OakPromoTag />}
+    <>
+      <OakFlex
+        $gap="space-between-sssx"
+        $alignItems={["flex-start", "center"]}
+        $justifyContent="space-between"
+        $flexDirection={["column", "row"]}
+        {...rest}
+      >
+        <OakFlex $gap="space-between-ssx" $flexDirection="column">
+          <OakFlex $gap="space-between-ssx">
+            <OakHeading $font="heading-5" tag="h2" $color={"text-primary"}>
+              {isCustomUnit && customHeadingText
+                ? customHeadingText
+                : standardHeadingText}
+            </OakHeading>
+            {!isLegacy && !isCustomUnit && <OakPromoTag />}
+          </OakFlex>
+          {!isCustomUnit && (
+            <OakTypography $font="body-2" $color={"text-primary"}>
+              {subheading}
+            </OakTypography>
+          )}
         </OakFlex>
-        <OakTypography $font="body-2" $color={"text-primary"}>
-          {subheading}
-        </OakTypography>
+        {href && !isCustomUnit && (
+          <CurriculumDownloadButton
+            isLegacy={isLegacy}
+            phase={phase}
+            curriculumHref={href}
+          />
+        )}
       </OakFlex>
-      {href && (
-        <CurriculumDownloadButton
-          isLegacy={isLegacy}
-          phase={phase}
-          curriculumHref={href}
-        />
+      {isCustomUnit && (
+        <OakFlex $width={"100%"}>
+          <OakInlineBanner
+            isOpen={true}
+            message={
+              "Swimming and water safety lessons should be selected based on the ability and experience of your pupils."
+            }
+            type="neutral"
+            $width={"100%"}
+          />
+        </OakFlex>
       )}
-    </OakFlex>
+    </>
   );
 };
 

--- a/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
+++ b/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
@@ -16,6 +16,7 @@ export type OakUnitsHeaderProps = {
   curriculumHref: string | null;
   isCustomUnit?: boolean;
   customHeadingText?: string;
+  bannerText?: string;
 } & SizeStyleProps;
 
 const OakUnitsHeaderCss = css<OakUnitsHeaderProps>`
@@ -41,17 +42,24 @@ const CurriculumDownloadButton = (
 };
 
 const UnstyledComponent = (props: OakUnitsHeaderProps) => {
-  const { subject, isLegacy, phase, curriculumHref: href, ...rest } = props;
+  const {
+    subject,
+    isLegacy,
+    phase,
+    curriculumHref: href,
+    bannerText,
+    isCustomUnit,
+    customHeadingText,
+    ...rest
+  } = props;
 
   const subheading = isLegacy
     ? "Resources made during the pandemic to support remote teaching."
     : "Brand-new teaching resources, thoughtfully crafted by teachers for classroom needs.";
 
-  const isCustomUnit = props.isCustomUnit;
   const standardHeadingText = isLegacy
     ? "Units released in 2020-22"
     : `${subject} units`;
-  const customHeadingText = props.customHeadingText;
 
   return (
     <>
@@ -85,13 +93,11 @@ const UnstyledComponent = (props: OakUnitsHeaderProps) => {
           />
         )}
       </OakFlex>
-      {isCustomUnit && (
+      {bannerText && (
         <OakFlex $width={"100%"}>
           <OakInlineBanner
             isOpen={true}
-            message={
-              "Swimming and water safety lessons should be selected based on the ability and experience of your pupils."
-            }
+            message={bannerText}
             type="neutral"
             $width={"100%"}
           />


### PR DESCRIPTION
# How to review this PR

`OakUnitsContainer` amendments to accommodate for the swimming units

added new props:
- `isCustomUnit`
-  `customHeadingText`
- `bannerText`

# Add your PR description below
https://www.notion.so/oaknationalacademy/oak-components-amend-OakUnitsContainer-component-1ce26cc4e1b180ff95bae9d84c0f1a6c

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

https://deploy-preview-398--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-teacher-oakunitscontainer--docs

## ACs
