### PR TITLE
PUPIL-1245 fix: ensure OakCodeRenderer tooltip uses a button with type button an…

### DIFF
--- a/src/components/molecules/OakInfoButton/OakInfoButton.tsx
+++ b/src/components/molecules/OakInfoButton/OakInfoButton.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, MouseEventHandler } from "react";
+import React, { ButtonHTMLAttributes, MouseEventHandler } from "react";
 import styled from "styled-components";
 
 import {
@@ -13,11 +13,13 @@ export type OakInfoButtonProps = {
   isLoading?: boolean;
   disabled?: boolean;
   buttonProps?: Partial<
-    InternalShadowRoundButtonProps & HTMLAttributes<Element>
+    InternalShadowRoundButtonProps & ButtonHTMLAttributes<HTMLButtonElement>
   >;
 };
 
-const StyledInternalShadowRoundButton = styled(InternalShadowRoundButton)`
+const StyledInternalShadowRoundButton = styled(
+  InternalShadowRoundButton<"button">,
+)`
   &:hover .shadow {
     box-shadow: none !important;
   }
@@ -38,6 +40,7 @@ export const OakInfoButton = (props: OakInfoButtonProps) => {
 
   return (
     <StyledInternalShadowRoundButton
+      element={"button"}
       iconName={isOpen && !disabled ? "cross" : "info"}
       defaultIconBackground={isOpen ? "black" : "bg-decorative5-main"}
       defaultIconColor={isOpen ? "white" : "black"}
@@ -48,7 +51,7 @@ export const OakInfoButton = (props: OakInfoButtonProps) => {
       disabledTextColor={"text-disabled"}
       disabledIconColor={"white"}
       isLoading={isLoading}
-      disabled={props.disabled}
+      disabled={disabled}
       iconBackgroundSize={"all-spacing-8"}
       iconSize={"all-spacing-7"}
       onClick={onClick}

--- a/src/components/organisms/shared/OakCodeRenderer/OakCodeRenderer.tsx
+++ b/src/components/organisms/shared/OakCodeRenderer/OakCodeRenderer.tsx
@@ -211,6 +211,9 @@ export const OakCodeRenderer = ({ string, ...rest }: OakCodeRendererProps) => {
             }
             id="oak-code-renderer-tooltip"
             tooltipPosition="bottom-right"
+            buttonProps={{
+              type: "button",
+            }}
           />
         </OakFlex>
       </OakFlex>

--- a/src/components/organisms/shared/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
+++ b/src/components/organisms/shared/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
@@ -591,6 +591,7 @@ have_homework =
           onClick={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
+          type="button"
         >
           <div
             className="c0 c26"

--- a/src/components/organisms/shared/OakInfo/OakInfo.tsx
+++ b/src/components/organisms/shared/OakInfo/OakInfo.tsx
@@ -1,4 +1,9 @@
-import React, { MouseEventHandler, ReactNode, useState } from "react";
+import React, {
+  ButtonHTMLAttributes,
+  MouseEventHandler,
+  ReactNode,
+  useState,
+} from "react";
 
 import {
   OakTooltip,
@@ -6,6 +11,7 @@ import {
   OakInfoButton,
 } from "@/components/molecules";
 import { OakBox } from "@/components/atoms";
+import { InternalShadowRoundButtonProps } from "@/components/molecules/InternalShadowRoundButton";
 
 export type OakInfoProps = {
   /**
@@ -15,13 +21,16 @@ export type OakInfoProps = {
   id: string;
   isLoading?: boolean;
   disabled?: boolean;
+  buttonProps?: Partial<
+    InternalShadowRoundButtonProps & ButtonHTMLAttributes<HTMLButtonElement>
+  >;
 } & Omit<OakTooltipProps, "children" | "tooltip" | "id">;
 
 /**
  * Presents a button which will show a hint when clicked
  */
 export const OakInfo = (props: OakInfoProps) => {
-  const { hint, id, isLoading, disabled, ...tooltipProps } = props;
+  const { hint, id, isLoading, disabled, buttonProps, ...tooltipProps } = props;
   const [isOpen, setIsOpen] = useState(false);
   const handleClick: MouseEventHandler = () => {
     setIsOpen(!isOpen);
@@ -39,6 +48,7 @@ export const OakInfo = (props: OakInfoProps) => {
           buttonProps={{
             "aria-describedby": id,
             "aria-label": isOpen ? "close info tooltip" : "open info tooltip",
+            ...buttonProps,
           }}
         />
       </OakTooltip>


### PR DESCRIPTION
…d added buttonProps to OakInfo

# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- Forced OakInfoButton to be a button element and updated typings accordingly
- Added buttonProps to OakInfo for passing through props
- Set the type of button to be `'button'` in OakCodeRenderer to ensure Code colour tooltip is always button and not submit

## Link to the design doc
[OakCodeRenderer](https://www.figma.com/design/XMr2P0ZaLW0dDq5SMzcLoX/Cycle-2-requirements---Pupils?node-id=2015-10786&m=dev)

## A link to the component in the deployment preview
Stories for OakInfo, OakInfoButton and OakCodeRenderer

## Testing instructions
Check that the UI for the OakCodeRenderer matches the designs and the Code colour tooltip works as expected. The tooltip HTML button should now have the attribute `type="button"`

## ACs
- [ ] OakCodeRenderer matches designs
- [ ] `type="button"` attribute is now on the native HTML button for the Code colour tooltip