### PR TITLE
feat: added warning type InlineBanner, added large variant and minor tweaks to match design system

### DIFF
--- a/src/components/molecules/OakInlineBanner/OakInlineBanner.stories.tsx
+++ b/src/components/molecules/OakInlineBanner/OakInlineBanner.stories.tsx
@@ -5,9 +5,11 @@ import React from "react";
 import {
   OakInlineBanner,
   bannerTypes,
+  bannerVariants,
 } from "@/components/molecules/OakInlineBanner";
 import { OakSecondaryLink } from "@/components/molecules/OakSecondaryLink";
 import { oakIconNames } from "@/components/atoms";
+import { OakPrimaryButton } from "@/components/molecules/OakPrimaryButton";
 
 const meta: Meta<typeof OakInlineBanner> = {
   component: OakInlineBanner,
@@ -16,6 +18,9 @@ const meta: Meta<typeof OakInlineBanner> = {
   argTypes: {
     type: {
       options: Object.keys(bannerTypes),
+    },
+    variant: {
+      options: Object.keys(bannerVariants),
     },
     title: {
       control: {
@@ -45,6 +50,7 @@ const meta: Meta<typeof OakInlineBanner> = {
     controls: {
       include: [
         "type",
+        "variant",
         "title",
         "isOpen",
         "message",
@@ -56,10 +62,10 @@ const meta: Meta<typeof OakInlineBanner> = {
   },
   args: {
     type: "info",
+    variant: "regular",
     isOpen: true,
     title: "Information",
-    message:
-      "Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.",
+    message: `Provide users with non-disruptive feedback`,
     cta: (
       <OakSecondaryLink
         iconName="chevron-right"
@@ -100,6 +106,23 @@ export const InfoSimple: Story = {
   },
 };
 
+export const InfoLarge: Story = {
+  args: {
+    type: "info",
+    variant: "large",
+    message: `Provide users with clear, timely, and non-disruptive feedback to support 
+      their understanding of actions and outcomes without interrupting their 
+      flow. Whether confirming a successful task, alerting them to an error, or 
+      informing them of a background process, feedback should be subtle and 
+      contextual—reinforcing confidence without demanding unnecessary attention.`,
+    cta: (
+      <OakPrimaryButton iconName="chevron-right" isTrailingIcon>
+        Button
+      </OakPrimaryButton>
+    ),
+  },
+};
+
 export const Neutral: Story = {
   args: {
     type: "neutral",
@@ -110,6 +133,23 @@ export const NeutralSimple: Story = {
   args: {
     type: "neutral",
     title: undefined,
+  },
+};
+
+export const NeutralLarge: Story = {
+  args: {
+    type: "neutral",
+    variant: "large",
+    message: `Provide users with clear, timely, and non-disruptive feedback to support 
+      their understanding of actions and outcomes without interrupting their 
+      flow. Whether confirming a successful task, alerting them to an error, or 
+      informing them of a background process, feedback should be subtle and 
+      contextual—reinforcing confidence without demanding unnecessary attention.`,
+    cta: (
+      <OakPrimaryButton iconName="chevron-right" isTrailingIcon>
+        Button
+      </OakPrimaryButton>
+    ),
   },
 };
 
@@ -126,6 +166,23 @@ export const SuccessSimple: Story = {
   },
 };
 
+export const SuccessLarge: Story = {
+  args: {
+    type: "success",
+    variant: "large",
+    message: `Provide users with clear, timely, and non-disruptive feedback to support 
+      their understanding of actions and outcomes without interrupting their 
+      flow. Whether confirming a successful task, alerting them to an error, or 
+      informing them of a background process, feedback should be subtle and 
+      contextual—reinforcing confidence without demanding unnecessary attention.`,
+    cta: (
+      <OakPrimaryButton iconName="chevron-right" isTrailingIcon>
+        Button
+      </OakPrimaryButton>
+    ),
+  },
+};
+
 export const Alert: Story = {
   args: {
     type: "alert",
@@ -139,6 +196,53 @@ export const AlertSimple: Story = {
   },
 };
 
+export const AlertLarge: Story = {
+  args: {
+    type: "alert",
+    variant: "large",
+    message: `Provide users with clear, timely, and non-disruptive feedback to support 
+      their understanding of actions and outcomes without interrupting their 
+      flow. Whether confirming a successful task, alerting them to an error, or 
+      informing them of a background process, feedback should be subtle and 
+      contextual—reinforcing confidence without demanding unnecessary attention.`,
+    cta: (
+      <OakPrimaryButton iconName="chevron-right" isTrailingIcon>
+        Button
+      </OakPrimaryButton>
+    ),
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    type: "warning",
+  },
+};
+
+export const WarningSimple: Story = {
+  args: {
+    type: "warning",
+    title: undefined,
+  },
+};
+
+export const WarningLarge: Story = {
+  args: {
+    type: "warning",
+    variant: "large",
+    message: `Provide users with clear, timely, and non-disruptive feedback to support 
+      their understanding of actions and outcomes without interrupting their 
+      flow. Whether confirming a successful task, alerting them to an error, or 
+      informing them of a background process, feedback should be subtle and 
+      contextual—reinforcing confidence without demanding unnecessary attention.`,
+    cta: (
+      <OakPrimaryButton iconName="chevron-right" isTrailingIcon>
+        Button
+      </OakPrimaryButton>
+    ),
+  },
+};
+
 export const Error: Story = {
   args: {
     type: "error",
@@ -149,6 +253,23 @@ export const ErrorSimple: Story = {
   args: {
     type: "error",
     title: undefined,
+  },
+};
+
+export const ErrorLarge: Story = {
+  args: {
+    type: "error",
+    variant: "large",
+    message: `Provide users with clear, timely, and non-disruptive feedback to support 
+      their understanding of actions and outcomes without interrupting their 
+      flow. Whether confirming a successful task, alerting them to an error, or 
+      informing them of a background process, feedback should be subtle and 
+      contextual—reinforcing confidence without demanding unnecessary attention.`,
+    cta: (
+      <OakPrimaryButton iconName="chevron-right" isTrailingIcon>
+        Button
+      </OakPrimaryButton>
+    ),
   },
 };
 
@@ -172,5 +293,27 @@ export const OverriddenStylingSimple: Story = {
     $background: "pink30",
     iconColorFilter: "oakGreen",
     title: undefined,
+  },
+};
+
+export const OverriddenStylingLarge: Story = {
+  args: {
+    type: undefined,
+    canDismiss: false,
+    icon: "rocket",
+    $borderColor: "pink",
+    $background: "pink30",
+    iconColorFilter: "oakGreen",
+    variant: "large",
+    message: `Provide users with clear, timely, and non-disruptive feedback to support 
+      their understanding of actions and outcomes without interrupting their 
+      flow. Whether confirming a successful task, alerting them to an error, or 
+      informing them of a background process, feedback should be subtle and 
+      contextual—reinforcing confidence without demanding unnecessary attention.`,
+    cta: (
+      <OakPrimaryButton iconName="chevron-right" isTrailingIcon>
+        Button
+      </OakPrimaryButton>
+    ),
   },
 };

--- a/src/components/molecules/OakInlineBanner/OakInlineBanner.test.tsx
+++ b/src/components/molecules/OakInlineBanner/OakInlineBanner.test.tsx
@@ -20,7 +20,7 @@ jest.mock("react-dom", () => {
 });
 
 describe(OakInlineBanner, () => {
-  it("matches snapshot", () => {
+  it("matches snapshot for banner with title", () => {
     const tree = create(
       <OakThemeProvider theme={oakDefaultTheme}>
         <OakInlineBanner
@@ -35,6 +35,50 @@ describe(OakInlineBanner, () => {
           onDismiss={() => {}}
           title="Information"
           type="info"
+        />
+      </OakThemeProvider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("matches snapshot for simple banner without title", () => {
+    const tree = create(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakInlineBanner
+          canDismiss
+          cta={
+            <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+              Link
+            </OakSecondaryLink>
+          }
+          isOpen
+          message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
+          onDismiss={() => {}}
+          type="info"
+        />
+      </OakThemeProvider>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("matches snapshot for large variant banner", () => {
+    const tree = create(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakInlineBanner
+          canDismiss
+          cta={
+            <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+              Link
+            </OakSecondaryLink>
+          }
+          isOpen
+          message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
+          onDismiss={() => {}}
+          title="Information"
+          type="info"
+          variant="large"
         />
       </OakThemeProvider>,
     ).toJSON();
@@ -107,7 +151,7 @@ describe(OakInlineBanner, () => {
     expect(onDismissSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("hides close icon is the banner cannot be dismissed", () => {
+  it("hides close icon if the banner cannot be dismissed", () => {
     const { queryAllByTestId } = renderWithTheme(
       <OakInlineBanner
         canDismiss={false}
@@ -226,7 +270,7 @@ describe(OakInlineBanner, () => {
     expect(queryAllByTestId("inline-banner-title")).toHaveLength(0);
   });
 
-  it("can orverride close button props", () => {
+  it("can override close button props", () => {
     const { getByTestId } = renderWithTheme(
       <OakInlineBanner
         canDismiss

--- a/src/components/molecules/OakInlineBanner/OakInlineBanner.tsx
+++ b/src/components/molecules/OakInlineBanner/OakInlineBanner.tsx
@@ -3,14 +3,29 @@ import React, { ReactNode } from "react";
 import { InternalShadowRoundButton } from "@/components/molecules/InternalShadowRoundButton";
 import {
   OakBox,
+  OakBoxProps,
   OakFlex,
   OakFlexProps,
   OakHeading,
+  OakHeadingProps,
   OakIcon,
   OakIconName,
+  OakIconProps,
 } from "@/components/atoms";
 import { OakColorToken } from "@/styles";
 import { OakColorFilterToken } from "@/styles/theme/color";
+import { PaddingStyleProps } from "@/styles/utils/spacingStyle";
+import { FlexStyleProps } from "@/styles/utils/flexStyle";
+
+export type OakInlineBannerTypes =
+  | "info"
+  | "neutral"
+  | "success"
+  | "alert"
+  | "error"
+  | "warning";
+
+export type OakInlineBannerVariants = "regular" | "large";
 
 export type OakInlineBannerProps = OakFlexProps & {
   /**
@@ -28,7 +43,7 @@ export type OakInlineBannerProps = OakFlexProps & {
   /**
    * The type of banner to display
    */
-  type?: "info" | "neutral" | "success" | "alert" | "error";
+  type?: OakInlineBannerTypes;
   /**
    * The icon to display in the banner
    */
@@ -53,10 +68,14 @@ export type OakInlineBannerProps = OakFlexProps & {
    * Props to override the close button
    */
   closeButtonOverrideProps?: Partial<typeof InternalShadowRoundButton>;
+  /**
+   * The variant of an Inline Banner to display
+   */
+  variant?: OakInlineBannerVariants;
 };
 
 export type BannerTypes = {
-  [key: string]: {
+  [key in OakInlineBannerTypes]: {
     icon: OakIconName;
     iconColorFilter: OakColorFilterToken;
     backgroundColour: OakColorToken;
@@ -84,16 +103,69 @@ export const bannerTypes: BannerTypes = {
     borderColour: "mint110",
   },
   alert: {
-    icon: "warning",
+    icon: "bell",
     iconColorFilter: "black",
     backgroundColour: "lemon30",
     borderColour: "lemon50",
+  },
+  warning: {
+    icon: "warning",
+    iconColorFilter: "amber",
+    backgroundColour: "amber30",
+    borderColour: "amber50",
   },
   error: {
     icon: "error",
     iconColorFilter: "red",
     backgroundColour: "red30",
     borderColour: "red",
+  },
+};
+
+export type OakInlineBannerVariantProps = {
+  [key in OakInlineBannerVariants]: {
+    icon: Partial<OakIconProps>;
+    heading: Partial<OakHeadingProps>;
+    closeButtonWrapper?: Partial<OakBoxProps>;
+    ctaWrapper?: Partial<OakBoxProps>;
+    flexDirection: FlexStyleProps["$flexDirection"];
+    bannerPadding: PaddingStyleProps["$pa"];
+  };
+};
+
+export const bannerVariants: OakInlineBannerVariantProps = {
+  regular: {
+    icon: {
+      $width: "all-spacing-7",
+      $height: "all-spacing-7",
+    },
+    heading: {
+      $font: ["heading-7"],
+    },
+    ctaWrapper: {
+      $mt: "space-between-xs",
+    },
+    flexDirection: "row",
+    bannerPadding: "inner-padding-m",
+  },
+  large: {
+    icon: {
+      $width: "all-spacing-8",
+      $height: "all-spacing-8",
+    },
+    heading: {
+      $font: ["heading-7"],
+    },
+    ctaWrapper: {
+      $mt: "space-between-m",
+    },
+    closeButtonWrapper: {
+      $position: "absolute",
+      $top: "all-spacing-0",
+      $right: "all-spacing-0",
+    },
+    flexDirection: "column",
+    bannerPadding: "inner-padding-xl",
   },
 };
 
@@ -105,13 +177,14 @@ export const bannerTypes: BannerTypes = {
  * - **isOpen** \-                      If true the banner will be displayed
  * - **title?** \-                      Optional title to display in the banner, without this the banner will be more compact
  * - **message** \-                     Message to display in the banner
- * - **type?** \-                       Optional type of banner to display (info, neutral, success, alert, error) (default: info)
+ * - **type?** \-                       Optional type of banner to display (info, neutral, success, alert, error, warning) (default: info)
  * - **icon?** \-                       Optional icon to display in the banner
  * - **iconColorFilter?** \-            Optional color filter to apply to the icon
  * - **cta?** \-                        Optional call to action to display in the banner (ReactNode)
  * - **canDismiss?** \-                 If true the banner can be dismissed (show close icon) (default: false)
  * - **onDismiss?** \-                  Function called when the banner is dismissed
  * - **closeButtonOverrideProps?** \-   Props to override the close button (aria-label, etc)
+ * - **variant?** \-                    The variant of the inline banner to display (regular, large) (default: regular)
  * - **...rest** \-                     Other props to be passed to the wrapper OakFlex component (can be used to override styles of the banner)
  */
 export const OakInlineBanner = ({
@@ -125,6 +198,7 @@ export const OakInlineBanner = ({
   icon,
   iconColorFilter,
   closeButtonOverrideProps,
+  variant = "regular",
   ...props
 }: OakInlineBannerProps) => {
   const iconResult = icon || bannerTypes[type]?.icon;
@@ -134,10 +208,10 @@ export const OakInlineBanner = ({
   return (
     <OakFlex
       data-testid="oak-inline-banner"
-      $alignItems="end"
+      $alignItems={title ? "start" : "end"}
       $display={isOpen ? "flex" : "none"}
       $background={bannerTypes[type]?.backgroundColour}
-      $pa={"inner-padding-s"}
+      $pa={bannerVariants[variant].bannerPadding}
       $borderRadius={"border-radius-m"}
       $ba="border-solid-s"
       $borderStyle={"solid"}
@@ -146,9 +220,10 @@ export const OakInlineBanner = ({
       {...props}
     >
       <OakFlex
-        $flexDirection={"row"}
+        $position={"relative"}
+        $flexDirection={bannerVariants[variant].flexDirection}
         $justifyContent={"space-between"}
-        $alignItems={title ? "start" : "center"}
+        $alignItems={title || variant === "large" ? "start" : "center"}
         $gap={"space-between-xs"}
         $width={"100%"}
       >
@@ -156,8 +231,7 @@ export const OakInlineBanner = ({
           <OakIcon
             iconName={iconResult || "info"}
             $colorFilter={iconColorFilterResult}
-            $width="all-spacing-7"
-            $height="all-spacing-7"
+            {...bannerVariants[variant].icon}
             data-testid="inline-banner-icon"
           />
         </OakBox>
@@ -170,9 +244,9 @@ export const OakInlineBanner = ({
         >
           {title && (
             <OakHeading
-              $font={["heading-7"]}
               data-testid="inline-banner-title"
               tag="h1"
+              {...bannerVariants[variant].heading}
             >
               {title}
             </OakHeading>
@@ -180,10 +254,14 @@ export const OakInlineBanner = ({
           <OakBox $font={"body-2"} data-testid="inline-banner-message">
             {message}
           </OakBox>
-          {!title && cta}
+          {cta && (
+            <OakBox {...(title ? bannerVariants[variant].ctaWrapper : {})}>
+              {cta}
+            </OakBox>
+          )}
         </OakFlex>
         {canDismiss && (
-          <OakBox>
+          <OakBox {...bannerVariants[variant].closeButtonWrapper}>
             <InternalShadowRoundButton
               aria-label={"Dismiss banner"}
               defaultIconBackground="transparent"
@@ -204,7 +282,6 @@ export const OakInlineBanner = ({
           </OakBox>
         )}
       </OakFlex>
-      {title && cta}
     </OakFlex>
   );
 };

--- a/src/components/molecules/OakInlineBanner/OakInlineBanner.tsx
+++ b/src/components/molecules/OakInlineBanner/OakInlineBanner.tsx
@@ -238,7 +238,29 @@ export const OakInlineBanner = ({
             data-testid="inline-banner-icon"
           />
         </OakBox>
+        {canDismiss && (
+          <OakFlex $order={2} {...bannerVariants[variant].closeButtonWrapper}>
+            <InternalShadowRoundButton
+              aria-label={"Dismiss banner"}
+              defaultIconBackground="transparent"
+              defaultIconColor="black"
+              defaultTextColor="transparent"
+              hoverTextColor="transparent"
+              disabledTextColor="transparent"
+              hoverIconBackground="black"
+              hoverIconColor="white"
+              disabledIconBackground="transparent"
+              iconBackgroundSize="all-spacing-6"
+              iconSize="all-spacing-6"
+              iconName="cross"
+              data-testid="inline-banner-close-button"
+              onClick={onDismiss}
+              {...closeButtonOverrideProps}
+            />
+          </OakFlex>
+        )}
         <OakFlex
+          $order={1}
           $width={"100%"}
           $flexDirection={title ? "column" : "row"}
           $justifyContent={title ? "center" : "space-between"}
@@ -263,27 +285,6 @@ export const OakInlineBanner = ({
             </OakBox>
           )}
         </OakFlex>
-        {canDismiss && (
-          <OakBox {...bannerVariants[variant].closeButtonWrapper}>
-            <InternalShadowRoundButton
-              aria-label={"Dismiss banner"}
-              defaultIconBackground="transparent"
-              defaultIconColor="black"
-              defaultTextColor="transparent"
-              hoverTextColor="transparent"
-              disabledTextColor="transparent"
-              hoverIconBackground="black"
-              hoverIconColor="white"
-              disabledIconBackground="transparent"
-              iconBackgroundSize="all-spacing-6"
-              iconSize="all-spacing-6"
-              iconName="cross"
-              data-testid="inline-banner-close-button"
-              onClick={onDismiss}
-              {...closeButtonOverrideProps}
-            />
-          </OakBox>
-        )}
       </OakFlex>
     </OakFlex>
   );

--- a/src/components/molecules/OakInlineBanner/OakInlineBanner.tsx
+++ b/src/components/molecules/OakInlineBanner/OakInlineBanner.tsx
@@ -130,6 +130,7 @@ export type OakInlineBannerVariantProps = {
     ctaWrapper?: Partial<OakBoxProps>;
     flexDirection: FlexStyleProps["$flexDirection"];
     bannerPadding: PaddingStyleProps["$pa"];
+    textContentGap?: FlexStyleProps["$gap"];
   };
 };
 
@@ -147,6 +148,7 @@ export const bannerVariants: OakInlineBannerVariantProps = {
     },
     flexDirection: "row",
     bannerPadding: "inner-padding-m",
+    textContentGap: "space-between-sssx",
   },
   large: {
     icon: {
@@ -154,10 +156,10 @@ export const bannerVariants: OakInlineBannerVariantProps = {
       $height: "all-spacing-8",
     },
     heading: {
-      $font: ["heading-7"],
+      $font: ["heading-6"],
     },
     ctaWrapper: {
-      $mt: "space-between-m",
+      $mt: "space-between-ssx",
     },
     closeButtonWrapper: {
       $position: "absolute",
@@ -166,6 +168,7 @@ export const bannerVariants: OakInlineBannerVariantProps = {
     },
     flexDirection: "column",
     bannerPadding: "inner-padding-xl",
+    textContentGap: "space-between-s",
   },
 };
 
@@ -240,7 +243,7 @@ export const OakInlineBanner = ({
           $flexDirection={title ? "column" : "row"}
           $justifyContent={title ? "center" : "space-between"}
           $alignItems={title ? "start" : "center"}
-          $gap={"space-between-sssx"}
+          $gap={bannerVariants[variant].textContentGap}
         >
           {title && (
             <OakHeading

--- a/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OakInlineBanner matches snapshot 1`] = `
+exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
 .c0 {
-  padding: 0.75rem;
+  padding: 1rem;
   background: #e3e9fb;
   border: 0.063rem solid;
   border-color: #a0b6f2;
@@ -16,6 +16,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
 }
 
 .c2 {
+  position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -33,7 +34,12 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c7 {
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -44,7 +50,21 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c10 {
+.c11 {
+  margin-top: 0.75rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c14 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c16 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -52,7 +72,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c22 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -63,21 +83,12 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c24 {
   position: absolute;
   top: 0rem;
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c19 {
-  position: relative;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  height: 1.5rem;
-  min-height: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -87,7 +98,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   object-fit: contain;
 }
 
-.c23 {
+.c15 {
   object-fit: contain;
 }
 
@@ -99,10 +110,10 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: end;
-  -webkit-box-align: end;
-  -ms-flex-align: end;
-  align-items: end;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
 }
 
 .c3 {
@@ -124,7 +135,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   gap: 0.75rem;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -143,14 +154,14 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c11 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c15 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -169,7 +180,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   gap: 0rem;
 }
 
-.c17 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -184,7 +195,7 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c8 {
+.c9 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -193,24 +204,24 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;
   letter-spacing: 0.0115rem;
-}
-
-.c20 {
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
-}
-
-.c22 {
-  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c13 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c25 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c19 {
   background: none;
   color: inherit;
   border: none;
@@ -224,60 +235,60 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   color: transparent;
 }
 
-.c13:disabled {
+.c19:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c14 {
+.c20 {
   display: inline-block;
   position: relative;
 }
 
-.c14:hover {
+.c20:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: transparent;
 }
 
-.c14:hover:not(:active) [data-icon-for="button"] img {
+.c20:hover:not(:active) [data-icon-for="button"] img {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
 }
 
-.c14:active {
+.c20:active {
   color: transparent;
 }
 
-.c14:disabled {
+.c20:disabled {
   color: transparent;
 }
 
-.c12 > :first-child:focus-visible .shadow {
+.c18 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c12 > :first-child:hover .shadow {
+.c18 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c12 > :first-child:active .shadow {
+.c18 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c12 > :first-child:disabled .icon-container {
+.c18 > :first-child:disabled .icon-container {
   background: transparent;
 }
 
-.c12 > :first-child:hover .icon-container {
+.c18 > :first-child:hover .icon-container {
   background: #222222;
 }
 
-.c12 > :first-child:active .icon-container {
+.c18 > :first-child:active .icon-container {
   background: transparent;
 }
 
-.c21 {
+.c12 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -300,26 +311,26 @@ exports[`OakInlineBanner matches snapshot 1`] = `
   color: #222222;
 }
 
-.c21:focus-visible {
+.c12:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c21:visited {
+.c12:visited {
   color: #575757;
 }
 
-.c21:active {
+.c12:active {
   color: #222222;
 }
 
-.c21[disabled] {
+.c12[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
 @media (hover:hover) {
-  .c21:hover,
-  .c21:visited:hover {
+  .c12:hover,
+  .c12:visited:hover {
     color: #222222;
   }
 }
@@ -365,46 +376,87 @@ exports[`OakInlineBanner matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c2 c7"
+      className="c7 c8"
     >
       <h1
-        className="c8"
+        className="c9"
         data-testid="inline-banner-title"
       >
         Information
       </h1>
       <div
-        className="c9"
+        className="c10"
         data-testid="inline-banner-message"
       >
         Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
+      </div>
+      <div
+        className="c11"
+      >
+        <a
+          className="c12"
+        >
+          <span
+            className="c13"
+          >
+            Link
+          </span>
+          <div
+            className="c14 "
+          >
+            <img
+              alt="chevron-right"
+              className="c15"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+              style={
+                {
+                  "bottom": 0,
+                  "color": "transparent",
+                  "height": "100%",
+                  "left": 0,
+                  "objectFit": undefined,
+                  "objectPosition": undefined,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </div>
+        </a>
       </div>
     </div>
     <div
       className="c4"
     >
       <div
-        className="c10 c11 c12"
+        className="c16 c17 c18"
       >
         <button
           aria-label="Dismiss banner"
-          className="c13 c14"
+          className="c19 c20"
           data-testid="inline-banner-close-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
           <div
-            className="c4 c15"
+            className="c4 c21"
           >
             <div
-              className="c16 c17 icon-container"
+              className="c22 c23 icon-container"
             >
               <div
-                className="c18 shadow"
+                className="c24 shadow"
               />
               <div
-                className="c19"
+                className="c14"
                 data-icon-for="button"
               >
                 <img
@@ -434,49 +486,989 @@ exports[`OakInlineBanner matches snapshot 1`] = `
               </div>
             </div>
             <span
-              className="c20"
+              className="c25"
             />
           </div>
         </button>
       </div>
     </div>
   </div>
-  <a
-    className="c21"
+</div>
+`;
+
+exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
+.c0 {
+  padding: 1.5rem;
+  background: #e3e9fb;
+  border: 0.063rem solid;
+  border-color: #a0b6f2;
+  border-radius: 0.375rem;
+  border-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c4 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c5 {
+  position: relative;
+  width: 2.5rem;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  min-height: 2.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c7 {
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c10 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c11 {
+  margin-top: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c14 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c16 {
+  position: absolute;
+  top: 0rem;
+  right: 0rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c17 {
+  position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c23 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  color: transparent;
+  background: transparent;
+  border-radius: 6.25rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c25 {
+  position: absolute;
+  top: 0rem;
+  width: 100%;
+  height: 100%;
+  border-radius: 6.25rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c6 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  object-fit: contain;
+}
+
+.c15 {
+  object-fit: contain;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0rem;
+}
+
+.c24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c9 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c13 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c26 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c20 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+  color: transparent;
+}
+
+.c20:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c21 {
+  display: inline-block;
+  position: relative;
+}
+
+.c21:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: transparent;
+}
+
+.c21:hover:not(:active) [data-icon-for="button"] img {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+}
+
+.c21:active {
+  color: transparent;
+}
+
+.c21:disabled {
+  color: transparent;
+}
+
+.c19 > :first-child:focus-visible .shadow {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c19 > :first-child:hover .shadow {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+.c19 > :first-child:active .shadow {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
+}
+
+.c19 > :first-child:disabled .icon-container {
+  background: transparent;
+}
+
+.c19 > :first-child:hover .icon-container {
+  background: #222222;
+}
+
+.c19 > :first-child:active .icon-container {
+  background: transparent;
+}
+
+.c12 {
+  display: inline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.25rem;
+  outline: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font: inherit;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  cursor: pointer;
+  color: #222222;
+}
+
+.c12:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c12:visited {
+  color: #575757;
+}
+
+.c12:active {
+  color: #222222;
+}
+
+.c12[disabled] {
+  cursor: not-allowed;
+  color: #808080;
+}
+
+@media (hover:hover) {
+  .c12:hover,
+  .c12:visited:hover {
+    color: #222222;
+  }
+}
+
+<div
+  className="c0 c1"
+  data-testid="oak-inline-banner"
+>
+  <div
+    className="c2 c3"
   >
-    <span
-      className="c22"
-    >
-      Link
-    </span>
     <div
-      className="c19 "
+      className="c4"
     >
-      <img
-        alt="chevron-right"
-        className="c23"
-        data-nimg="fill"
-        decoding="async"
-        loading="lazy"
-        onError={[Function]}
-        onLoad={[Function]}
-        src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
-        style={
-          {
-            "bottom": 0,
-            "color": "transparent",
-            "height": "100%",
-            "left": 0,
-            "objectFit": undefined,
-            "objectPosition": undefined,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-            "width": "100%",
+      <div
+        className="c5"
+        data-testid="inline-banner-icon"
+      >
+        <img
+          alt="info"
+          className="c6"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1709052869/icons/Icon_Info_vsx3xi.svg"
+          style={
+            {
+              "bottom": 0,
+              "color": "transparent",
+              "height": "100%",
+              "left": 0,
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": "100%",
+            }
           }
-        }
-      />
+        />
+      </div>
     </div>
-  </a>
+    <div
+      className="c7 c8"
+    >
+      <h1
+        className="c9"
+        data-testid="inline-banner-title"
+      >
+        Information
+      </h1>
+      <div
+        className="c10"
+        data-testid="inline-banner-message"
+      >
+        Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
+      </div>
+      <div
+        className="c11"
+      >
+        <a
+          className="c12"
+        >
+          <span
+            className="c13"
+          >
+            Link
+          </span>
+          <div
+            className="c14 "
+          >
+            <img
+              alt="chevron-right"
+              className="c15"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+              style={
+                {
+                  "bottom": 0,
+                  "color": "transparent",
+                  "height": "100%",
+                  "left": 0,
+                  "objectFit": undefined,
+                  "objectPosition": undefined,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </div>
+        </a>
+      </div>
+    </div>
+    <div
+      className="c16"
+    >
+      <div
+        className="c17 c18 c19"
+      >
+        <button
+          aria-label="Dismiss banner"
+          className="c20 c21"
+          data-testid="inline-banner-close-button"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          <div
+            className="c4 c22"
+          >
+            <div
+              className="c23 c24 icon-container"
+            >
+              <div
+                className="c25 shadow"
+              />
+              <div
+                className="c14"
+                data-icon-for="button"
+              >
+                <img
+                  alt="cross"
+                  className="c6"
+                  data-nimg="fill"
+                  decoding="async"
+                  loading="lazy"
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895179/icons/xigimrbivcaxt4omxamp.svg"
+                  style={
+                    {
+                      "bottom": 0,
+                      "color": "transparent",
+                      "height": "100%",
+                      "left": 0,
+                      "objectFit": undefined,
+                      "objectPosition": undefined,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <span
+              className="c26"
+            />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = `
+.c0 {
+  padding: 1rem;
+  background: #e3e9fb;
+  border: 0.063rem solid;
+  border-color: #a0b6f2;
+  border-radius: 0.375rem;
+  border-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c4 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c5 {
+  position: relative;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c7 {
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c9 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c12 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c14 {
+  position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c20 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  color: transparent;
+  background: transparent;
+  border-radius: 6.25rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c22 {
+  position: absolute;
+  top: 0rem;
+  width: 100%;
+  height: 100%;
+  border-radius: 6.25rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c6 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  object-fit: contain;
+}
+
+.c13 {
+  object-fit: contain;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: end;
+  -webkit-box-align: end;
+  -ms-flex-align: end;
+  align-items: end;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  gap: 0.25rem;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0rem;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c11 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c23 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c17 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+  color: transparent;
+}
+
+.c17:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c18 {
+  display: inline-block;
+  position: relative;
+}
+
+.c18:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: transparent;
+}
+
+.c18:hover:not(:active) [data-icon-for="button"] img {
+  -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+  filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
+}
+
+.c18:active {
+  color: transparent;
+}
+
+.c18:disabled {
+  color: transparent;
+}
+
+.c16 > :first-child:focus-visible .shadow {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c16 > :first-child:hover .shadow {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
+}
+
+.c16 > :first-child:active .shadow {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
+}
+
+.c16 > :first-child:disabled .icon-container {
+  background: transparent;
+}
+
+.c16 > :first-child:hover .icon-container {
+  background: #222222;
+}
+
+.c16 > :first-child:active .icon-container {
+  background: transparent;
+}
+
+.c10 {
+  display: inline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.25rem;
+  outline: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  margin: -0.25rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font: inherit;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  cursor: pointer;
+  color: #222222;
+}
+
+.c10:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c10:visited {
+  color: #575757;
+}
+
+.c10:active {
+  color: #222222;
+}
+
+.c10[disabled] {
+  cursor: not-allowed;
+  color: #808080;
+}
+
+@media (hover:hover) {
+  .c10:hover,
+  .c10:visited:hover {
+    color: #222222;
+  }
+}
+
+<div
+  className="c0 c1"
+  data-testid="oak-inline-banner"
+>
+  <div
+    className="c2 c3"
+  >
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+        data-testid="inline-banner-icon"
+      >
+        <img
+          alt="info"
+          className="c6"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1709052869/icons/Icon_Info_vsx3xi.svg"
+          style={
+            {
+              "bottom": 0,
+              "color": "transparent",
+              "height": "100%",
+              "left": 0,
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": "100%",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="c7 c8"
+    >
+      <div
+        className="c9"
+        data-testid="inline-banner-message"
+      >
+        Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
+      </div>
+      <div
+        className="c4"
+      >
+        <a
+          className="c10"
+        >
+          <span
+            className="c11"
+          >
+            Link
+          </span>
+          <div
+            className="c12 "
+          >
+            <img
+              alt="chevron-right"
+              className="c13"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+              style={
+                {
+                  "bottom": 0,
+                  "color": "transparent",
+                  "height": "100%",
+                  "left": 0,
+                  "objectFit": undefined,
+                  "objectPosition": undefined,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </div>
+        </a>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c14 c15 c16"
+      >
+        <button
+          aria-label="Dismiss banner"
+          className="c17 c18"
+          data-testid="inline-banner-close-button"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          <div
+            className="c4 c19"
+          >
+            <div
+              className="c20 c21 icon-container"
+            >
+              <div
+                className="c22 shadow"
+              />
+              <div
+                className="c12"
+                data-icon-for="button"
+              >
+                <img
+                  alt="cross"
+                  className="c6"
+                  data-nimg="fill"
+                  decoding="async"
+                  loading="lazy"
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895179/icons/xigimrbivcaxt4omxamp.svg"
+                  style={
+                    {
+                      "bottom": 0,
+                      "color": "transparent",
+                      "height": "100%",
+                      "left": 0,
+                      "objectFit": undefined,
+                      "objectPosition": undefined,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <span
+              className="c23"
+            />
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -547,7 +547,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
 }
 
 .c11 {
-  margin-top: 1.5rem;
+  margin-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -654,7 +654,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  gap: 0.25rem;
+  gap: 1rem;
 }
 
 .c18 {
@@ -701,8 +701,8 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
 .c9 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
   -webkit-letter-spacing: 0.0115rem;
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;

--- a/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -34,37 +34,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
-  width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 300;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
-}
-
-.c11 {
-  margin-top: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c14 {
-  position: relative;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  height: 1.5rem;
-  min-height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c16 {
+.c8 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -72,7 +42,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c14 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -83,12 +53,42 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c16 {
   position: absolute;
   top: 0rem;
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c17 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c19 {
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c22 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c23 {
+  margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -98,7 +98,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   object-fit: contain;
 }
 
-.c15 {
+.c26 {
   object-fit: contain;
 }
 
@@ -135,33 +135,24 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   gap: 0.75rem;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  gap: 0.25rem;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
 }
 
-.c17 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c21 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -180,7 +171,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   gap: 0rem;
 }
 
-.c23 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -195,7 +186,29 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   justify-content: center;
 }
 
-.c9 {
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  gap: 0.25rem;
+}
+
+.c21 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -206,22 +219,22 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c13 {
+.c18 {
   font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c25 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
 }
 
-.c19 {
+.c11 {
   background: none;
   color: inherit;
   border: none;
@@ -235,60 +248,60 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   color: transparent;
 }
 
-.c19:disabled {
+.c11:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c20 {
+.c12 {
   display: inline-block;
   position: relative;
 }
 
-.c20:hover {
+.c12:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: transparent;
 }
 
-.c20:hover:not(:active) [data-icon-for="button"] img {
+.c12:hover:not(:active) [data-icon-for="button"] img {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
 }
 
-.c20:active {
+.c12:active {
   color: transparent;
 }
 
-.c20:disabled {
+.c12:disabled {
   color: transparent;
 }
 
-.c18 > :first-child:focus-visible .shadow {
+.c10 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c18 > :first-child:hover .shadow {
+.c10 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c18 > :first-child:active .shadow {
+.c10 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c18 > :first-child:disabled .icon-container {
+.c10 > :first-child:disabled .icon-container {
   background: transparent;
 }
 
-.c18 > :first-child:hover .icon-container {
+.c10 > :first-child:hover .icon-container {
   background: #222222;
 }
 
-.c18 > :first-child:active .icon-container {
+.c10 > :first-child:active .icon-container {
   background: transparent;
 }
 
-.c12 {
+.c24 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -311,26 +324,26 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   color: #222222;
 }
 
-.c12:focus-visible {
+.c24:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c12:visited {
+.c24:visited {
   color: #575757;
 }
 
-.c12:active {
+.c24:active {
   color: #222222;
 }
 
-.c12[disabled] {
+.c24[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
 @media (hover:hover) {
-  .c12:hover,
-  .c12:visited:hover {
+  .c24:hover,
+  .c24:visited:hover {
     color: #222222;
   }
 }
@@ -376,87 +389,30 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
       </div>
     </div>
     <div
-      className="c7 c8"
-    >
-      <h1
-        className="c9"
-        data-testid="inline-banner-title"
-      >
-        Information
-      </h1>
-      <div
-        className="c10"
-        data-testid="inline-banner-message"
-      >
-        Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
-      </div>
-      <div
-        className="c11"
-      >
-        <a
-          className="c12"
-        >
-          <span
-            className="c13"
-          >
-            Link
-          </span>
-          <div
-            className="c14 "
-          >
-            <img
-              alt="chevron-right"
-              className="c15"
-              data-nimg="fill"
-              decoding="async"
-              loading="lazy"
-              onError={[Function]}
-              onLoad={[Function]}
-              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
-              style={
-                {
-                  "bottom": 0,
-                  "color": "transparent",
-                  "height": "100%",
-                  "left": 0,
-                  "objectFit": undefined,
-                  "objectPosition": undefined,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "width": "100%",
-                }
-              }
-            />
-          </div>
-        </a>
-      </div>
-    </div>
-    <div
-      className="c4"
+      className="c4 c7"
     >
       <div
-        className="c16 c17 c18"
+        className="c8 c9 c10"
       >
         <button
           aria-label="Dismiss banner"
-          className="c19 c20"
+          className="c11 c12"
           data-testid="inline-banner-close-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
           <div
-            className="c4 c21"
+            className="c4 c13"
           >
             <div
-              className="c22 c23 icon-container"
+              className="c14 c15 icon-container"
             >
               <div
-                className="c24 shadow"
+                className="c16 shadow"
               />
               <div
-                className="c14"
+                className="c17"
                 data-icon-for="button"
               >
                 <img
@@ -486,10 +442,67 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
               </div>
             </div>
             <span
-              className="c25"
+              className="c18"
             />
           </div>
         </button>
+      </div>
+    </div>
+    <div
+      className="c19 c20"
+    >
+      <h1
+        className="c21"
+        data-testid="inline-banner-title"
+      >
+        Information
+      </h1>
+      <div
+        className="c22"
+        data-testid="inline-banner-message"
+      >
+        Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
+      </div>
+      <div
+        className="c23"
+      >
+        <a
+          className="c24"
+        >
+          <span
+            className="c25"
+          >
+            Link
+          </span>
+          <div
+            className="c17 "
+          >
+            <img
+              alt="chevron-right"
+              className="c26"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+              style={
+                {
+                  "bottom": 0,
+                  "color": "transparent",
+                  "height": "100%",
+                  "left": 0,
+                  "objectFit": undefined,
+                  "objectPosition": undefined,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </div>
+        </a>
       </div>
     </div>
   </div>
@@ -531,43 +544,13 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
 }
 
 .c7 {
-  width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 300;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
-}
-
-.c11 {
-  margin-top: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c14 {
-  position: relative;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  height: 1.5rem;
-  min-height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c16 {
   position: absolute;
   top: 0rem;
   right: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c9 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -575,7 +558,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c23 {
+.c15 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -586,12 +569,42 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c25 {
+.c17 {
   position: absolute;
   top: 0rem;
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c18 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c20 {
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c23 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c24 {
+  margin-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -601,7 +614,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   object-fit: contain;
 }
 
-.c15 {
+.c27 {
   object-fit: contain;
 }
 
@@ -643,28 +656,19 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  gap: 1rem;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
 }
 
-.c18 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c22 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -683,7 +687,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   gap: 0rem;
 }
 
-.c24 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -698,7 +702,29 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   justify-content: center;
 }
 
-.c9 {
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  gap: 1rem;
+}
+
+.c22 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
@@ -709,11 +735,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c26 {
+.c19 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -724,7 +746,11 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c20 {
+.c26 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c12 {
   background: none;
   color: inherit;
   border: none;
@@ -738,60 +764,60 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   color: transparent;
 }
 
-.c20:disabled {
+.c12:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c21 {
+.c13 {
   display: inline-block;
   position: relative;
 }
 
-.c21:hover {
+.c13:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: transparent;
 }
 
-.c21:hover:not(:active) [data-icon-for="button"] img {
+.c13:hover:not(:active) [data-icon-for="button"] img {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
 }
 
-.c21:active {
+.c13:active {
   color: transparent;
 }
 
-.c21:disabled {
+.c13:disabled {
   color: transparent;
 }
 
-.c19 > :first-child:focus-visible .shadow {
+.c11 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c19 > :first-child:hover .shadow {
+.c11 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c19 > :first-child:active .shadow {
+.c11 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c19 > :first-child:disabled .icon-container {
+.c11 > :first-child:disabled .icon-container {
   background: transparent;
 }
 
-.c19 > :first-child:hover .icon-container {
+.c11 > :first-child:hover .icon-container {
   background: #222222;
 }
 
-.c19 > :first-child:active .icon-container {
+.c11 > :first-child:active .icon-container {
   background: transparent;
 }
 
-.c12 {
+.c25 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -814,26 +840,26 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   color: #222222;
 }
 
-.c12:focus-visible {
+.c25:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c12:visited {
+.c25:visited {
   color: #575757;
 }
 
-.c12:active {
+.c25:active {
   color: #222222;
 }
 
-.c12[disabled] {
+.c25[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
 @media (hover:hover) {
-  .c12:hover,
-  .c12:visited:hover {
+  .c25:hover,
+  .c25:visited:hover {
     color: #222222;
   }
 }
@@ -881,85 +907,28 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
     <div
       className="c7 c8"
     >
-      <h1
-        className="c9"
-        data-testid="inline-banner-title"
-      >
-        Information
-      </h1>
       <div
-        className="c10"
-        data-testid="inline-banner-message"
-      >
-        Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
-      </div>
-      <div
-        className="c11"
-      >
-        <a
-          className="c12"
-        >
-          <span
-            className="c13"
-          >
-            Link
-          </span>
-          <div
-            className="c14 "
-          >
-            <img
-              alt="chevron-right"
-              className="c15"
-              data-nimg="fill"
-              decoding="async"
-              loading="lazy"
-              onError={[Function]}
-              onLoad={[Function]}
-              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
-              style={
-                {
-                  "bottom": 0,
-                  "color": "transparent",
-                  "height": "100%",
-                  "left": 0,
-                  "objectFit": undefined,
-                  "objectPosition": undefined,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "width": "100%",
-                }
-              }
-            />
-          </div>
-        </a>
-      </div>
-    </div>
-    <div
-      className="c16"
-    >
-      <div
-        className="c17 c18 c19"
+        className="c9 c10 c11"
       >
         <button
           aria-label="Dismiss banner"
-          className="c20 c21"
+          className="c12 c13"
           data-testid="inline-banner-close-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
           <div
-            className="c4 c22"
+            className="c4 c14"
           >
             <div
-              className="c23 c24 icon-container"
+              className="c15 c16 icon-container"
             >
               <div
-                className="c25 shadow"
+                className="c17 shadow"
               />
               <div
-                className="c14"
+                className="c18"
                 data-icon-for="button"
               >
                 <img
@@ -989,10 +958,67 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
               </div>
             </div>
             <span
-              className="c26"
+              className="c19"
             />
           </div>
         </button>
+      </div>
+    </div>
+    <div
+      className="c20 c21"
+    >
+      <h1
+        className="c22"
+        data-testid="inline-banner-title"
+      >
+        Information
+      </h1>
+      <div
+        className="c23"
+        data-testid="inline-banner-message"
+      >
+        Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
+      </div>
+      <div
+        className="c24"
+      >
+        <a
+          className="c25"
+        >
+          <span
+            className="c26"
+          >
+            Link
+          </span>
+          <div
+            className="c18 "
+          >
+            <img
+              alt="chevron-right"
+              className="c27"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+              style={
+                {
+                  "bottom": 0,
+                  "color": "transparent",
+                  "height": "100%",
+                  "left": 0,
+                  "objectFit": undefined,
+                  "objectPosition": undefined,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </div>
+        </a>
       </div>
     </div>
   </div>
@@ -1033,32 +1059,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
-  width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 300;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
-}
-
-.c12 {
-  position: relative;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  height: 1.5rem;
-  min-height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c14 {
+.c8 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -1066,7 +1067,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c14 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -1077,7 +1078,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c16 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -1086,13 +1087,38 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
+.c17 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c19 {
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c21 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
 .c6 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c13 {
+.c24 {
   object-fit: contain;
 }
 
@@ -1129,33 +1155,24 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   gap: 0.75rem;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  gap: 0.25rem;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
 }
 
-.c15 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c19 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1174,7 +1191,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   gap: 0rem;
 }
 
-.c21 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1189,11 +1206,29 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   justify-content: center;
 }
 
-.c11 {
-  font-family: --var(google-font),Lexend,sans-serif;
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  gap: 0.25rem;
 }
 
-.c23 {
+.c18 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -1204,7 +1239,11 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   letter-spacing: 0.0115rem;
 }
 
-.c17 {
+.c23 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c11 {
   background: none;
   color: inherit;
   border: none;
@@ -1218,60 +1257,60 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   color: transparent;
 }
 
-.c17:disabled {
+.c11:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c18 {
+.c12 {
   display: inline-block;
   position: relative;
 }
 
-.c18:hover {
+.c12:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: transparent;
 }
 
-.c18:hover:not(:active) [data-icon-for="button"] img {
+.c12:hover:not(:active) [data-icon-for="button"] img {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
 }
 
-.c18:active {
+.c12:active {
   color: transparent;
 }
 
-.c18:disabled {
+.c12:disabled {
   color: transparent;
 }
 
-.c16 > :first-child:focus-visible .shadow {
+.c10 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c16 > :first-child:hover .shadow {
+.c10 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c16 > :first-child:active .shadow {
+.c10 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c16 > :first-child:disabled .icon-container {
+.c10 > :first-child:disabled .icon-container {
   background: transparent;
 }
 
-.c16 > :first-child:hover .icon-container {
+.c10 > :first-child:hover .icon-container {
   background: #222222;
 }
 
-.c16 > :first-child:active .icon-container {
+.c10 > :first-child:active .icon-container {
   background: transparent;
 }
 
-.c10 {
+.c22 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1294,26 +1333,26 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   color: #222222;
 }
 
-.c10:focus-visible {
+.c22:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c10:visited {
+.c22:visited {
   color: #575757;
 }
 
-.c10:active {
+.c22:active {
   color: #222222;
 }
 
-.c10[disabled] {
+.c22[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
 
 @media (hover:hover) {
-  .c10:hover,
-  .c10:visited:hover {
+  .c22:hover,
+  .c22:visited:hover {
     color: #222222;
   }
 }
@@ -1359,81 +1398,30 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
       </div>
     </div>
     <div
-      className="c7 c8"
+      className="c4 c7"
     >
       <div
-        className="c9"
-        data-testid="inline-banner-message"
-      >
-        Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
-      </div>
-      <div
-        className="c4"
-      >
-        <a
-          className="c10"
-        >
-          <span
-            className="c11"
-          >
-            Link
-          </span>
-          <div
-            className="c12 "
-          >
-            <img
-              alt="chevron-right"
-              className="c13"
-              data-nimg="fill"
-              decoding="async"
-              loading="lazy"
-              onError={[Function]}
-              onLoad={[Function]}
-              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
-              style={
-                {
-                  "bottom": 0,
-                  "color": "transparent",
-                  "height": "100%",
-                  "left": 0,
-                  "objectFit": undefined,
-                  "objectPosition": undefined,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "width": "100%",
-                }
-              }
-            />
-          </div>
-        </a>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c14 c15 c16"
+        className="c8 c9 c10"
       >
         <button
           aria-label="Dismiss banner"
-          className="c17 c18"
+          className="c11 c12"
           data-testid="inline-banner-close-button"
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
           <div
-            className="c4 c19"
+            className="c4 c13"
           >
             <div
-              className="c20 c21 icon-container"
+              className="c14 c15 icon-container"
             >
               <div
-                className="c22 shadow"
+                className="c16 shadow"
               />
               <div
-                className="c12"
+                className="c17"
                 data-icon-for="button"
               >
                 <img
@@ -1463,10 +1451,61 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
               </div>
             </div>
             <span
-              className="c23"
+              className="c18"
             />
           </div>
         </button>
+      </div>
+    </div>
+    <div
+      className="c19 c20"
+    >
+      <div
+        className="c21"
+        data-testid="inline-banner-message"
+      >
+        Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
+      </div>
+      <div
+        className="c4"
+      >
+        <a
+          className="c22"
+        >
+          <span
+            className="c23"
+          >
+            Link
+          </span>
+          <div
+            className="c17 "
+          >
+            <img
+              alt="chevron-right"
+              className="c24"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+              style={
+                {
+                  "bottom": 0,
+                  "color": "transparent",
+                  "height": "100%",
+                  "left": 0,
+                  "objectFit": undefined,
+                  "objectPosition": undefined,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </div>
+        </a>
       </div>
     </div>
   </div>

--- a/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -158,6 +158,9 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
   gap: 0.25rem;
 }
 

--- a/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 
 .c2 {
   max-width: 40rem;
-  padding: 0.75rem;
+  padding: 1rem;
   background: #e3e9fb;
   border: 0.063rem solid;
   border-color: #a0b6f2;
@@ -21,6 +21,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c4 {
+  position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -34,7 +35,12 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c8 {
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -45,7 +51,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c17 {
+.c18 {
   width: 1.5rem;
   height: 1.5rem;
   background: #ffffff;
@@ -54,7 +60,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c21 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -62,7 +68,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c23 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -71,7 +77,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c27 {
+.c28 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -86,7 +92,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   object-fit: contain;
 }
 
-.c28 {
+.c29 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
@@ -136,7 +142,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   gap: 0.75rem;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -155,7 +161,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -166,7 +172,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   gap: 1rem;
 }
 
-.c18 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -188,7 +194,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   flex-shrink: 0;
 }
 
-.c25 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -207,7 +213,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   gap: 0.5rem;
 }
 
-.c26 {
+.c27 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -219,7 +225,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   text-align: left;
 }
 
-.c11 {
+.c12 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -230,7 +236,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c12 {
+.c13 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
@@ -241,7 +247,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c23 {
+.c24 {
   background: none;
   color: inherit;
   border: none;
@@ -263,19 +269,19 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c23:disabled {
+.c24:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c24 {
+.c25 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c24:hover {
+.c25:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -283,44 +289,44 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   border-color: #575757;
 }
 
-.c24:active {
+.c25:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c24:disabled {
+.c25:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c21 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c22 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c21 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c22 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c21 .yellow-shadow:has(+ .internal-button:hover),
-.c21 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c22 .yellow-shadow:has(+ .internal-button:hover),
+.c22 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c21 .grey-shadow:has(+ * + .internal-button:hover) {
+.c22 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c21 .grey-shadow:has(+ * + .internal-button:active) {
+.c22 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c21 .yellow-shadow:has(+ .internal-button:active) {
+.c22 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c13 {
+.c14 {
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -333,17 +339,17 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c16 {
   position: absolute;
   opacity: 0;
   cursor: pointer;
 }
 
-.c19 {
+.c20 {
   border-radius: 50%;
 }
 
-.c14:focus-visible ~ .c16::before {
+.c15:focus-visible ~ .c17::before {
   content: "";
   height: 2rem;
   width: 2rem;
@@ -354,7 +360,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   box-shadow: inset 0 0 0 0.13rem #ffe555;
 }
 
-.c14:checked ~ .c16::after {
+.c15:checked ~ .c17::after {
   content: "";
   height: 1rem;
   width: 1rem;
@@ -408,10 +414,10 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c4 c8"
+        className="c8 c9"
       >
         <div
-          className="c9"
+          className="c10"
           data-testid="inline-banner-message"
         >
           Before downloading, choose options for KS4. The document will still display both KS3 and KS4.
@@ -420,12 +426,12 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c0 c10"
+    className="c0 c11"
     data-testid="child-subject-selector"
     role="radiogroup"
   >
     <label
-      className="c11"
+      className="c12"
     >
       Choose subject for KS4 units
     </label>
@@ -433,13 +439,13 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
       className="c0"
     >
       <label
-        className="c12 c13"
+        className="c13 c14"
         data-testid="child-subject-radio-button"
         htmlFor="biology"
       >
         <input
           checked={true}
-          className="c14 c15"
+          className="c15 c16"
           id="biology"
           name="childSubjectRadio"
           onChange={[Function]}
@@ -447,7 +453,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
           value="biology"
         />
         <div
-          className="c16 c17 c18 c19"
+          className="c17 c18 c19 c20"
         />
         Biology
       </label>
@@ -456,13 +462,13 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
       className="c0"
     >
       <label
-        className="c12 c13"
+        className="c13 c14"
         data-testid="child-subject-radio-button"
         htmlFor="physics"
       >
         <input
           checked={false}
-          className="c14 c15"
+          className="c15 c16"
           id="physics"
           name="childSubjectRadio"
           onChange={[Function]}
@@ -470,7 +476,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
           value="physics"
         />
         <div
-          className="c16 c17 c18 c19"
+          className="c17 c18 c19 c20"
         />
         Physics
       </label>
@@ -479,13 +485,13 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
       className="c0"
     >
       <label
-        className="c12 c13"
+        className="c13 c14"
         data-testid="child-subject-radio-button"
         htmlFor="chemistry"
       >
         <input
           checked={false}
-          className="c14 c15"
+          className="c15 c16"
           id="chemistry"
           name="childSubjectRadio"
           onChange={[Function]}
@@ -493,19 +499,19 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
           value="chemistry"
         />
         <div
-          className="c16 c17 c18 c19"
+          className="c17 c18 c19 c20"
         />
         Chemistry
       </label>
     </div>
   </div>
   <div
-    className="c0 c10"
+    className="c0 c11"
     data-testid="tier-selector"
     role="radiogroup"
   >
     <label
-      className="c11"
+      className="c12"
     >
       Choose learning tier for KS4 units
     </label>
@@ -513,13 +519,13 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
       className="c0"
     >
       <label
-        className="c12 c13"
+        className="c13 c14"
         data-testid="tier-radio-button"
         htmlFor="foundation"
       >
         <input
           checked={true}
-          className="c14 c15"
+          className="c15 c16"
           id="foundation"
           name="tierRadio"
           onChange={[Function]}
@@ -527,7 +533,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
           value="foundation"
         />
         <div
-          className="c16 c17 c18 c19"
+          className="c17 c18 c19 c20"
         />
         Foundation
       </label>
@@ -536,13 +542,13 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
       className="c0"
     >
       <label
-        className="c12 c13"
+        className="c13 c14"
         data-testid="tier-radio-button"
         htmlFor="higher"
       >
         <input
           checked={false}
-          className="c14 c15"
+          className="c15 c16"
           id="higher"
           name="tierRadio"
           onChange={[Function]}
@@ -550,41 +556,41 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
           value="higher"
         />
         <div
-          className="c16 c17 c18 c19"
+          className="c17 c18 c19 c20"
         />
         Higher
       </label>
     </div>
   </div>
   <div
-    className="c20 c21"
+    className="c21 c22"
   >
     <div
-      className="c22 grey-shadow"
+      className="c23 grey-shadow"
     />
     <div
-      className="c22 yellow-shadow"
+      className="c23 yellow-shadow"
     />
     <button
-      className="c23 c24 internal-button"
+      className="c24 c25 internal-button"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
       <div
-        className="c0 c25"
+        className="c0 c26"
       >
         <span
-          className="c26"
+          className="c27"
         >
           Next
         </span>
         <div
-          className="c27"
+          className="c28"
         >
           <img
             alt="arrow-right"
-            className="c28"
+            className="c29"
             data-nimg="fill"
             decoding="async"
             loading="lazy"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- Added new Warning type of OakInlineBanner
- Added stories for Warning type OakInlineBanners
- Added regular/large variants of OakInlineBanner
- Added stories for all large variants of OakInlineBanner
- Moved CTA button from bottom right to bottom left when showing regular banner with a title
- Changed Alert type banner icon to a Bell instead Warning symbol
- Increased padding to `m` for regular and simple banners to match designs, `xl` when large variant
- Updated content of stories to match Figma Design Kit
- Updated Jest snapshot for OakDownloadsJourneyChildSubjectTierSelector which uses OakInlineBanner

## Link to the design doc
[Inline Banner and Inline Banner Large in the design kit](https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=14386-1882&m=dev)

## A link to the component in the deployment preview
[Preview deploy storybook link](https://deploy-preview-405--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oakinlinebanner--docs)

## Testing instructions
Compare storybook to the designs for InlineBanner and InlineBannerLarge.

InlineBanners should be default and regular variants. When it has no title it is simple. When the variant is large it should match the InlineBannerLarge design.

## ACs
- [ ] New stories for warning type
- [ ] New stories for large variants
- [ ] OakInlineBanner regular variant, without title matches Inline Banner Simple design
- [ ] OakInlineBanner regular variant, with a title matches Inline Banner design
- [ ] OakInlineBanner large variant, with a title matches Inline Banner Large design
- [ ] OakInlineBanner defaults to regular variant
- [ ] OakInlineBanner Alert variant icon has changed to Bell