### PR TITLE
feat: added ability to insert footer content and disable share button on teacher modal

### DIFF
--- a/src/components/organisms/teacher/OakTeacherNotesModal/OakTeacherNotesModal.stories.tsx
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/OakTeacherNotesModal.stories.tsx
@@ -147,7 +147,7 @@ const getMsgs = () => {
     "Please do not include phone numbers. This information will be redacted.",
     "Please do not include addresses. This information will be redacted.",
   ].map((m) => (
-    <OakFlex $alignItems="center" $gap="space-between-ssx">
+    <OakFlex $alignItems="center" $gap="space-between-ssx" role="alert">
       <OakIcon iconName="error" $colorFilter="icon-error" />
       <OakSpan $color="icon-error" $font="body-3-bold">
         {m}

--- a/src/components/organisms/teacher/OakTeacherNotesModal/OakTeacherNotesModal.stories.tsx
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/OakTeacherNotesModal.stories.tsx
@@ -8,6 +8,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { OakTeacherNotesModal } from "./OakTeacherNotesModal";
 
 import { OakSecondaryButton } from "@/components/molecules";
+import { OakFlex, OakIcon, OakSpan } from "@/components";
 
 // This component is just to demo how to insert a Tiptap editor into the modal
 // This work should actally be done from OWA to avoid bloating oak components
@@ -82,6 +83,7 @@ const meta: Meta<typeof OakTeacherNotesModal> = {
       type: "boolean",
     },
     remainingCharacters: { type: "number" },
+    shareLinkDisabled: { type: "boolean" },
   },
   parameters: {
     controls: {
@@ -92,6 +94,7 @@ const meta: Meta<typeof OakTeacherNotesModal> = {
         "error",
         "isBold",
         "isBulletList",
+        "shareLinkDisabled",
       ],
     },
   },
@@ -137,6 +140,22 @@ export const Default: Story = {
   },
 };
 
+const getMsgs = () => {
+  return [
+    "Please do not include names of individuals. This information will be redacted.",
+    "Please do not include email addresses. This information will be redacted.",
+    "Please do not include phone numbers. This information will be redacted.",
+    "Please do not include addresses. This information will be redacted.",
+  ].map((m) => (
+    <OakFlex $alignItems="center" $gap="space-between-ssx">
+      <OakIcon iconName="error" $colorFilter="icon-error" />
+      <OakSpan $color="icon-error" $font="body-3-bold">
+        {m}
+      </OakSpan>
+    </OakFlex>
+  ));
+};
+
 export const WithTipTap: Story = {
   render: (args) => {
     const [, updateArgs] = useArgs();
@@ -152,6 +171,7 @@ export const WithTipTap: Story = {
           {...args}
           onClose={onClose}
           editorNode={editorNode}
+          footer={<OakFlex $flexDirection="column">{getMsgs()}</OakFlex>}
         />
       </>
     );

--- a/src/components/organisms/teacher/OakTeacherNotesModal/OakTeacherNotesModal.test.tsx
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/OakTeacherNotesModal.test.tsx
@@ -93,4 +93,19 @@ describe("OakTeacherNotesModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /bullet list/i }));
     expect(defaultProps.onBulletListClick).toHaveBeenCalled();
   });
+
+  it("disables the share link button when shareLinkDisabled is true", () => {
+    renderWithTheme(
+      <OakTeacherNotesModal {...defaultProps} shareLinkDisabled={true} />,
+    );
+    expect(screen.getByRole("button", { name: /share link/i })).toBeDisabled();
+  });
+
+  it("renders the footer when provided", () => {
+    const footerContent = <div>Footer Content</div>;
+    const { getByText } = renderWithTheme(
+      <OakTeacherNotesModal {...defaultProps} footer={footerContent} />,
+    );
+    expect(getByText("Footer Content")).toBeInTheDocument();
+  });
 });

