### PR TITLE
refactor: updated OakUnitsContainer and OakUnitsHeader to take a ReactNode for the banner

### DIFF
--- a/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.tsx
+++ b/src/components/organisms/teacher/OakUnitsContainer/OakUnitsContainer.tsx
@@ -17,9 +17,6 @@ const OakULFlex = styled(OakUL)`
 export type OakUnitsContainerProps = OakUnitsHeaderProps & {
   showHeader: boolean;
   unitCards: Array<React.ReactNode>;
-  isCustomUnit?: boolean;
-  customHeadingText?: string;
-  bannerText?: string;
 };
 
 const OakUnitsContainerCss = css<OakUnitsContainerProps>``;
@@ -34,7 +31,7 @@ const UnstyledComponent = (props: OakUnitsContainerProps) => {
     subject,
     isCustomUnit,
     customHeadingText,
-    bannerText,
+    banner,
     ...rest
   } = props;
   return (
@@ -56,7 +53,7 @@ const UnstyledComponent = (props: OakUnitsContainerProps) => {
           $width="100%"
           isCustomUnit={isCustomUnit}
           customHeadingText={customHeadingText}
-          bannerText={bannerText}
+          banner={banner}
         />
       )}
       <OakULFlex aria-label="A list of units" $reset $width="100%">

--- a/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
+++ b/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
@@ -2,11 +2,7 @@ import React from "react";
 import styled, { css } from "styled-components";
 
 import { OakFlex, OakHeading, OakTypography } from "@/components/atoms";
-import {
-  OakInlineBanner,
-  OakPromoTag,
-  OakTertiaryButton,
-} from "@/components/molecules";
+import { OakPromoTag, OakTertiaryButton } from "@/components/molecules";
 import { SizeStyleProps, sizeStyle } from "@/styles/utils/sizeStyle";
 
 export type OakUnitsHeaderProps = {
@@ -16,7 +12,7 @@ export type OakUnitsHeaderProps = {
   curriculumHref: string | null;
   isCustomUnit?: boolean;
   customHeadingText?: string;
-  bannerText?: string;
+  banner?: React.ReactNode;
 } & SizeStyleProps;
 
 const OakUnitsHeaderCss = css<OakUnitsHeaderProps>`
@@ -47,7 +43,7 @@ const UnstyledComponent = (props: OakUnitsHeaderProps) => {
     isLegacy,
     phase,
     curriculumHref: href,
-    bannerText,
+    banner,
     isCustomUnit,
     customHeadingText,
     ...rest
@@ -93,16 +89,7 @@ const UnstyledComponent = (props: OakUnitsHeaderProps) => {
           />
         )}
       </OakFlex>
-      {bannerText && (
-        <OakFlex $width={"100%"}>
-          <OakInlineBanner
-            isOpen={true}
-            message={bannerText}
-            type="neutral"
-            $width={"100%"}
-          />
-        </OakFlex>
-      )}
+      {banner && <OakFlex $width={"100%"}>{banner}</OakFlex>}
     </>
   );
 };


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Updated the OakUnitsHeader component to accept a full ReactNode as the content, instead of just plain text.

The purpose of this is to allow more flexibility with what banner is displayed in its place.

## Link to the design doc
There should be no noticeable changes when comparing against the original implementation.

## A link to the component in the deployment preview
OakUnitsContainer story
OakUnitsHeader story

## Testing instructions
Check that there are no noticeable visual changes with the original components after implementing this.

## ACs
- [ ] OakUnitsContainer looks the same as before
- [ ] OakUnitsHeader looks the same as before