### PR TITLE
fix: use align stretch to fill background on firefox

### DIFF
--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
@@ -12,7 +12,6 @@ import {
 import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 import { OakSmallTertiaryInvertedButton } from "@/components/molecules";
-import { SizeStyleProps } from "@/styles/utils/sizeStyle";
 
 const FlexWithFocus = styled(OakFlex)`
   animation-timing-function: ease-out;
@@ -79,7 +78,7 @@ export type OakUnitListItemProps = {
   onClick?: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   onSave?: () => void;
   isSaved?: boolean;
-} & SizeStyleProps;
+};
 
 /**
  *
@@ -134,8 +133,8 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
             }
             $justifyContent={"center"}
             $alignItems={"center"}
-            $height="100%"
             $minWidth="all-spacing-11"
+            $alignSelf="stretch"
           >
             <OakHeading
               tag="h3"

--- a/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 
 .c8 {
   min-width: 4rem;
-  height: 100%;
   background: #a0b6f2;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -129,6 +128,9 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
 }
 
 .c13 {
@@ -184,6 +186,21 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 .c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -250,7 +267,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   white-space: nowrap;
 }
 
-.c30 {
+.c31 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -425,7 +442,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
           href=""
         >
           <div
-            className="c28 c9"
+            className="c28 c29"
           >
             <h3
               className="c11"
@@ -444,13 +461,13 @@ exports[`OakUnitListItem matches snapshot 1`] = `
           </div>
         </a>
         <div
-          className="c26 c29"
+          className="c26 c30"
         >
           <p
-            className="c30"
+            className="c31"
           />
           <p
-            className="c30"
+            className="c31"
           >
             0 lessons
           </p>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Fixes an issue with the unit list item in firefox that doesn't appear in storybook but when the comoponent is added to OWA the index number background does not fill the height of the flex container. The component should look the same in storybook.

Before:
![Screenshot 2025-04-24 at 08 30 04](https://github.com/user-attachments/assets/a5276fef-dbb9-46d4-88d4-5ef748dad15e)

After:
![Screenshot 2025-04-24 at 08 30 35](https://github.com/user-attachments/assets/18c56d56-8054-488c-9f91-0dc1a93baa7e)


## A link to the component in the deployment preview
https://deploy-preview-409--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-teacher-oakunitlistitem--with-save