--- a/src/components/organisms/teacher/OakTeacherNotesModal/OakTeacherNotesModal.tsx
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/OakTeacherNotesModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import {
+  OakInlineBanner,
   OakLink,
   OakModalCenter,
   OakSmallPrimaryButton,
@@ -90,6 +91,8 @@ export type OakTeacherNotesModalProps = {
   noteShared: boolean;
   error?: boolean;
   termsAndConditionsHref: string;
+  shareLinkDisabled?: boolean;
+  footer?: React.ReactNode;
 } & EditorContainerProps;
 
 export const OakTeacherNotesModal = ({
@@ -100,6 +103,8 @@ export const OakTeacherNotesModal = ({
   noteShared,
   error,
   termsAndConditionsHref,
+  shareLinkDisabled,
+  footer,
   ...rest
 }: OakTeacherNotesModalProps) => {
   let message = undefined;
@@ -157,16 +162,24 @@ export const OakTeacherNotesModal = ({
           <OakGridArea $colSpan={[0, 6]} $display={["none", "block"]}>
             {messageRender}
           </OakGridArea>
-          <OakGridArea $colSpan={[12, 6]}>
+          <OakGridArea $colSpan={12}>
             <OakFlex
               $gap="space-between-s"
               $width={"100%"}
               $justifyContent={["center", "flex-end"]}
+              $alignItems="center"
+              $flexDirection={["column", "row"]}
             >
+              {footer && (
+                <OakFlex $flexGrow={1} $alignSelf="flex-start">
+                  {footer}
+                </OakFlex>
+              )}
               <OakSmallPrimaryButton
                 onClick={onShareClicked}
                 iconName="copy"
                 isTrailingIcon
+                disabled={shareLinkDisabled}
               >
                 Share link
               </OakSmallPrimaryButton>
@@ -180,13 +193,28 @@ export const OakTeacherNotesModal = ({
         >
           {messageRender}
         </OakFlex>
-        <OakP>
-          Do not include personal, sensitive, or pupil information. See our{" "}
-          <OakLink href={termsAndConditionsHref} target="_blank">
-            Terms & conditions
-          </OakLink>{" "}
-          for guidance.
-        </OakP>
+        <OakInlineBanner
+          isOpen={true}
+          type="alert"
+          message={
+            <>
+              <OakP $font="heading-light-7">
+                Please do not include any personal or sensitive information that
+                could be used to identify, locate, or contact an individual,
+                either directly or indirectly.
+              </OakP>
+              <OakP $font="body-2" $mt="space-between-sssx">
+                Names, email addresses, or other personal information will be
+                redacted from your note to help keep everyone safe. For more
+                guidance, see our{" "}
+                <OakLink href="https://www.thenational.academy/legal/terms-and-conditions">
+                  Terms & conditions
+                </OakLink>
+                .
+              </OakP>
+            </>
+          }
+        />
       </OakFlex>
     </OakModalCenter>
   );

--- a/src/components/organisms/teacher/OakTeacherNotesModal/OakTeacherNotesModal.tsx
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/OakTeacherNotesModal.tsx
@@ -46,7 +46,7 @@ const EditorContainer = ({
       <OakFlex
         $pa={"inner-padding-s"}
         $background={"bg-primary"}
-        $height={"all-spacing-16"}
+        $height={"all-spacing-19"}
         $minHeight={"all-spacing-12"}
         $borderRadius={"border-radius-s"}
         $borderColor={"border-primary"}
@@ -207,7 +207,11 @@ export const OakTeacherNotesModal = ({
                 Names, email addresses, or other personal information will be
                 redacted from your note to help keep everyone safe. For more
                 guidance, see our{" "}
-                <OakLink href="https://www.thenational.academy/legal/terms-and-conditions">
+                <OakLink
+                  target={"_blank"}
+                  href="https://www.thenational.academy/legal/terms-and-conditions"
+                  aria-label="Oak's terms and conditions(opens in a new tab)"
+                >
                   Terms & conditions
                 </OakLink>
                 .

--- a/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
@@ -156,6 +156,37 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
+.c54 {
+  padding: 1rem;
+  background: #fff7cc;
+  border: 0.063rem solid;
+  border-color: #f6e8a0;
+  border-radius: 0.375rem;
+  border-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c56 {
+  position: relative;
+  width: 100%;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c59 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
 .c21 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
@@ -302,6 +333,13 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -321,6 +359,61 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
+}
+
+.c55 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: end;
+  -webkit-box-align: end;
+  -ms-flex-align: end;
+  align-items: end;
+}
+
+.c57 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.c58 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  gap: 0.25rem;
 }
 
 .c31 {
@@ -399,7 +492,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   text-align: left;
 }
 
-.c56 {
+.c63 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -414,8 +507,27 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c54 {
+.c60 {
   font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c61 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+  margin-top: 0.25rem;
 }
 
 .c14 {
@@ -539,7 +651,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   background: transparent;
 }
 
-.c55 {
+.c62 {
   display: inline;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -562,19 +674,19 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   color: #0d24c4;
 }
 
-.c55:focus-visible {
+.c62:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c55:visited {
+.c62:visited {
   color: #081676;
 }
 
-.c55:active {
+.c62:active {
   color: #081676;
 }
 
-.c55[disabled] {
+.c62[disabled] {
   cursor: not-allowed;
   color: #808080;
 }
@@ -706,6 +818,14 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 
 @media (min-width:750px) {
   .c47 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media (min-width:750px) {
+  .c47 {
     -webkit-box-pack: end;
     -webkit-justify-content: flex-end;
     -ms-flex-pack: end;
@@ -737,15 +857,9 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   }
 }
 
-@media (min-width:750px) {
-  .c45 {
-    grid-column: span 6;
-  }
-}
-
 @media (hover:hover) {
-  .c55:hover,
-  .c55:visited:hover {
+  .c62:hover,
+  .c62:visited:hover {
     color: #0a1d9d;
   }
 }
@@ -1041,25 +1155,79 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
               <div
                 className="c52 c53"
               />
-              <p
-                className="c54"
+              <div
+                className="c54 c55"
+                data-testid="oak-inline-banner"
               >
-                Do not include personal, sensitive, or pupil information. See our
-                 
-                <a
-                  className="c55"
-                  href="https://oak.app/terms"
-                  target="_blank"
+                <div
+                  className="c56 c57"
                 >
-                  <span
-                    className="c56"
+                  <div
+                    className="c16"
                   >
-                    Terms & conditions
-                  </span>
-                </a>
-                 
-                for guidance.
-              </p>
+                    <div
+                      className="c20"
+                      data-testid="inline-banner-icon"
+                    >
+                      <img
+                        alt=""
+                        className="c21"
+                        data-nimg="fill"
+                        decoding="async"
+                        loading="lazy"
+                        onError={[Function]}
+                        onLoad={[Function]}
+                        src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895207/icons/ecejtvqerx81prxyxh9b.svg"
+                        style={
+                          {
+                            "bottom": 0,
+                            "color": "transparent",
+                            "height": "100%",
+                            "left": 0,
+                            "objectFit": undefined,
+                            "objectPosition": undefined,
+                            "position": "absolute",
+                            "right": 0,
+                            "top": 0,
+                            "width": "100%",
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="c46 c58"
+                  >
+                    <div
+                      className="c59"
+                      data-testid="inline-banner-message"
+                    >
+                      <p
+                        className="c60"
+                      >
+                        Please do not include any personal or sensitive information that could be used to identify, locate, or contact an individual, either directly or indirectly.
+                      </p>
+                      <p
+                        className="c61"
+                      >
+                        Names, email addresses, or other personal information will be redacted from your note to help keep everyone safe. For more guidance, see our
+                         
+                        <a
+                          className="c62"
+                          href="https://www.thenational.academy/legal/terms-and-conditions"
+                        >
+                          <span
+                            className="c63"
+                          >
+                            Terms & conditions
+                          </span>
+                        </a>
+                        .
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 
 .c29 {
   overflow-y: scroll;
-  height: 7.5rem;
+  height: 15rem;
   min-height: 4.5rem;
   padding: 0.75rem;
   background: #ffffff;
@@ -1213,8 +1213,10 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
                         Names, email addresses, or other personal information will be redacted from your note to help keep everyone safe. For more guidance, see our
                          
                         <a
+                          aria-label="Oak's terms and conditions(opens in a new tab)"
                           className="c62"
                           href="https://www.thenational.academy/legal/terms-and-conditions"
+                          target="_blank"
                         >
                           <span
                             className="c63"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Made updates to the OakTeacherNotesModal

- Updated the banner at the bottom copy and styling (as per designs)
- Added ability to disabled the share link button
- Added space for footer content to be added

## Link to the design doc
[designs](https://www.figma.com/design/OEMJMj2akckSSxkbumdJAD/%F0%9F%A7%AA-Lesson-Delivery-Squad-Experiments?node-id=5111-81975&m=dev)

## A link to the component in the deployment preview

## Testing instructions
TipTap storybook story has the example with the footer content set. The share disabled button should now be a toggle control for the story.

## ACs
- [ ] Check the storybook for the component matches the designs
- [ ] Check the share button disables when set 
- [ ] Check the footer content appears in the right place
- [ ] Check there are no regressions on the UI when footer content is shown