### PR TITLE
fix: add test ids to icons where they are being used in tests in OWA

### DIFF
--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/OakPupilJourneySubjectButton.tsx
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/OakPupilJourneySubjectButton.tsx
@@ -72,6 +72,7 @@ export const OakPupilJourneySubjectButton = <C extends ElementType = "button">({
   const iconOverride = (
     <OakIcon
       iconName={subjectIconName}
+      alt={subjectIconName}
       $minWidth={"all-spacing-12"}
       $minHeight={"all-spacing-12"}
       aria-hidden="true"

--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/OakPupilJourneySubjectButton.tsx
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/OakPupilJourneySubjectButton.tsx
@@ -72,7 +72,7 @@ export const OakPupilJourneySubjectButton = <C extends ElementType = "button">({
   const iconOverride = (
     <OakIcon
       iconName={subjectIconName}
-      alt={subjectIconName}
+      data-testid={subjectIconName}
       $minWidth={"all-spacing-12"}
       $minHeight={"all-spacing-12"}
       aria-hidden="true"

--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
         className="c7"
       >
         <img
-          alt=""
+          alt="subject-english"
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
@@ -167,9 +167,10 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
       <div
         aria-hidden="true"
         className="c7"
+        data-testid="subject-english"
       >
         <img
-          alt="subject-english"
+          alt=""
           className="c8"
           data-nimg="fill"
           decoding="async"

--- a/src/components/organisms/pupil/quiz/OakQuizResultItem/OakQuizResultItem.tsx
+++ b/src/components/organisms/pupil/quiz/OakQuizResultItem/OakQuizResultItem.tsx
@@ -114,6 +114,7 @@ export const OakQuizResultItem = ({
         {feedbackState && (
           <OakIcon
             iconName={feedbackState === "correct" ? "tick" : "cross"}
+            alt={feedbackState === "correct" ? "tick" : "cross"}
             $width={"all-spacing-7"}
             $height={"all-spacing-7"}
             $colorFilter={

--- a/src/components/organisms/pupil/quiz/OakQuizResultItem/OakQuizResultItem.tsx
+++ b/src/components/organisms/pupil/quiz/OakQuizResultItem/OakQuizResultItem.tsx
@@ -114,7 +114,7 @@ export const OakQuizResultItem = ({
         {feedbackState && (
           <OakIcon
             iconName={feedbackState === "correct" ? "tick" : "cross"}
-            alt={feedbackState === "correct" ? "tick" : "cross"}
+            data-testid={feedbackState === "correct" ? "tick" : "cross"}
             $width={"all-spacing-7"}
             $height={"all-spacing-7"}
             $colorFilter={


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- after removing alt text from icons by default a few tests in OWA were using the alt text in tests to validate the correct icon is being applied, so I've added data-testids to these so they can still be identified correctly in tests