### PR TITLE
OakInlineBanner CTA content stacking in Firefox fix

### DIFF
--- a/src/components/molecules/OakInlineBanner/OakInlineBanner.tsx
+++ b/src/components/molecules/OakInlineBanner/OakInlineBanner.tsx
@@ -280,9 +280,9 @@ export const OakInlineBanner = ({
             {message}
           </OakBox>
           {cta && (
-            <OakBox {...(title ? bannerVariants[variant].ctaWrapper : {})}>
+            <OakFlex {...(title ? bannerVariants[variant].ctaWrapper : {})}>
               {cta}
-            </OakBox>
+            </OakFlex>
           )}
         </OakFlex>
       </OakFlex>

--- a/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -464,7 +464,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
         Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
       </div>
       <div
-        className="c23"
+        className="c23 c9"
       >
         <a
           className="c24"
@@ -980,7 +980,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
         Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
       </div>
       <div
-        className="c24"
+        className="c24 c10"
       >
         <a
           className="c25"
@@ -1467,7 +1467,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
         Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet.
       </div>
       <div
-        className="c4"
+        className="c4 c9"
       >
         <a
           className="c22"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
For the OakInlineBanner child links with icons were stacking on Firefox. This PR updates child CTA content to be flex rows to ensure horizontal alignments.

Before:
![image](https://github.com/user-attachments/assets/531f9bff-efa5-49ec-acf2-72f120b8d148)

After:
![image](https://github.com/user-attachments/assets/8ecdf424-c522-4cae-88d5-d81a494f4b26)


## A link to the component in the deployment preview
{deployment_url}/?path=/docs/components-molecules-oakinlinebanner--docs

## Testing instructions
- [ ] Check firefox is now displaying links horizontally and not stacking the text and icon
- [ ] Check chrome/safari has not regressed
- [ ] Check CTA in different variants and types have not regressed

## ACs
- [ ] Consistent design across all browsers for all types and variants
