### PR TITLE
Don't pass non-DOM attributes down to DOM

### DIFF
--- a/src/components/molecules/OakToast/OakToast.tsx
+++ b/src/components/molecules/OakToast/OakToast.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import styled from "styled-components";
 import { Transition, TransitionStatus } from "react-transition-group";
 
@@ -156,7 +156,7 @@ export const OakToast = ({
     }
   }, [autoDismiss, autoDismissDuration, isVisible, id]);
 
-  const transitionRef = React.useRef<HTMLDivElement>(null);
+  const transitionRef = useRef<HTMLDivElement>(null);
 
   const { background, icon, color } = variants[variant];
 

--- a/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
+++ b/src/components/organisms/curriculum/OakRadioAsButton/OakRadioAsButton.tsx
@@ -17,7 +17,7 @@ import { RadioContext } from "@/components/molecules/OakRadioGroup/OakRadioGroup
 const StyledOakIcon = styled(OakIcon)``;
 
 const StyledInternalRadio = styled(InternalRadio)<{
-  keepIconColor?: boolean;
+  $keepIconColor?: boolean;
 }>`
   position: absolute;
   opacity: 0;
@@ -25,7 +25,7 @@ const StyledInternalRadio = styled(InternalRadio)<{
 
   &:checked:not(:disabled) + ${StyledOakIcon} {
     filter: ${(props) =>
-      props.keepIconColor ? "none" : parseColorFilter("white")};
+      props.$keepIconColor ? "none" : parseColorFilter("white")};
   }
 
   &:checked:not(:disabled) {

--- a/src/components/organisms/shared/OakMediaClip/OakMediaClip.tsx
+++ b/src/components/organisms/shared/OakMediaClip/OakMediaClip.tsx
@@ -139,7 +139,7 @@ const StyledInternalButton = styled(InternalButton)<
   ${(props) => css`
     &:hover {
       h4 {
-        text-decoration: ${props.muxPlayingState === "standard"
+        text-decoration: ${props.$muxPlayingState === "standard"
           ? "underline"
           : "none"};
       }
@@ -219,7 +219,7 @@ export const OakMediaClip = ({
           $justifyContent={"flex-start"}
           onClick={onClick}
           $pa={"inner-padding-xs"}
-          muxPlayingState={muxPlayingState}
+          $muxPlayingState={muxPlayingState}
         >
           <OakFlex
             $flexDirection={"row"}

--- a/src/components/organisms/shared/OakMediaClip/__snapshots__/OakMediaClip.test.tsx.snap
+++ b/src/components/organisms/shared/OakMediaClip/__snapshots__/OakMediaClip.test.tsx.snap
@@ -253,7 +253,6 @@ exports[`OakMediaClip matches snapshot 1`] = `
       />
       <button
         className="c5 c6 internal-button"
-        muxPlayingState="standard"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}

--- a/src/components/organisms/teacher/OakSearchFilterCheckBox/OakSearchFilterCheckBox.tsx
+++ b/src/components/organisms/teacher/OakSearchFilterCheckBox/OakSearchFilterCheckBox.tsx
@@ -16,7 +16,7 @@ import { parseColorFilter } from "@/styles/helpers/parseColorFilter";
 const StyledOakIcon = styled(OakIcon)``;
 
 const StyledInternalCheckBox = styled(InternalCheckBox)<{
-  keepIconColor?: boolean;
+  $keepIconColor?: boolean;
 }>`
   position: absolute;
   opacity: 0;
@@ -24,7 +24,7 @@ const StyledInternalCheckBox = styled(InternalCheckBox)<{
 
   &:checked:not(:disabled) + ${StyledOakIcon} {
     filter: ${(props) =>
-      props.keepIconColor ? "none" : parseColorFilter("white")};
+      props.$keepIconColor ? "none" : parseColorFilter("white")};
   }
 
   &:checked:not(:disabled) {
@@ -106,7 +106,16 @@ export type OakSearchFilterCheckBoxProps = Omit<
 export const OakSearchFilterCheckBox = (
   props: OakSearchFilterCheckBoxProps,
 ) => {
-  const { id, value, disabled, innerRef, displayValue, icon, ...rest } = props;
+  const {
+    id,
+    value,
+    disabled,
+    innerRef,
+    displayValue,
+    icon,
+    keepIconColor,
+    ...rest
+  } = props;
 
   const defaultRef = useRef<HTMLInputElement>(null);
   const inputRef = innerRef ?? defaultRef;
@@ -141,6 +150,7 @@ export const OakSearchFilterCheckBox = (
           value={value}
           disabled={disabled}
           ref={inputRef}
+          $keepIconColor={keepIconColor}
           {...rest}
         />
         {icon && <StyledOakIcon alt="" iconName={icon} />}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Don't pass non-DOM attributes down to DOM by prefixing with "$"


## A link to the component in the deployment preview
Functional changes to 

 - [`<OakSearchFilterCheckBox />`](https://deploy-preview-424--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-teacher-oaksearchfiltercheckbox--docs)
 - [`<OakMediaClip />`](https://deploy-preview-424--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-teacher-oakmediaclip--docs)

## Testing instructions
Regression test the above components


