### PR TITLE
Feat/lesq 1337/toast component [LESQ-1337]

### DIFF
--- a/src/components/molecules/OakToast/OakToast.stories.tsx
+++ b/src/components/molecules/OakToast/OakToast.stories.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { StoryObj, Meta } from "@storybook/react";
+
+import { OakToast } from "./OakToast";
+
+const meta: Meta<typeof OakToast> = {
+  title: "components/molecules/OakToast",
+  component: OakToast,
+  tags: ["autodocs"],
+  argTypes: {
+    message: {
+      control: {
+        type: "text",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OakToast>;
+
+export const Default: Story = {
+  render: (args) => <OakToast {...args} />,
+  args: {
+    message: (
+      <span>
+        This is a <b>toast</b> message
+      </span>
+    ),
+  },
+};

--- a/src/components/molecules/OakToast/OakToast.stories.tsx
+++ b/src/components/molecules/OakToast/OakToast.stories.tsx
@@ -34,6 +34,6 @@ export const Default: Story = {
   render: (args) => <OakToast {...args} />,
   args: {
     message: "this is a toast message",
-    autoDismiss: true,
+    autoDismiss: false,
   },
 };

--- a/src/components/molecules/OakToast/OakToast.stories.tsx
+++ b/src/components/molecules/OakToast/OakToast.stories.tsx
@@ -55,6 +55,7 @@ export const Default: Story = {
     autoDismiss: false,
     showIcon: true,
     variant: "green",
+    onClose: () => console.log("Toast closed"),
   },
 };
 
@@ -71,5 +72,6 @@ export const LongElaborateMessage: Story = {
     autoDismiss: false,
     showIcon: true,
     variant: "pink",
+    onClose: () => console.log("Toast closed"),
   },
 };

--- a/src/components/molecules/OakToast/OakToast.stories.tsx
+++ b/src/components/molecules/OakToast/OakToast.stories.tsx
@@ -13,6 +13,16 @@ const meta: Meta<typeof OakToast> = {
         type: "text",
       },
     },
+    autoDismiss: {
+      control: {
+        type: "boolean",
+      },
+    },
+    autoDismissDuration: {
+      control: {
+        type: "number",
+      },
+    },
   },
 };
 
@@ -23,10 +33,7 @@ type Story = StoryObj<typeof OakToast>;
 export const Default: Story = {
   render: (args) => <OakToast {...args} />,
   args: {
-    message: (
-      <span>
-        This is a <b>toast</b> message
-      </span>
-    ),
+    message: "this is a toast message",
+    autoDismiss: true,
   },
 };

--- a/src/components/molecules/OakToast/OakToast.stories.tsx
+++ b/src/components/molecules/OakToast/OakToast.stories.tsx
@@ -23,6 +23,24 @@ const meta: Meta<typeof OakToast> = {
         type: "number",
       },
     },
+    showIcon: {
+      control: {
+        type: "boolean",
+      },
+    },
+    variant: {
+      options: [
+        "green",
+        "yellow",
+        "pink",
+        "blue",
+        "aqua",
+        "light",
+        "dark",
+        "error",
+        "success",
+      ],
+    },
   },
 };
 
@@ -35,5 +53,23 @@ export const Default: Story = {
   args: {
     message: "this is a toast message",
     autoDismiss: false,
+    showIcon: true,
+    variant: "green",
+  },
+};
+
+export const LongElaborateMessage: Story = {
+  render: (args) => <OakToast {...args} />,
+  args: {
+    message: (
+      <span>
+        "Lorem ipsum dolor sit amet, <b>consectetur adipiscing elit</b>. Sed do
+        eiusmod <i>tempor incididunt</i> ut labore et dolore magna <b>aliqua</b>
+        ."
+      </span>
+    ),
+    autoDismiss: false,
+    showIcon: true,
+    variant: "pink",
   },
 };

