### PR TITLE
fix: autocomplete email addresses in registration banner component

### DIFF
--- a/src/components/organisms/teacher/OakInlineRegistrationBanner/OakInlineRegistrationBanner.test.tsx
+++ b/src/components/organisms/teacher/OakInlineRegistrationBanner/OakInlineRegistrationBanner.test.tsx
@@ -55,7 +55,7 @@ describe("OakInlineRegistrationBanner", () => {
     );
     expect(errorMessage).toBeInTheDocument();
   });
-  it("shows and error message when onSubmit fails", async () => {
+  it("shows an error message when onSubmit fails", async () => {
     renderWithTheme(
       <OakInlineRegistrationBanner
         onSubmit={(email: string) => Promise.reject(new Error(email))}

--- a/src/components/organisms/teacher/OakInlineRegistrationBanner/OakInlineRegistrationBanner.tsx
+++ b/src/components/organisms/teacher/OakInlineRegistrationBanner/OakInlineRegistrationBanner.tsx
@@ -45,6 +45,7 @@ export const OakInlineRegistrationBanner = (
           {bodyText}
           <OakBox
             as="form"
+            noValidate
             onSubmit={async (e) => {
               e.preventDefault();
               setSuccess(false);
@@ -87,6 +88,8 @@ export const OakInlineRegistrationBanner = (
                 />
 
                 <OakTextInput
+                  type="email"
+                  autoComplete="email"
                   placeholder="Enter email address"
                   $maxHeight="all-spacing-10"
                   value={email}

--- a/src/components/organisms/teacher/OakInlineRegistrationBanner/__snapshots__/OakInlineRegistrationBanner.test.tsx.snap
+++ b/src/components/organisms/teacher/OakInlineRegistrationBanner/__snapshots__/OakInlineRegistrationBanner.test.tsx.snap
@@ -440,6 +440,7 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
       </p>
       <form
         className="c1"
+        noValidate={true}
         onSubmit={[Function]}
       >
         <div
@@ -461,11 +462,12 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
                 className="c1 c15"
               >
                 <input
+                  autoComplete="email"
                   className="c16"
                   onChange={[Function]}
                   onFocus={[Function]}
                   placeholder="Enter email address"
-                  type="text"
+                  type="email"
                   value=""
                 />
               </div>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

This PR follows up from [this comment](https://github.com/oaknational/Oak-Web-Application/pull/3318#pullrequestreview-2735114654 ) by adding autocomplete="email" to the text input in the OakInlineRegistrationBanner.

The ticket I picked up also suggested adding the attribute type="email", I tried this and the native validation of the input component was preventing errors from being thrown and therefore our own validation logic never fired. 

There's a way of turning off validation at the form level, but as we're using as="form" that isn't available to us.

## Testing instructions

[Component can be found here](https://deploy-preview-418--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-teacher-oakinlineregistrationbanner--docs)

When opening the dev tools you should see that it has the attribute autocomplete="email"

