### PR TITLE
feat: add modalouterflexprops to oakmodalcenter

### DIFF
--- a/src/components/molecules/OakModalCenter/OakModalCenter.tsx
+++ b/src/components/molecules/OakModalCenter/OakModalCenter.tsx
@@ -30,6 +30,10 @@ export type OakModalCenterProps = {
    */
   modalFlexProps?: Partial<OakFlexProps & HTMLAttributes<Element>>;
   /**
+   * Override HTMLAttributes & OakFlex props for the outer modal container
+   */
+  modalOuterFlexProps?: Partial<OakFlexProps & HTMLAttributes<Element>>;
+  /**
    * Override HTMLAttributes & OakFlex props for the inner modal container
    */
   modalInnerFlexProps?: Partial<OakFlexProps & HTMLAttributes<Element>>;
@@ -97,6 +101,7 @@ const FadeInFlex = styled(OakFlex)<{ $state: TransitionStatus }>`
  * - **disableEscapeKey?** \-       If true, pressing the escape key will not call onClose
  * - **hideCloseButton?** \-        If true, the close button will be hidden
  * - **modalFlexProps?** \-         Override HTMLAttributes & OakFlex props for the modal container
+ * - **modalOuterFlexProps?** \-    Override HTMLAttributes & OakFlex props for the outer modal container
  * - **modalInnerFlexProps?** \-    Override HTMLAttributes & OakFlex props for the inner modal container
  * - **backdropFlexProps?** \-      Override HTMLAttributes & OakFlex props for the backdrop container
  * - **footerSlot?** \-             Fixed area at the bottom of the modal, this will remain fixed in view if the content is scrollable
@@ -110,6 +115,7 @@ export const OakModalCenter = ({
   disableEscapeKey = false,
   hideCloseButton = false,
   modalFlexProps,
+  modalOuterFlexProps,
   modalInnerFlexProps,
   backdropFlexProps,
   footerSlot,
@@ -190,6 +196,7 @@ export const OakModalCenter = ({
             $maxWidth="all-spacing-23"
             $width="100%"
             $pa="inner-padding-l"
+            {...modalOuterFlexProps}
           >
             <FocusOnBox
               onEscapeKey={() => !disableEscapeKey && onClose()}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

- adds `modalOuterFlexProps` to `OakModalCenter` so width of the modal can be adjusted
- show `modalOuterFlexProps` and `modalInnerFlexProps` in stories

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

- Test stories for `OakModalCenter`

## ACs

- `OakModalCenter` should still display as before
- `modalOuterFlexProps` and `modalInnerFlexProps` can be controlled in the stories