--- a/src/components/molecules/OakToast/OakToast.test.tsx
+++ b/src/components/molecules/OakToast/OakToast.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { create } from "react-test-renderer";
+
+import { OakToast } from "./OakToast";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { OakThemeProvider } from "@/components/atoms";
+import { oakDefaultTheme } from "@/styles";
+
+const defautProps = {
+  message: <span>This is a toast message</span>,
+};
+
+describe("OakToast", () => {
+  it("renders", () => {
+    const { getByTestId } = renderWithTheme(<OakToast {...defautProps} />);
+    expect(getByTestId("oak-toast")).toBeInTheDocument();
+  });
+
+  it("matches snapshot", () => {
+    const tree = create(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakToast {...defautProps} />
+      </OakThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/OakToast/OakToast.test.tsx
+++ b/src/components/molecules/OakToast/OakToast.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { create } from "react-test-renderer";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { OakToast } from "./OakToast";
 
@@ -17,8 +19,32 @@ const defautProps = {
 
 describe("OakToast", () => {
   it("renders", () => {
-    const { getByTestId } = renderWithTheme(<OakToast {...defautProps} />);
-    expect(getByTestId("oak-toast")).toBeInTheDocument();
+    renderWithTheme(<OakToast {...defautProps} />);
+    expect(screen.getByTestId("oak-toast")).toBeInTheDocument();
+  });
+
+  it("disappears with auto dismiss enabled", async () => {
+    renderWithTheme(<OakToast {...defautProps} autoDismiss />);
+    const toast = screen.getByTestId("oak-toast");
+    expect(toast).toBeVisible();
+    setTimeout(() => {
+      expect(toast).not.toBeVisible();
+    }, 5000);
+  });
+
+  it("disappears when close is clicked", async () => {
+    renderWithTheme(<OakToast {...defautProps} />);
+    const toast = screen.getByTestId("oak-toast");
+    expect(toast).toBeVisible();
+    const closeButton = screen.getByRole("button");
+    userEvent.click(closeButton);
+    await waitFor(() => expect(toast).not.toBeVisible());
+  });
+
+  it("does not render close button when autoDismiss is true", () => {
+    renderWithTheme(<OakToast {...defautProps} autoDismiss />);
+    const closeButton = screen.queryByRole("button");
+    expect(closeButton).not.toBeInTheDocument();
   });
 
   it("matches snapshot", () => {

--- a/src/components/molecules/OakToast/OakToast.test.tsx
+++ b/src/components/molecules/OakToast/OakToast.test.tsx
@@ -10,6 +10,9 @@ import { oakDefaultTheme } from "@/styles";
 
 const defautProps = {
   message: <span>This is a toast message</span>,
+  variant: "green" as const,
+  showIcon: true,
+  autoDismiss: false,
 };
 
 describe("OakToast", () => {

--- a/src/components/molecules/OakToast/OakToast.tsx
+++ b/src/components/molecules/OakToast/OakToast.tsx
@@ -38,21 +38,24 @@ type Variant = Record<
   }
 >;
 
+const SuccessIconBackground = styled(OakBox)`
+  top: 6px;
+  left: 6px;
+`;
+
 const SuccessIcon = (
   <OakBox $position="relative">
-    <OakBox
-      $width="all-spacing-4"
-      $height="all-spacing-4"
+    <SuccessIconBackground
+      $width="all-spacing-5"
+      $height="all-spacing-5"
       $background="white"
       $borderRadius="border-radius-circle"
       $position="absolute"
-      $top="all-spacing-1"
-      $left="all-spacing-1"
     />
     <OakIcon
       iconName="success"
-      $width="all-spacing-6"
-      $height="all-spacing-6"
+      $width="all-spacing-7"
+      $height="all-spacing-7"
     />
   </OakBox>
 );
@@ -99,8 +102,8 @@ const variants: Variant = {
       <OakIcon
         iconName="warning"
         $colorFilter="text-inverted"
-        $height="all-spacing-6"
-        $width="all-spacing-6"
+        $height="all-spacing-7"
+        $width="all-spacing-7"
       />
     ),
     color: "white",

--- a/src/components/molecules/OakToast/OakToast.tsx
+++ b/src/components/molecules/OakToast/OakToast.tsx
@@ -1,22 +1,67 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import { Transition, TransitionStatus } from "react-transition-group";
 
 import { OakFlex } from "@/components/atoms/OakFlex";
 import { OakColorToken } from "@/styles";
+import { parseOpacity } from "@/styles/helpers/parseOpacity";
 
 export type OakToastProps = {
   message: React.ReactNode;
   background?: OakColorToken;
+  autoDismissDuration?: number;
+  autoDismiss?: boolean;
 };
 
-export const OakToast = ({ message, background }: OakToastProps) => {
+const StyledFlex = styled(OakFlex)<{ $state: TransitionStatus }>`
+  opacity: ${({ $state }) => {
+    switch ($state) {
+      case "exiting":
+      case "entering":
+        return parseOpacity("semi-transparent");
+      case "exited":
+        return parseOpacity("transparent");
+      case "entered":
+        return parseOpacity("opaque");
+      default:
+        return parseOpacity("transparent");
+    }
+  }};
+  transition: opacity 0.3s ease-in-out;
+`;
+
+export const OakToast = ({
+  message,
+  background,
+  autoDismiss,
+  autoDismissDuration,
+}: OakToastProps) => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    if (autoDismiss && isVisible) {
+      const timer = setTimeout(() => {
+        setIsVisible(false);
+      }, autoDismissDuration || 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [autoDismiss, autoDismissDuration, isVisible]);
+
+  const transitionRef = React.useRef<HTMLDivElement>(null);
+
   return (
-    <OakFlex
-      data-testid="oak-toast"
-      $pa="inner-padding-m"
-      $borderRadius="border-radius-m2"
-      $background={background ?? "bg-decorative1-main"}
-    >
-      {message}
-    </OakFlex>
+    <Transition nodeRef={transitionRef} in={isVisible} timeout={300} appear>
+      {(state) => (
+        <StyledFlex
+          data-testid="oak-toast"
+          $pa="inner-padding-m"
+          $borderRadius="border-radius-m2"
+          $background={background ?? "bg-decorative1-main"}
+          $state={state}
+        >
+          {message}
+        </StyledFlex>
+      )}
+    </Transition>
   );
 };

--- a/src/components/molecules/OakToast/OakToast.tsx
+++ b/src/components/molecules/OakToast/OakToast.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import { OakFlex } from "@/components/atoms/OakFlex";
+import { OakColorToken } from "@/styles";
+
+export type OakToastProps = {
+  message: React.ReactNode;
+  background?: OakColorToken;
+};
+
+export const OakToast = ({ message, background }: OakToastProps) => {
+  return (
+    <OakFlex
+      data-testid="oak-toast"
+      $pa="inner-padding-m"
+      $borderRadius="border-radius-m2"
+      $background={background ?? "bg-decorative1-main"}
+    >
+      {message}
+    </OakFlex>
+  );
+};

--- a/src/components/molecules/OakToast/OakToast.tsx
+++ b/src/components/molecules/OakToast/OakToast.tsx
@@ -15,6 +15,7 @@ export type OakToastProps = {
   autoDismissDuration?: number;
   autoDismiss: boolean;
   showIcon: boolean;
+  onClose?: () => void;
 };
 
 type VariantKey =
@@ -134,6 +135,7 @@ export const OakToast = ({
   autoDismiss = false,
   autoDismissDuration = 5000,
   showIcon,
+  onClose,
 }: OakToastProps) => {
   const [isVisible, setIsVisible] = useState(true);
 
@@ -154,7 +156,13 @@ export const OakToast = ({
   const { background, icon, color } = variants[variant];
 
   return (
-    <Transition nodeRef={transitionRef} in={isVisible} timeout={300} appear>
+    <Transition
+      nodeRef={transitionRef}
+      in={isVisible}
+      timeout={300}
+      appear
+      onExited={onClose}
+    >
       {(state) => (
         <StyledFlex
           data-testid="oak-toast"

--- a/src/components/molecules/OakToast/OakToast.tsx
+++ b/src/components/molecules/OakToast/OakToast.tsx
@@ -2,16 +2,113 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { Transition, TransitionStatus } from "react-transition-group";
 
+import { InternalShadowIconButton } from "../InternalShadowIconButton";
+
 import { OakFlex } from "@/components/atoms/OakFlex";
 import { OakColorToken } from "@/styles";
 import { parseOpacity } from "@/styles/helpers/parseOpacity";
-import { InternalShadowRoundButton } from "../InternalShadowRoundButton";
+import { OakBox, OakIcon } from "@/components/atoms";
 
 export type OakToastProps = {
   message: React.ReactNode;
-  background?: OakColorToken;
+  variant: VariantKey;
   autoDismissDuration?: number;
-  autoDismiss?: boolean;
+  autoDismiss: boolean;
+  showIcon: boolean;
+};
+
+type VariantKey =
+  | "green"
+  | "yellow"
+  | "pink"
+  | "blue"
+  | "aqua"
+  | "light"
+  | "dark"
+  | "error"
+  | "success";
+
+type Variant = Record<
+  VariantKey,
+  {
+    background: OakColorToken;
+    icon: React.ReactNode;
+    color: OakColorToken;
+  }
+>;
+
+const SuccessIcon = (
+  <OakBox $position="relative">
+    <OakBox
+      $width="all-spacing-4"
+      $height="all-spacing-4"
+      $background="white"
+      $borderRadius="border-radius-circle"
+      $position="absolute"
+      $top="all-spacing-1"
+      $left="all-spacing-1"
+    />
+    <OakIcon
+      iconName="success"
+      $width="all-spacing-6"
+      $height="all-spacing-6"
+    />
+  </OakBox>
+);
+
+const variants: Variant = {
+  green: {
+    background: "mint",
+    icon: SuccessIcon,
+    color: "black",
+  },
+  yellow: {
+    background: "lemon",
+    icon: SuccessIcon,
+    color: "black",
+  },
+  pink: {
+    background: "pink",
+    icon: SuccessIcon,
+    color: "black",
+  },
+  blue: {
+    background: "lavender110",
+    icon: SuccessIcon,
+    color: "black",
+  },
+  aqua: {
+    background: "aqua",
+    icon: SuccessIcon,
+    color: "black",
+  },
+  light: {
+    background: "white",
+    icon: SuccessIcon,
+    color: "black",
+  },
+  dark: {
+    background: "black",
+    icon: SuccessIcon,
+    color: "white",
+  },
+  error: {
+    background: "red",
+    icon: (
+      <OakIcon
+        iconName="warning"
+        $colorFilter="text-inverted"
+        $height="all-spacing-6"
+        $width="all-spacing-6"
+      />
+    ),
+    color: "white",
+  },
+  success: {
+    background: "oakGreen",
+    icon: SuccessIcon,
+    color: "white",
+  },
 };
 
 const StyledFlex = styled(OakFlex)<{ $state: TransitionStatus }>`
@@ -33,9 +130,10 @@ const StyledFlex = styled(OakFlex)<{ $state: TransitionStatus }>`
 
 export const OakToast = ({
   message,
-  background,
+  variant,
   autoDismiss,
   autoDismissDuration,
+  showIcon,
 }: OakToastProps) => {
   const [isVisible, setIsVisible] = useState(true);
 
@@ -50,6 +148,8 @@ export const OakToast = ({
 
   const transitionRef = React.useRef<HTMLDivElement>(null);
 
+  const { background, icon, color } = variants[variant];
+
   return (
     <Transition nodeRef={transitionRef} in={isVisible} timeout={300} appear>
       {(state) => (
@@ -57,26 +157,27 @@ export const OakToast = ({
           data-testid="oak-toast"
           $pa="inner-padding-m"
           $borderRadius="border-radius-m2"
-          $background={background ?? "bg-decorative1-main"}
+          $background={background}
           $state={state}
           $width="max-content"
           $maxWidth="all-spacing-20"
           $gap="space-between-xs"
+          $dropShadow="drop-shadow-standard"
+          $alignItems="center"
+          $font="heading-light-7"
+          $color={color}
+          $position="relative"
         >
+          {showIcon && icon}
           {message}
           {!autoDismiss && (
-            <InternalShadowRoundButton
+            <InternalShadowIconButton
               aria-label={"Dismiss toast"}
-              defaultIconBackground="transparent"
-              defaultIconColor="black"
+              defaultIconColor={color}
               defaultTextColor="transparent"
               hoverTextColor="transparent"
               disabledTextColor="transparent"
-              hoverIconBackground="black"
-              hoverIconColor="white"
-              disabledIconBackground="transparent"
-              iconBackgroundSize="all-spacing-6"
-              iconSize="all-spacing-6"
+              hoverIconColor={color}
               iconName="cross"
               onClick={() => setIsVisible(false)}
             />

--- a/src/components/molecules/OakToast/OakToast.tsx
+++ b/src/components/molecules/OakToast/OakToast.tsx
@@ -5,6 +5,7 @@ import { Transition, TransitionStatus } from "react-transition-group";
 import { OakFlex } from "@/components/atoms/OakFlex";
 import { OakColorToken } from "@/styles";
 import { parseOpacity } from "@/styles/helpers/parseOpacity";
+import { InternalShadowRoundButton } from "../InternalShadowRoundButton";
 
 export type OakToastProps = {
   message: React.ReactNode;
@@ -58,8 +59,28 @@ export const OakToast = ({
           $borderRadius="border-radius-m2"
           $background={background ?? "bg-decorative1-main"}
           $state={state}
+          $width="max-content"
+          $maxWidth="all-spacing-20"
+          $gap="space-between-xs"
         >
           {message}
+          {!autoDismiss && (
+            <InternalShadowRoundButton
+              aria-label={"Dismiss toast"}
+              defaultIconBackground="transparent"
+              defaultIconColor="black"
+              defaultTextColor="transparent"
+              hoverTextColor="transparent"
+              disabledTextColor="transparent"
+              hoverIconBackground="black"
+              hoverIconColor="white"
+              disabledIconBackground="transparent"
+              iconBackgroundSize="all-spacing-6"
+              iconSize="all-spacing-6"
+              iconName="cross"
+              onClick={() => setIsVisible(false)}
+            />
+          )}
         </StyledFlex>
       )}
     </Transition>

--- a/src/components/molecules/OakToast/OakToast.tsx
+++ b/src/components/molecules/OakToast/OakToast.tsx
@@ -131,17 +131,20 @@ const StyledFlex = styled(OakFlex)<{ $state: TransitionStatus }>`
 export const OakToast = ({
   message,
   variant,
-  autoDismiss,
-  autoDismissDuration,
+  autoDismiss = false,
+  autoDismissDuration = 5000,
   showIcon,
 }: OakToastProps) => {
   const [isVisible, setIsVisible] = useState(true);
 
   useEffect(() => {
     if (autoDismiss && isVisible) {
-      const timer = setTimeout(() => {
-        setIsVisible(false);
-      }, autoDismissDuration || 5000);
+      const timer = setTimeout(
+        () => {
+          setIsVisible(false);
+        },
+        Math.max(5000, autoDismissDuration),
+      );
       return () => clearTimeout(timer);
     }
   }, [autoDismiss, autoDismissDuration, isVisible]);

--- a/src/components/molecules/OakToast/OakToast.tsx
+++ b/src/components/molecules/OakToast/OakToast.tsx
@@ -171,7 +171,7 @@ export const OakToast = ({
           $background={background}
           $state={state}
           $width="max-content"
-          $maxWidth="all-spacing-20"
+          $maxWidth={["all-spacing-19", "all-spacing-20"]}
           $gap="space-between-xs"
           $dropShadow="drop-shadow-standard"
           $alignItems="center"
@@ -183,7 +183,7 @@ export const OakToast = ({
           {message}
           {!autoDismiss && (
             <InternalShadowIconButton
-              aria-label={"Dismiss toast"}
+              aria-label={"Dismiss"}
               defaultIconColor={color}
               defaultTextColor="transparent"
               hoverTextColor="transparent"

--- a/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
+++ b/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
@@ -92,6 +92,28 @@ exports[`OakToast matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
+.c6 {
+  object-fit: contain;
+}
+
+.c17 {
+  -webkit-filter: invert(34%) sepia(0%) saturate(698%) hue-rotate(158deg) brightness(95%) contrast(89%);
+  filter: invert(34%) sepia(0%) saturate(698%) hue-rotate(158deg) brightness(95%) contrast(89%);
+  object-fit: contain;
+}
+
+.c19 {
+  -webkit-filter: invert(82%) sepia(25%) saturate(963%) hue-rotate(359deg) brightness(106%) contrast(101%);
+  filter: invert(82%) sepia(25%) saturate(963%) hue-rotate(359deg) brightness(106%) contrast(101%);
+  object-fit: contain;
+}
+
+.c20 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  object-fit: contain;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -143,28 +165,6 @@ exports[`OakToast matches snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c6 {
-  object-fit: contain;
-}
-
-.c17 {
-  -webkit-filter: invert(34%) sepia(0%) saturate(698%) hue-rotate(158deg) brightness(95%) contrast(89%);
-  filter: invert(34%) sepia(0%) saturate(698%) hue-rotate(158deg) brightness(95%) contrast(89%);
-  object-fit: contain;
-}
-
-.c19 {
-  -webkit-filter: invert(82%) sepia(25%) saturate(963%) hue-rotate(359deg) brightness(106%) contrast(101%);
-  filter: invert(82%) sepia(25%) saturate(963%) hue-rotate(359deg) brightness(106%) contrast(101%);
-  object-fit: contain;
-}
-
-.c20 {
-  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
-  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
-  object-fit: contain;
 }
 
 .c21 {

--- a/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
+++ b/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
@@ -29,25 +29,23 @@ exports[`OakToast matches snapshot 1`] = `
 
 .c4 {
   position: absolute;
-  top: 0.25rem;
-  left: 0.25rem;
-  width: 1rem;
-  height: 1rem;
+  width: 1.25rem;
+  height: 1.25rem;
   background: #ffffff;
   border-radius: 6.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c6 {
   position: relative;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  height: 1.5rem;
-  min-height: 1.5rem;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c8 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -55,20 +53,20 @@ exports[`OakToast matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c13 {
   padding-left: 0rem;
   padding-right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c15 {
   position: relative;
   color: transparent;
   border-radius: 6.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c17 {
   position: absolute;
   top: 0.25rem;
   left: 0.25rem;
@@ -80,7 +78,7 @@ exports[`OakToast matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c19 {
   position: absolute;
   top: 0.125rem;
   left: 0.125rem;
@@ -92,23 +90,32 @@ exports[`OakToast matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c21 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c7 {
   object-fit: contain;
 }
 
-.c17 {
+.c18 {
   -webkit-filter: invert(34%) sepia(0%) saturate(698%) hue-rotate(158deg) brightness(95%) contrast(89%);
   filter: invert(34%) sepia(0%) saturate(698%) hue-rotate(158deg) brightness(95%) contrast(89%);
   object-fit: contain;
 }
 
-.c19 {
+.c20 {
   -webkit-filter: invert(82%) sepia(25%) saturate(963%) hue-rotate(359deg) brightness(106%) contrast(101%);
   filter: invert(82%) sepia(25%) saturate(963%) hue-rotate(359deg) brightness(106%) contrast(101%);
   object-fit: contain;
 }
 
-.c20 {
+.c22 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
@@ -126,14 +133,14 @@ exports[`OakToast matches snapshot 1`] = `
   gap: 0.75rem;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -152,7 +159,7 @@ exports[`OakToast matches snapshot 1`] = `
   gap: 0rem;
 }
 
-.c15 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -167,7 +174,7 @@ exports[`OakToast matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c23 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -178,7 +185,7 @@ exports[`OakToast matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c10 {
+.c11 {
   background: none;
   color: inherit;
   border: none;
@@ -193,50 +200,55 @@ exports[`OakToast matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c10:disabled {
+.c11:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   position: relative;
 }
 
-.c11:hover {
+.c12:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: transparent;
 }
 
-.c11:hover:not(:active) [data-icon-for="button"] img {
+.c12:hover:not(:active) [data-icon-for="button"] img {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
 }
 
-.c11:active {
+.c12:active {
   color: transparent;
 }
 
-.c11:disabled {
+.c12:disabled {
   color: transparent;
 }
 
-.c9 > :first-child:hover .highlight {
+.c10 > :first-child:hover .highlight {
   display: block;
 }
 
-.c9 > :first-child:active .highlight {
+.c10 > :first-child:active .highlight {
   display: block;
 }
 
-.c9 > :first-child:active .shadow {
+.c10 > :first-child:active .shadow {
   display: block;
 }
 
-.c9 > :first-child:focus-visible {
+.c10 > :first-child:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
   background: white;
+}
+
+.c5 {
+  top: 6px;
+  left: 6px;
 }
 
 .c2 {
@@ -259,14 +271,14 @@ exports[`OakToast matches snapshot 1`] = `
     className="c3"
   >
     <div
-      className="c4"
+      className="c4 c5"
     />
     <div
-      className="c5"
+      className="c6"
     >
       <img
         alt=""
-        className="c6"
+        className="c7"
         data-nimg="fill"
         decoding="async"
         loading="lazy"
@@ -294,30 +306,30 @@ exports[`OakToast matches snapshot 1`] = `
     This is a toast message
   </span>
   <div
-    className="c7 c8 c9"
+    className="c8 c9 c10"
   >
     <button
       aria-label="Dismiss"
-      className="c10 c11"
+      className="c11 c12"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
       <div
-        className="c12 c13"
+        className="c13 c14"
       >
         <div
-          className="c14 c15 icon-container"
+          className="c15 c16 icon-container"
         >
           <div
             className="c3"
           >
             <div
-              className="c16 shadow"
+              className="c17 shadow"
             >
               <img
                 alt=""
-                className="c17"
+                className="c18"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -341,36 +353,7 @@ exports[`OakToast matches snapshot 1`] = `
               />
             </div>
             <div
-              className="c18 highlight"
-            >
-              <img
-                alt=""
-                className="c19"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                onError={[Function]}
-                onLoad={[Function]}
-                src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895179/icons/xigimrbivcaxt4omxamp.svg"
-                style={
-                  {
-                    "bottom": 0,
-                    "color": "transparent",
-                    "height": "100%",
-                    "left": 0,
-                    "objectFit": undefined,
-                    "objectPosition": undefined,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                    "width": "100%",
-                  }
-                }
-              />
-            </div>
-            <div
-              className="c5"
-              data-icon-for="button"
+              className="c19 highlight"
             >
               <img
                 alt=""
@@ -397,10 +380,39 @@ exports[`OakToast matches snapshot 1`] = `
                 }
               />
             </div>
+            <div
+              className="c21"
+              data-icon-for="button"
+            >
+              <img
+                alt=""
+                className="c22"
+                data-nimg="fill"
+                decoding="async"
+                loading="lazy"
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895179/icons/xigimrbivcaxt4omxamp.svg"
+                style={
+                  {
+                    "bottom": 0,
+                    "color": "transparent",
+                    "height": "100%",
+                    "left": 0,
+                    "objectFit": undefined,
+                    "objectPosition": undefined,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
           </div>
         </div>
         <span
-          className="c21"
+          className="c23"
         />
       </div>
     </button>

--- a/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
+++ b/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
@@ -2,9 +2,93 @@
 
 exports[`OakToast matches snapshot 1`] = `
 .c0 {
+  position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 22.5rem;
   padding: 1rem;
+  color: #222222;
   background: #bef2bd;
   border-radius: 0.5rem;
+  box-shadow: 0 0.5rem 0.5rem rgba(92,92,92,20%);
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c3 {
+  position: relative;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c4 {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  width: 1rem;
+  height: 1rem;
+  background: #ffffff;
+  border-radius: 6.25rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c5 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c7 {
+  position: relative;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c12 {
+  padding-left: 0rem;
+  padding-right: 0.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c14 {
+  position: relative;
+  color: transparent;
+  border-radius: 6.25rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c16 {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  display: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c18 {
+  position: absolute;
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -13,14 +97,307 @@ exports[`OakToast matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 0rem;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c6 {
+  object-fit: contain;
+}
+
+.c17 {
+  -webkit-filter: invert(34%) sepia(0%) saturate(698%) hue-rotate(158deg) brightness(95%) contrast(89%);
+  filter: invert(34%) sepia(0%) saturate(698%) hue-rotate(158deg) brightness(95%) contrast(89%);
+  object-fit: contain;
+}
+
+.c19 {
+  -webkit-filter: invert(82%) sepia(25%) saturate(963%) hue-rotate(359deg) brightness(106%) contrast(101%);
+  filter: invert(82%) sepia(25%) saturate(963%) hue-rotate(359deg) brightness(106%) contrast(101%);
+  object-fit: contain;
+}
+
+.c20 {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  object-fit: contain;
+}
+
+.c21 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c10 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+  color: transparent;
+  border-radius: 0.25rem;
+}
+
+.c10:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+.c11 {
+  display: inline-block;
+  position: relative;
+}
+
+.c11:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: transparent;
+}
+
+.c11:hover:not(:active) [data-icon-for="button"] img {
+  -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+  filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
+}
+
+.c11:active {
+  color: transparent;
+}
+
+.c11:disabled {
+  color: transparent;
+}
+
+.c9 > :first-child:hover .highlight {
+  display: block;
+}
+
+.c9 > :first-child:active .highlight {
+  display: block;
+}
+
+.c9 > :first-child:active .shadow {
+  display: block;
+}
+
+.c9 > :first-child:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+  background: white;
+}
+
+.c2 {
+  opacity: 0.25;
+  -webkit-transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
 }
 
 <div
-  className="c0 c1"
+  className="c0 c1 c2"
   data-testid="oak-toast"
 >
+  <div
+    className="c3"
+  >
+    <div
+      className="c4"
+    />
+    <div
+      className="c5"
+    >
+      <img
+        alt=""
+        className="c6"
+        data-nimg="fill"
+        decoding="async"
+        loading="lazy"
+        onError={[Function]}
+        onLoad={[Function]}
+        src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895534/icons/Icon-Success_aiiprx.svg"
+        style={
+          {
+            "bottom": 0,
+            "color": "transparent",
+            "height": "100%",
+            "left": 0,
+            "objectFit": undefined,
+            "objectPosition": undefined,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "100%",
+          }
+        }
+      />
+    </div>
+  </div>
   <span>
     This is a toast message
   </span>
+  <div
+    className="c7 c8 c9"
+  >
+    <button
+      aria-label="Dismiss toast"
+      className="c10 c11"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="c12 c13"
+      >
+        <div
+          className="c14 c15 icon-container"
+        >
+          <div
+            className="c3"
+          >
+            <div
+              className="c16 shadow"
+            >
+              <img
+                alt=""
+                className="c17"
+                data-nimg="fill"
+                decoding="async"
+                loading="lazy"
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895179/icons/xigimrbivcaxt4omxamp.svg"
+                style={
+                  {
+                    "bottom": 0,
+                    "color": "transparent",
+                    "height": "100%",
+                    "left": 0,
+                    "objectFit": undefined,
+                    "objectPosition": undefined,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="c18 highlight"
+            >
+              <img
+                alt=""
+                className="c19"
+                data-nimg="fill"
+                decoding="async"
+                loading="lazy"
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895179/icons/xigimrbivcaxt4omxamp.svg"
+                style={
+                  {
+                    "bottom": 0,
+                    "color": "transparent",
+                    "height": "100%",
+                    "left": 0,
+                    "objectFit": undefined,
+                    "objectPosition": undefined,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="c5"
+              data-icon-for="button"
+            >
+              <img
+                alt=""
+                className="c20"
+                data-nimg="fill"
+                decoding="async"
+                loading="lazy"
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895179/icons/xigimrbivcaxt4omxamp.svg"
+                style={
+                  {
+                    "bottom": 0,
+                    "color": "transparent",
+                    "height": "100%",
+                    "left": 0,
+                    "objectFit": undefined,
+                    "objectPosition": undefined,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <span
+          className="c21"
+        />
+      </div>
+    </button>
+  </div>
 </div>
 `;

--- a/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
+++ b/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakToast matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  max-width: 22.5rem;
+  max-width: 15rem;
   padding: 1rem;
   color: #222222;
   background: #bef2bd;
@@ -245,6 +245,12 @@ exports[`OakToast matches snapshot 1`] = `
   transition: opacity 0.3s ease-in-out;
 }
 
+@media (min-width:750px) {
+  .c0 {
+    max-width: 22.5rem;
+  }
+}
+
 <div
   className="c0 c1 c2"
   data-testid="oak-toast"
@@ -291,7 +297,7 @@ exports[`OakToast matches snapshot 1`] = `
     className="c7 c8 c9"
   >
     <button
-      aria-label="Dismiss toast"
+      aria-label="Dismiss"
       className="c10 c11"
       onClick={[Function]}
       onMouseEnter={[Function]}

--- a/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
+++ b/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakToast matches snapshot 1`] = `
+.c0 {
+  padding: 1rem;
+  background: #bef2bd;
+  border-radius: 0.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+<div
+  className="c0 c1"
+  data-testid="oak-toast"
+>
+  <span>
+    This is a toast message
+  </span>
+</div>
+`;

--- a/src/components/molecules/OakToast/index.ts
+++ b/src/components/molecules/OakToast/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakToast";

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -50,3 +50,4 @@ export * from "./OakBasicAccordion";
 export * from "./OakLinkCard";
 export * from "./OakInfoButton";
 export * from "./OakSmallTertiaryInvertedButton";
+export * from "./OakToast";


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- adds new component `OakToast`
- adds defined variants with colour & icon combinations
- optional icon
- auto dismissable with customisable duration

## Link to the design doc
https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=14265-1860&m=dev

## A link to the component in the deployment preview
https://deploy-preview-414--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oaktoast--docs

## Testing instructions
Verify the component against the designs, it should:
- be dismissable by close button
- there should be a fade in and out animation 
- enabling autoDismiss should dismiss after 5 seconds
- setting a duration less than 5 seconds (5000) should still display for the minimum of 5 seconds
- there should be no close button when auto dismiss is enabled
- you should be able to toggle the icon off
- background and font/icon colours should match designs for each variant

