### PR TITLE
fix: make OakToast duration extendible

### DIFF
--- a/src/components/molecules/OakToast/OakToast.stories.tsx
+++ b/src/components/molecules/OakToast/OakToast.stories.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import { StoryObj, Meta } from "@storybook/react";
+import { useArgs } from "@storybook/preview-api";
+
+import { OakPrimaryButton } from "../OakPrimaryButton";
 
 import { OakToast } from "./OakToast";
+
+import { OakFlex } from "@/components/atoms";
 
 const meta: Meta<typeof OakToast> = {
   title: "components/molecules/OakToast",
@@ -55,6 +60,7 @@ export const Default: Story = {
     autoDismiss: false,
     showIcon: true,
     variant: "green",
+    id: 1,
     onClose: () => console.log("Toast closed"),
   },
 };
@@ -72,6 +78,31 @@ export const LongElaborateMessage: Story = {
     autoDismiss: false,
     showIcon: true,
     variant: "pink",
+    id: 1,
+    onClose: () => console.log("Toast closed"),
+  },
+};
+
+export const ExtendibleAutoDismiss: Story = {
+  render: (args) => {
+    const [{ id }, updateArgs] = useArgs();
+    const replaceToast = () => {
+      updateArgs({ id: id + 1, variant: "pink" });
+    };
+    return (
+      <OakFlex $flexDirection="column" $gap="all-spacing-5">
+        <OakPrimaryButton onClick={replaceToast}>Update toast</OakPrimaryButton>
+        <OakToast {...args} />
+      </OakFlex>
+    );
+  },
+  args: {
+    message: "this is a toast message",
+    autoDismiss: true,
+    autoDismissDuration: 5000,
+    showIcon: true,
+    variant: "blue",
+    id: 1,
     onClose: () => console.log("Toast closed"),
   },
 };

--- a/src/components/molecules/OakToast/OakToast.test.tsx
+++ b/src/components/molecules/OakToast/OakToast.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { create } from "react-test-renderer";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { OakToast } from "./OakToast";
@@ -15,9 +15,16 @@ const defautProps = {
   variant: "green" as const,
   showIcon: true,
   autoDismiss: false,
+  id: 1,
 };
 
 describe("OakToast", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   it("renders", () => {
     renderWithTheme(<OakToast {...defautProps} />);
     expect(screen.getByTestId("oak-toast")).toBeInTheDocument();
@@ -27,9 +34,8 @@ describe("OakToast", () => {
     renderWithTheme(<OakToast {...defautProps} autoDismiss />);
     const toast = screen.getByTestId("oak-toast");
     expect(toast).toBeVisible();
-    setTimeout(() => {
-      expect(toast).not.toBeVisible();
-    }, 5000);
+    act(() => jest.advanceTimersByTime(5300));
+    await waitFor(() => expect(toast).not.toBeVisible());
   });
 
   it("disappears when close is clicked", async () => {
@@ -45,6 +51,20 @@ describe("OakToast", () => {
     renderWithTheme(<OakToast {...defautProps} autoDismiss />);
     const closeButton = screen.queryByRole("button");
     expect(closeButton).not.toBeInTheDocument();
+  });
+
+  it("extends the autodismiss duration when reopened", async () => {
+    const { rerender } = renderWithTheme(
+      <OakToast {...defautProps} autoDismiss id={1} />,
+    );
+    const toast = screen.getByTestId("oak-toast");
+    expect(toast).toBeVisible();
+    jest.advanceTimersByTime(2000);
+    rerender(<OakToast {...defautProps} autoDismiss id={2} />);
+    jest.advanceTimersByTime(4000);
+    expect(toast).toBeVisible();
+    jest.advanceTimersByTime(2000);
+    await waitFor(() => expect(toast).not.toBeVisible());
   });
 
   it("matches snapshot", () => {

--- a/src/components/molecules/OakToast/OakToast.tsx
+++ b/src/components/molecules/OakToast/OakToast.tsx
@@ -16,6 +16,7 @@ export type OakToastProps = {
   autoDismiss: boolean;
   showIcon: boolean;
   onClose?: () => void;
+  id?: number;
 };
 
 type VariantKey =
@@ -139,6 +140,7 @@ export const OakToast = ({
   autoDismissDuration = 5000,
   showIcon,
   onClose,
+  id,
 }: OakToastProps) => {
   const [isVisible, setIsVisible] = useState(true);
 
@@ -152,7 +154,7 @@ export const OakToast = ({
       );
       return () => clearTimeout(timer);
     }
-  }, [autoDismiss, autoDismissDuration, isVisible]);
+  }, [autoDismiss, autoDismissDuration, isVisible, id]);
 
   const transitionRef = React.useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- adds an `id` prop to OakToast that can be used to make sure new OakToasts replace any currently visible OakToast's timeout for the `autoHideDuration`

## Testing instructions
Go to the [new story for OakToast](https://deploy-preview-417--lively-meringue-8ebd43.netlify.app/?path=/story/components-molecules-oaktoast--extendible-auto-dismiss) and click the button to update the toast (before the first one disappears), the new pink toast should hang around for 5 seconds no matter when you press the button (as long as the blue toast didn't disappear already). You can refresh the page to reset the component.
