### PR TITLE
Fix/lesq 1321/unit list card focus

### DIFF
--- a/src/components/atoms/OakIcon/OakIcon.test.tsx
+++ b/src/components/atoms/OakIcon/OakIcon.test.tsx
@@ -42,13 +42,6 @@ describe("OakIcon", () => {
     });
   });
 
-  it("defaults the alt text to the icon name", () => {
-    const { getByRole } = render(
-      <OakIcon data-testid="test" iconName="home" />,
-    );
-    expect(getByRole("img")).toHaveAttribute("alt", "home");
-  });
-
   it("sets the alt text", () => {
     const { getByRole } = render(
       <OakIcon data-testid="test" iconName="home" alt="Home" />,
@@ -57,7 +50,7 @@ describe("OakIcon", () => {
   });
   it("handles typedImageMap being undefined", () => {
     const { getByRole } = render(
-      <OakIcon data-testid="test" iconName="home" />,
+      <OakIcon data-testid="test" iconName="home" alt="home" />,
     );
     expect(getByRole("img")).toHaveAttribute("alt", "home");
   });

--- a/src/components/atoms/OakIcon/OakIcon.tsx
+++ b/src/components/atoms/OakIcon/OakIcon.tsx
@@ -61,7 +61,7 @@ export const OakIcon = (props: OakIconProps) => {
   return (
     <OakImage
       src={generateOakIconURL(iconName)}
-      alt={alt ?? iconName}
+      alt={alt ?? ""}
       $width={$width}
       $height={$height}
       $minHeight={$minHeight}

--- a/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
+++ b/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`OakIcon matches snapshot 1`] = `
   className="c0"
 >
   <img
-    alt="home"
+    alt=""
     className="c1"
     data-nimg="fill"
     decoding="async"

--- a/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt="arrow-right"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
           data-icon-for="button"
         >
           <img
-            alt="arrow-right"
+            alt=""
             className="c11"
             data-nimg="fill"
             decoding="async"

--- a/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
+++ b/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
@@ -141,7 +141,7 @@ input:checked + .c7 {
         className="c10"
       >
         <img
-          alt="tick"
+          alt=""
           className="c11"
           data-nimg="fill"
           decoding="async"

--- a/src/components/molecules/OakCopyLinkButton/__snapshots__/OakCopyLinkButton.test.tsx.snap
+++ b/src/components/molecules/OakCopyLinkButton/__snapshots__/OakCopyLinkButton.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
             className="c9"
           >
             <img
-              alt="copy"
+              alt=""
               className="c10"
               data-nimg="fill"
               decoding="async"

--- a/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
+++ b/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
       className="c3"
     >
       <img
-        alt="move-arrows"
+        alt=""
         className="c4"
         data-nimg="fill"
         decoding="async"

--- a/src/components/molecules/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
+++ b/src/components/molecules/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
@@ -432,7 +432,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
                   data-icon-for="button"
                 >
                   <img
-                    alt="cross"
+                    alt=""
                     class="c22"
                     data-nimg="fill"
                     decoding="async"

--- a/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
       className="c6"
     >
       <img
-        alt="worksheet-3"
+        alt=""
         className="c7"
         data-nimg="fill"
         decoding="async"

--- a/src/components/molecules/OakInfoButton/__snapshots__/OakInfoButton.test.tsx.snap
+++ b/src/components/molecules/OakInfoButton/__snapshots__/OakInfoButton.test.tsx.snap
@@ -197,7 +197,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
             data-icon-for="button"
           >
             <img
-              alt="info"
+              alt=""
               className="c12"
               data-nimg="fill"
               decoding="async"

--- a/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -363,7 +363,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
         data-testid="inline-banner-icon"
       >
         <img
-          alt="info"
+          alt=""
           className="c6"
           data-nimg="fill"
           decoding="async"
@@ -416,7 +416,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
                 data-icon-for="button"
               >
                 <img
-                  alt="cross"
+                  alt=""
                   className="c6"
                   data-nimg="fill"
                   decoding="async"
@@ -478,7 +478,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
             className="c17 "
           >
             <img
-              alt="chevron-right"
+              alt=""
               className="c26"
               data-nimg="fill"
               decoding="async"
@@ -879,7 +879,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
         data-testid="inline-banner-icon"
       >
         <img
-          alt="info"
+          alt=""
           className="c6"
           data-nimg="fill"
           decoding="async"
@@ -932,7 +932,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
                 data-icon-for="button"
               >
                 <img
-                  alt="cross"
+                  alt=""
                   className="c6"
                   data-nimg="fill"
                   decoding="async"
@@ -994,7 +994,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
             className="c18 "
           >
             <img
-              alt="chevron-right"
+              alt=""
               className="c27"
               data-nimg="fill"
               decoding="async"
@@ -1372,7 +1372,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
         data-testid="inline-banner-icon"
       >
         <img
-          alt="info"
+          alt=""
           className="c6"
           data-nimg="fill"
           decoding="async"
@@ -1425,7 +1425,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
                 data-icon-for="button"
               >
                 <img
-                  alt="cross"
+                  alt=""
                   className="c6"
                   data-nimg="fill"
                   decoding="async"
@@ -1481,7 +1481,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
             className="c17 "
           >
             <img
-              alt="chevron-right"
+              alt=""
               className="c24"
               data-nimg="fill"
               decoding="async"

--- a/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
+++ b/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
       className="c4"
     >
       <img
-        alt="question-mark"
+        alt=""
         className="c5"
         data-nimg="fill"
         decoding="async"

--- a/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
+++ b/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
@@ -325,7 +325,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
                   data-icon-for="button"
                 >
                   <img
-                    alt="cross"
+                    alt=""
                     class="c20"
                     data-nimg="fill"
                     decoding="async"

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
@@ -321,7 +321,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
                       data-icon-for="button"
                     >
                       <img
-                        alt="cross"
+                        alt=""
                         className="c21"
                         data-nimg="fill"
                         decoding="async"

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
@@ -114,7 +114,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
     data-testid="icon"
   >
     <img
-      alt="content-guidance"
+      alt=""
       className="c3"
       data-nimg="fill"
       decoding="async"

--- a/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt="arrow-right"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt="arrow-right"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
+++ b/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`OakRoundIcon matches snapshot 1`] = `
     className="c1"
   >
     <img
-      alt="home"
+      alt=""
       className="c2"
       data-nimg="fill"
       decoding="async"

--- a/src/components/molecules/OakScaleImageButton/__snapshots__/OakScaleImageButton.test.tsx.snap
+++ b/src/components/molecules/OakScaleImageButton/__snapshots__/OakScaleImageButton.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`OakScaleImageButton matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt="expand"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt="arrow-right"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/molecules/OakSignLanguageButton/__snapshots__/OakSignLanguageButton.test.tsx.snap
+++ b/src/components/molecules/OakSignLanguageButton/__snapshots__/OakSignLanguageButton.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
             className="c9"
           >
             <img
-              alt="sign-language"
+              alt=""
               className="c10"
               data-nimg="fill"
               decoding="async"

--- a/src/components/molecules/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt="arrow-right"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/molecules/OakSmallPrimaryInvertedButton/__snapshots__/OakSmallPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallPrimaryInvertedButton/__snapshots__/OakSmallPrimaryInvertedButton.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt="arrow-right"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/molecules/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt="arrow-right"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -391,7 +391,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
           data-testid="inline-banner-icon"
         >
           <img
-            alt="info"
+            alt=""
             className="c7"
             data-nimg="fill"
             decoding="async"
@@ -592,7 +592,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
           className="c28"
         >
           <img
-            alt="arrow-right"
+            alt=""
             className="c29"
             data-nimg="fill"
             decoding="async"

--- a/src/components/organisms/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
@@ -292,7 +292,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
             className="c13"
           >
             <img
-              alt="chevron-right"
+              alt=""
               className="c14"
               data-nimg="fill"
               decoding="async"

--- a/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
                 className="c15"
               >
                 <img
-                  alt="chevron-right"
+                  alt=""
                   className="c16"
                   data-nimg="fill"
                   decoding="async"

--- a/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
@@ -393,7 +393,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
                   className="c22"
                 >
                   <img
-                    alt="chevron-right"
+                    alt=""
                     className="c23"
                     data-nimg="fill"
                     decoding="async"
@@ -474,7 +474,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
                   className="c22"
                 >
                   <img
-                    alt="chevron-right"
+                    alt=""
                     className="c23"
                     data-nimg="fill"
                     decoding="async"

--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt="subject-english"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
@@ -246,7 +246,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
               data-icon-for="button"
             >
               <img
-                alt="chevron-down"
+                alt=""
                 className="c15"
                 data-nimg="fill"
                 decoding="async"

--- a/src/components/organisms/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -299,7 +299,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
                   data-icon-for="button"
                 >
                   <img
-                    alt="lightbulb"
+                    alt=""
                     className="c17"
                     data-nimg="fill"
                     decoding="async"

--- a/src/components/organisms/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -229,7 +229,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
         className="c5"
       >
         <img
-          alt="intro"
+          alt=""
           className="c6"
           data-nimg="fill"
           decoding="async"
@@ -275,7 +275,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
         className="c14"
       >
         <img
-          alt="chevron-right"
+          alt=""
           className="c6"
           data-nimg="fill"
           decoding="async"

--- a/src/components/organisms/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
@@ -209,7 +209,7 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
           className="c6"
         >
           <img
-            alt="intro"
+            alt=""
             className="c7"
             data-nimg="fill"
             decoding="async"

--- a/src/components/organisms/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
@@ -173,7 +173,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
         className="c4"
       >
         <img
-          alt="intro"
+          alt=""
           className="c5"
           data-nimg="fill"
           decoding="async"

--- a/src/components/organisms/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
@@ -209,7 +209,7 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
           className="c6"
         >
           <img
-            alt="quiz"
+            alt=""
             className="c7"
             data-nimg="fill"
             decoding="async"

--- a/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -259,7 +259,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
         className="c8"
       >
         <img
-          alt="intro"
+          alt=""
           className="c9"
           data-nimg="fill"
           decoding="async"

--- a/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
                 data-icon-for="button"
               >
                 <img
-                  alt="chevron-down"
+                  alt=""
                   className="c13"
                   data-nimg="fill"
                   decoding="async"

--- a/src/components/organisms/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`OakHintButton matches snapshot 1`] = `
           data-icon-for="button"
         >
           <img
-            alt="lightbulb"
+            alt=""
             className="c12"
             data-nimg="fill"
             decoding="async"

--- a/src/components/organisms/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -212,7 +212,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
               data-icon-for="button"
             >
               <img
-                alt="lightbulb"
+                alt=""
                 className="c12"
                 data-nimg="fill"
                 decoding="async"

--- a/src/components/organisms/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
         className="c4"
       >
         <img
-          alt="move-arrows"
+          alt=""
           className="c5"
           data-nimg="fill"
           decoding="async"

--- a/src/components/organisms/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
         className="c4"
       >
         <img
-          alt="move-arrows"
+          alt=""
           className="c5"
           data-nimg="fill"
           decoding="async"

--- a/src/components/organisms/shared/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
+++ b/src/components/organisms/shared/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
@@ -607,7 +607,7 @@ have_homework =
                 data-icon-for="button"
               >
                 <img
-                  alt="info"
+                  alt=""
                   className="c31"
                   data-nimg="fill"
                   decoding="async"

--- a/src/components/organisms/shared/OakInfo/__snapshots__/OakInfo.test.tsx.snap
+++ b/src/components/organisms/shared/OakInfo/__snapshots__/OakInfo.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`OakInfo matches snapshot 1`] = `
               data-icon-for="button"
             >
               <img
-                alt="info"
+                alt=""
                 className="c12"
                 data-nimg="fill"
                 decoding="async"

--- a/src/components/organisms/shared/OakMediaClipStackListItem/__snapshots__/OakMediaClipStackListItem.test.tsx.snap
+++ b/src/components/organisms/shared/OakMediaClipStackListItem/__snapshots__/OakMediaClipStackListItem.test.tsx.snap
@@ -315,7 +315,7 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
         id="play-icon"
       >
         <img
-          alt="play"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -269,7 +269,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
           disabled={true}
         >
           <img
-            alt="chevron-left"
+            alt=""
             className="c7"
             data-nimg="fill"
             decoding="async"
@@ -451,7 +451,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
           disabled={false}
         >
           <img
-            alt="chevron-right"
+            alt=""
             className="c7"
             data-nimg="fill"
             decoding="async"

--- a/src/components/organisms/shared/OakVideoTranscript/OakVideoTranscript.test.tsx
+++ b/src/components/organisms/shared/OakVideoTranscript/OakVideoTranscript.test.tsx
@@ -36,21 +36,18 @@ describe(OakVideoTranscript, () => {
   });
 
   it("handles transcript click correctly", () => {
-    const { getByAltText, getAllByText } = renderWithTheme(
+    const { getAllByText } = renderWithTheme(
       <OakVideoTranscript {...defaultProps}>children</OakVideoTranscript>,
     );
 
     const transcriptButton = getAllByText("Show transcript")[0];
-    const chevronIcon = getByAltText("chevron-down");
 
     expect(transcriptButton).toHaveTextContent("Show transcript");
-    expect(chevronIcon).toBeInTheDocument();
 
     act(() => {
       transcriptButton && fireEvent.click(transcriptButton);
     });
 
     expect(transcriptButton).toHaveTextContent("Hide transcript");
-    expect(chevronIcon).toHaveAttribute("alt", "chevron-up");
   });
 });

--- a/src/components/organisms/shared/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/shared/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
@@ -229,7 +229,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
               className="c10"
             >
               <img
-                alt="chevron-down"
+                alt=""
                 className="c11"
                 data-nimg="fill"
                 decoding="async"

--- a/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
@@ -826,7 +826,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
                       data-icon-for="button"
                     >
                       <img
-                        alt="cross"
+                        alt=""
                         className="c21"
                         data-nimg="fill"
                         decoding="async"
@@ -1008,7 +1008,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
                             className="c50"
                           >
                             <img
-                              alt="copy"
+                              alt=""
                               className="c51"
                               data-nimg="fill"
                               decoding="async"

--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
@@ -18,6 +18,10 @@ const FlexWithFocus = styled(OakFlex)`
   transition-duration: 300ms;
   outline: none;
 
+  &:hover .hover-text {
+    text-decoration: underline;
+  }
+
   &:focus-visible {
     box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
       ${parseDropShadow("drop-shadow-centered-grey")};
@@ -32,8 +36,6 @@ const StyledUnitListItem = styled(OakFlex)<{ $disabled?: boolean }>`
   ${(props) =>
     !props.$disabled &&
     css`
-      cursor: pointer;
-
       /* Don't apply hover styles on touch devices */
       @media (hover: hover) {
     &:hover {
@@ -148,6 +150,7 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
             <OakP
               $font={"heading-7"}
               $color={unavailable ? "text-disabled" : "text-primary"}
+              className="hover-text"
             >
               {props.title}
             </OakP>

--- a/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -407,7 +407,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
             className="c20"
           >
             <img
-              alt="chevron-right"
+              alt=""
               className="c21"
               data-nimg="fill"
               decoding="async"

--- a/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -287,6 +287,11 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   outline: none;
 }
 
+.c6:hover .hover-text {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c6:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -297,7 +302,6 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   animation-timing-function: ease-out;
   -webkit-transition-duration: 300ms;
   transition-duration: 300ms;
-  cursor: pointer;
 }
 
 .c10 {
@@ -379,7 +383,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
           className="c12 c13"
         >
           <p
-            className="c14"
+            className="c14 hover-text"
           >
             Lesson 1
           </p>

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/OakUnitListOptionalityItemCard.test.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/OakUnitListOptionalityItemCard.test.tsx
@@ -47,6 +47,8 @@ describe("OakUnitListOptionalityItemCard", () => {
         lessonCount={"0 lessons"}
         href={""}
         slug="test"
+        onSave={() => {}}
+        isSaved={false}
       />,
     );
 

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/OakUnitListOptionalityItemCard.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/OakUnitListOptionalityItemCard.tsx
@@ -12,6 +12,10 @@ const StyledOptionalityListItem = styled(OakFlex)<{ $disabled?: boolean }>`
   animation-timing-function: ease-out;
   transition-duration: 300ms;
 
+  &:hover .hover-text {
+    text-decoration: underline;
+  }
+
   &:focus-visible {
     background: ${parseColor("white")};
     box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
@@ -20,8 +24,6 @@ const StyledOptionalityListItem = styled(OakFlex)<{ $disabled?: boolean }>`
   ${(props) =>
     !props.$disabled &&
     css`  
-      cursor: pointer;
-
       /* Don't apply hover styles on touch devices */
       @media (hover: hover) {
     &:hover {
@@ -74,6 +76,10 @@ const HeadingWithFocus = styled(OakHeading)`
   border-radius: 6px;
   padding: 4px;
 
+  &:hover {
+    text-decoration: underline;
+  }
+
   &:focus-visible {
     box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
       ${parseDropShadow("drop-shadow-centered-grey")};
@@ -109,6 +115,9 @@ export const OakUnitListOptionalityItemCard = (
         $ba="border-solid-m"
         $disabled={unavailable}
         $flexGrow={1}
+        as={onSave ? "li" : "a"}
+        href={unavailable ? undefined : href}
+        ref={firstItemRef}
         {...rest}
       >
         <OakFlex
@@ -121,10 +130,11 @@ export const OakUnitListOptionalityItemCard = (
             $color={unavailable ? "text-disabled" : "text-primary"}
             tag={"h3"}
             $mb={"space-between-xs"}
-            as={"a"}
+            as={onSave ? "a" : "h3"}
             onClick={unavailable ? undefined : onClick}
             href={unavailable ? undefined : href}
             ref={firstItemRef}
+            className={onSave ? undefined : "hover-text"}
           >
             {props.title}
           </HeadingWithFocus>
@@ -136,6 +146,7 @@ export const OakUnitListOptionalityItemCard = (
               <OakSpan
                 $color={unavailable ? "text-disabled" : "text-primary"}
                 $font={"heading-light-7"}
+                className={onSave ? undefined : "hover-text"}
               >
                 {lessonCount}
               </OakSpan>

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
@@ -134,7 +134,11 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   animation-timing-function: ease-out;
   -webkit-transition-duration: 300ms;
   transition-duration: 300ms;
-  cursor: pointer;
+}
+
+.c3:hover .hover-text {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c3:focus-visible {
@@ -152,6 +156,11 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   padding: 4px;
 }
 
+.c7:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c7:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
@@ -165,19 +174,20 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
 <div
     className="c0 c1"
   >
-    <div
+    <a
       className="c2 c1 c3"
+      href=""
       title="Lesson 1"
     >
       <div
         className="c4 c5"
       >
-        <a
-          className="c6 c7"
+        <h3
+          className="c6 c7 hover-text"
           href=""
         >
           Lesson 1
-        </a>
+        </h3>
         <div
           className="c8 c9"
         >
@@ -185,7 +195,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
             className="c4 c10"
           >
             <span
-              className="c11"
+              className="c11 hover-text"
             >
               0 lessons
             </span>
@@ -220,7 +230,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
           </div>
         </div>
       </div>
-    </div>
+    </a>
   </div>,
   ",",
 ]

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
@@ -203,7 +203,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
               className="c12"
             >
               <img
-                alt="chevron-right"
+                alt=""
                 className="c13"
                 data-nimg="fill"
                 decoding="async"

--- a/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
@@ -485,7 +485,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
               data-icon-for="button"
             >
               <img
-                alt="chevron-right"
+                alt=""
                 className="c26"
                 data-nimg="fill"
                 decoding="async"

--- a/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
@@ -436,7 +436,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
             data-icon-for="button"
           >
             <img
-              alt="chevron-right"
+              alt=""
               className="c23"
               data-nimg="fill"
               decoding="async"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- removes icon name as default alt text on OakIcon so now icons (including in buttons) will have alt text "" by default
- Add an underline to the unit title on OakUnitListItem and OakUnitListOptionalityItem when the link is hovered
- Remove the cursor pointer from the whole of the optionality item cards
- Refactored the OakUnitListOptionalityItemCard so that the whole card is still a link when save is not enabled, and add underline to the `10 lessons >` on hover as well as the title

## Link to the design doc
From comments on [this PR](https://github.com/oaknational/Oak-Web-Application/pull/3374)

## A link to the component in the deployment preview
Optionality item: [with save](https://deploy-preview-410--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-teacher-oakunitlistoptionalityitem--with-save) and [without save](https://deploy-preview-410--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-teacher-oakunitlistoptionalityitem--default)
Unit list item: [with save ](https://deploy-preview-410--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-teacher-oakunitlistitem--with-save)and [without save](https://deploy-preview-410--lively-meringue-8ebd43.netlify.app/?path=/story/components-organisms-teacher-oakunitlistitem--default)


