### PR TITLE
Feat/lesq 1415/save count [LESQ-1415]

### DIFF
--- a/src/components/molecules/OakSaveCount/OakSaveCount.stories.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.stories.tsx
@@ -18,6 +18,11 @@ const meta: Meta<typeof OakSaveCount> = {
         type: "text",
       },
     },
+    loading: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
 };
 export default meta;
@@ -29,5 +34,6 @@ export const Default: Story = {
   args: {
     count: 1,
     href: "#",
+    loading: false,
   },
 };

--- a/src/components/molecules/OakSaveCount/OakSaveCount.stories.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.stories.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakSaveCount } from "./OakSaveCount";
+
+const meta: Meta<typeof OakSaveCount> = {
+  component: OakSaveCount,
+  tags: ["autodocs"],
+  title: "components/molecules/OakSaveCount",
+  argTypes: {
+    count: {
+      control: {
+        type: "number",
+      },
+    },
+    href: {
+      control: {
+        type: "text",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof OakSaveCount>;
+
+export const Default: Story = {
+  render: (args) => <OakSaveCount {...args} />,
+  args: {
+    count: 1,
+    href: "#",
+  },
+};

--- a/src/components/molecules/OakSaveCount/OakSaveCount.test.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { OakSaveCount } from "./OakSaveCount";
+
+const defaultProps = {
+  count: 0,
+  href: "#",
+};
+
+describe("OakSaveCount", () => {
+  it("should render a count", () => {
+    render(<OakSaveCount {...defaultProps} />);
+    const count = screen.getByRole("link");
+    expect(count).toBeInTheDocument();
+    expect(count).toHaveTextContent("0");
+  });
+  it("should match snapshot", () => {
+    const { container } = render(<OakSaveCount {...defaultProps} />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/OakSaveCount/OakSaveCount.test.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.test.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
+
 import { OakSaveCount } from "./OakSaveCount";
+
+import { OakThemeProvider } from "@/components/atoms";
+import { oakDefaultTheme } from "@/styles";
 
 const defaultProps = {
   count: 0,
@@ -10,13 +14,22 @@ const defaultProps = {
 
 describe("OakSaveCount", () => {
   it("should render a count", () => {
-    render(<OakSaveCount {...defaultProps} />);
+    render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        {" "}
+        <OakSaveCount {...defaultProps} />
+      </OakThemeProvider>,
+    );
     const count = screen.getByRole("link");
     expect(count).toBeInTheDocument();
     expect(count).toHaveTextContent("0");
   });
   it("should match snapshot", () => {
-    const { container } = render(<OakSaveCount {...defaultProps} />);
+    const { container } = render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakSaveCount {...defaultProps} />
+      </OakThemeProvider>,
+    );
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/molecules/OakSaveCount/OakSaveCount.test.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.test.tsx
@@ -10,19 +10,47 @@ import { oakDefaultTheme } from "@/styles";
 const defaultProps = {
   count: 0,
   href: "#",
+  loading: false,
 };
 
 describe("OakSaveCount", () => {
   it("should render a count", () => {
     render(
       <OakThemeProvider theme={oakDefaultTheme}>
-        {" "}
         <OakSaveCount {...defaultProps} />
       </OakThemeProvider>,
     );
     const count = screen.getByRole("link");
     expect(count).toBeInTheDocument();
     expect(count).toHaveTextContent("0");
+  });
+  it("should render a count with a value of 99+", () => {
+    render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakSaveCount {...defaultProps} count={100} />
+      </OakThemeProvider>,
+    );
+    const count = screen.getByRole("link");
+    expect(count).toBeInTheDocument();
+    expect(count).toHaveTextContent("99+");
+  });
+  it("should render the correct icon when count is 0", () => {
+    render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakSaveCount {...defaultProps} />
+      </OakThemeProvider>,
+    );
+    const icon = screen.getByTestId("bookmark-outlined");
+    expect(icon).toBeInTheDocument();
+  });
+  it("should render the correct icon when count is greater than 0", () => {
+    render(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        <OakSaveCount {...defaultProps} count={1} />
+      </OakThemeProvider>,
+    );
+    const icon = screen.getByTestId("bookmark-filled");
+    expect(icon).toBeInTheDocument();
   });
   it("should match snapshot", () => {
     const { container } = render(

--- a/src/components/molecules/OakSaveCount/OakSaveCount.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.tsx
@@ -34,11 +34,12 @@ const StyledInternalButton = styled(InternalButton)`
 
 export const OakSaveCount = ({ count, href, loading }: OakSaveCountProps) => {
   const iconName = count === 0 ? "bookmark-outlined" : "bookmark-filled";
+  const showTruncatedCount = count > 99;
   return (
     <StyledInternalButton as="a" href={href}>
       <OakScreenReader>View my library</OakScreenReader>
       <OakFlex
-        $width="all-spacing-10"
+        $width={showTruncatedCount ? "all-spacing-11" : "all-spacing-10"}
         $height="all-spacing-7"
         $background={
           loading ? "bg-btn-secondary-hover" : "bg-decorative1-subdued"
@@ -62,7 +63,7 @@ export const OakSaveCount = ({ count, href, loading }: OakSaveCountProps) => {
             $font="heading-light-7"
             aria-label={`${count} saved unit${count === 1 ? "" : "s"}`}
           >
-            {count > 99 ? "99+" : count}
+            {showTruncatedCount ? "99+" : count}
           </OakSpan>
         </OakBox>
       </OakFlex>

--- a/src/components/molecules/OakSaveCount/OakSaveCount.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { OakBox, OakFlex, OakIcon, OakSpan } from "@/components/atoms";
+import { InternalButton } from "@/components/atoms/InternalButton";
+
+export type OakSaveCountProps = {
+  count: number;
+  href: string;
+};
+
+export const OakSaveCount = ({ count, href }: OakSaveCountProps) => {
+  return (
+    <InternalButton as="a" href={href}>
+      <OakFlex
+        $width="all-spacing-10"
+        $height="all-spacing-7"
+        $background="mint"
+        $alignItems="center"
+        $pa="inner-padding-ssx"
+        $borderRadius="border-radius-s"
+      >
+        <OakIcon
+          iconName={count === 0 ? "bookmark-outlined" : "bookmark-filled"}
+          $width="all-spacing-6"
+        />
+        <OakBox $width="all-spacing-6" $textAlign="center">
+          <OakSpan $font="heading-light-7">
+            {count > 99 ? "99+" : count}
+          </OakSpan>
+        </OakBox>
+      </OakFlex>
+    </InternalButton>
+  );
+};

--- a/src/components/molecules/OakSaveCount/OakSaveCount.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.tsx
@@ -1,22 +1,43 @@
 import React from "react";
+import styled from "styled-components";
+
 import { OakBox, OakFlex, OakIcon, OakSpan } from "@/components/atoms";
 import { InternalButton } from "@/components/atoms/InternalButton";
+import { parseColor } from "@/styles/helpers/parseColor";
+import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 
 export type OakSaveCountProps = {
   count: number;
   href: string;
 };
 
+const StyledInternalButton = styled(InternalButton)`
+  :hover {
+    .oak-save-count {
+      background-color: ${parseColor("bg-decorative1-main")};
+    }
+  }
+  :focus-visible {
+    .oak-save-count {
+      box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
+        ${parseDropShadow("drop-shadow-centered-grey")};
+    }
+  }
+`;
+
 export const OakSaveCount = ({ count, href }: OakSaveCountProps) => {
   return (
-    <InternalButton as="a" href={href}>
+    <StyledInternalButton as="a" href={href}>
       <OakFlex
         $width="all-spacing-10"
         $height="all-spacing-7"
-        $background="mint"
+        $background="bg-decorative1-subdued"
         $alignItems="center"
         $pa="inner-padding-ssx"
         $borderRadius="border-radius-s"
+        $borderColor="bg-decorative1-main"
+        $ba="border-solid-s"
+        className="oak-save-count"
       >
         <OakIcon
           iconName={count === 0 ? "bookmark-outlined" : "bookmark-filled"}
@@ -28,6 +49,6 @@ export const OakSaveCount = ({ count, href }: OakSaveCountProps) => {
           </OakSpan>
         </OakBox>
       </OakFlex>
-    </InternalButton>
+    </StyledInternalButton>
   );
 };

--- a/src/components/molecules/OakSaveCount/OakSaveCount.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.tsx
@@ -51,7 +51,10 @@ export const OakSaveCount = ({ count, href, loading }: OakSaveCountProps) => {
           $width="all-spacing-6"
         />
         <OakBox $width="all-spacing-6" $textAlign="center">
-          <OakSpan $font="heading-light-7">
+          <OakSpan
+            $font="heading-light-7"
+            aria-label={`${count} saved unit${count === 1 ? "" : "s"}`}
+          >
             {count > 99 ? "99+" : count}
           </OakSpan>
         </OakBox>

--- a/src/components/molecules/OakSaveCount/OakSaveCount.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import styled from "styled-components";
 
-import { OakBox, OakFlex, OakIcon, OakSpan } from "@/components/atoms";
+import {
+  OakBox,
+  OakFlex,
+  OakIcon,
+  OakScreenReader,
+  OakSpan,
+} from "@/components/atoms";
 import { InternalButton } from "@/components/atoms/InternalButton";
 import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
@@ -30,6 +36,7 @@ export const OakSaveCount = ({ count, href, loading }: OakSaveCountProps) => {
   const iconName = count === 0 ? "bookmark-outlined" : "bookmark-filled";
   return (
     <StyledInternalButton as="a" href={href}>
+      <OakScreenReader>View my library</OakScreenReader>
       <OakFlex
         $width="all-spacing-10"
         $height="all-spacing-7"

--- a/src/components/molecules/OakSaveCount/OakSaveCount.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.tsx
@@ -9,6 +9,7 @@ import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 export type OakSaveCountProps = {
   count: number;
   href: string;
+  loading: boolean;
 };
 
 const StyledInternalButton = styled(InternalButton)`
@@ -25,22 +26,28 @@ const StyledInternalButton = styled(InternalButton)`
   }
 `;
 
-export const OakSaveCount = ({ count, href }: OakSaveCountProps) => {
+export const OakSaveCount = ({ count, href, loading }: OakSaveCountProps) => {
+  const iconName = count === 0 ? "bookmark-outlined" : "bookmark-filled";
   return (
     <StyledInternalButton as="a" href={href}>
       <OakFlex
         $width="all-spacing-10"
         $height="all-spacing-7"
-        $background="bg-decorative1-subdued"
+        $background={
+          loading ? "bg-btn-secondary-hover" : "bg-decorative1-subdued"
+        }
         $alignItems="center"
         $pa="inner-padding-ssx"
         $borderRadius="border-radius-s"
-        $borderColor="bg-decorative1-main"
+        $borderColor={
+          loading ? "border-neutral-lighter" : "bg-decorative1-main"
+        }
         $ba="border-solid-s"
-        className="oak-save-count"
+        className={loading ? undefined : "oak-save-count"}
       >
         <OakIcon
-          iconName={count === 0 ? "bookmark-outlined" : "bookmark-filled"}
+          iconName={iconName}
+          data-testid={iconName}
           $width="all-spacing-6"
         />
         <OakBox $width="all-spacing-6" $textAlign="center">

--- a/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
+++ b/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakSaveCount should match snapshot 1`] = `
+.c1 {
+  width: 3.5rem;
+  height: 2rem;
+  padding: 0.25rem;
+  background: #bef2bd;
+  border-radius: 0.25rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c3 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 2rem;
+  min-height: 2rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c5 {
+  width: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+  text-align: center;
+}
+
+.c4 {
+  object-fit: contain;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c0 {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-family: unset;
+  outline: none;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c0:disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+<div>
+  <a
+    class="c0"
+    href="#"
+  >
+    <div
+      class="c1 c2"
+    >
+      <div
+        class="c3"
+      >
+        <img
+          alt=""
+          class="c4"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1734519491/icons/bookmark-outlined_rxe5v0.svg"
+          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+        />
+      </div>
+      <div
+        class="c5"
+      >
+        <span
+          class="c6"
+        >
+          0
+        </span>
+      </div>
+    </div>
+  </a>
+</div>
+`;

--- a/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
+++ b/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
@@ -1,16 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSaveCount should match snapshot 1`] = `
-.c1 {
+.c2 {
   width: 3.5rem;
   height: 2rem;
   padding: 0.25rem;
-  background: #bef2bd;
+  background: #dff9de;
+  border: 0.063rem solid;
+  border-color: #bef2bd;
   border-radius: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c4 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -19,17 +21,17 @@ exports[`OakSaveCount should match snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c6 {
   width: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   text-align: center;
 }
 
-.c4 {
+.c5 {
   object-fit: contain;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -40,7 +42,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -69,20 +71,28 @@ exports[`OakSaveCount should match snapshot 1`] = `
   cursor: default;
 }
 
+.c1:hover .oak-save-count {
+  background-color: #bef2bd;
+}
+
+.c1:focus-visible .oak-save-count {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
 <div>
   <a
-    class="c0"
+    class="c0 c1"
     href="#"
   >
     <div
-      class="c1 c2"
+      class="c2 c3 oak-save-count"
     >
       <div
-        class="c3"
+        class="c4"
       >
         <img
           alt=""
-          class="c4"
+          class="c5"
           data-nimg="fill"
           decoding="async"
           loading="lazy"
@@ -91,10 +101,10 @@ exports[`OakSaveCount should match snapshot 1`] = `
         />
       </div>
       <div
-        class="c5"
+        class="c6"
       >
         <span
-          class="c6"
+          class="c7"
         >
           0
         </span>

--- a/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
+++ b/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
         class="c6"
       >
         <span
+          aria-label="0 saved units"
           class="c7"
         >
           0

--- a/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
+++ b/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSaveCount should match snapshot 1`] = `
-.c2 {
+.c3 {
   width: 3.5rem;
   height: 2rem;
   padding: 0.25rem;
@@ -12,7 +12,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -21,17 +21,17 @@ exports[`OakSaveCount should match snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c7 {
   width: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
   text-align: center;
 }
 
-.c5 {
+.c6 {
   object-fit: contain;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -42,7 +42,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c8 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -51,6 +51,19 @@ exports[`OakSaveCount should match snapshot 1`] = `
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;
   letter-spacing: 0.0115rem;
+}
+
+.c2 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .c0 {
@@ -84,16 +97,21 @@ exports[`OakSaveCount should match snapshot 1`] = `
     class="c0 c1"
     href="#"
   >
+    <span
+      class="c2"
+    >
+      View my library
+    </span>
     <div
-      class="c2 c3 oak-save-count"
+      class="c3 c4 oak-save-count"
     >
       <div
-        class="c4"
+        class="c5"
         data-testid="bookmark-outlined"
       >
         <img
           alt=""
-          class="c5"
+          class="c6"
           data-nimg="fill"
           decoding="async"
           loading="lazy"
@@ -102,11 +120,11 @@ exports[`OakSaveCount should match snapshot 1`] = `
         />
       </div>
       <div
-        class="c6"
+        class="c7"
       >
         <span
           aria-label="0 saved units"
-          class="c7"
+          class="c8"
         >
           0
         </span>

--- a/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
+++ b/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
@@ -89,6 +89,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
     >
       <div
         class="c4"
+        data-testid="bookmark-outlined"
       >
         <img
           alt=""


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- create new molecule `OakSaveCount`
- the prescribed width and height on the designs aren't valid spacing tokens in the component library so I used the closest available values

## Link to the design doc
https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=14263-4518&p=f&m=dev

## A link to the component in the deployment preview
https://deploy-preview-422--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oaksavecount--docs

## ACs

- [ ] when loading the button should be greyed out with no hover or focus styles
- [ ] when not loading the styles should match the desins
- [ ] when the count is 0 the icon should be outlines
- [ ] when the count is > 0 the icon should be filled in
- [ ] when the count is greater than 99 the text should read '99+'
