### PR TITLE
Remove `isOpen` as attribute from DOM node in `<InternalReviewAccordion/>`

### DIFF
--- a/src/components/organisms/pupil/lesson/InternalReviewAccordion/InternalReviewAccordion.tsx
+++ b/src/components/organisms/pupil/lesson/InternalReviewAccordion/InternalReviewAccordion.tsx
@@ -31,13 +31,13 @@ export const StyledAccordionContent = styled(InternalAccordionContent)`
 `;
 
 export const StyledAccordionButton = styled(InternalShadowRoundButton)<
-  FlexStyleProps & { isOpen: boolean }
+  FlexStyleProps & { $isOpen: boolean }
 >`
   ${flexStyle}
   ${oakBoxCss}
   .icon-container img {
     ${(props) => css`
-      transform: ${props.isOpen ? "rotate(180deg)" : "none"};
+      transform: ${props.$isOpen ? "rotate(180deg)" : "none"};
       transition: all 0.3s ease 0s;
     `};
   }
@@ -59,7 +59,7 @@ const Accordion = ({ children, id }: InternalReviewAccordionProps) => {
         $pt={["inner-padding-l", "inner-padding-none"]}
       >
         <StyledAccordionButton
-          isOpen={isOpen}
+          $isOpen={isOpen}
           onClick={() => setOpen(!isOpen)}
           aria-expanded={isOpen}
           id={id}

--- a/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
@@ -222,7 +222,6 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
         aria-expanded={true}
         className="c6 c7"
         id="see-more"
-        isOpen={true}
         onClick={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Remove `isOpen` as attribute from DOM node in `<InternalReviewAccordion/>`

This was mistakenly leaking through to the DOM node


## A link to the component in the deployment preview
https://deploy-preview-425--lively-meringue-8ebd43.netlify.app/

## Testing instructions
Regression test

 - [`<OakPupilLessonReviewQuiz/>`](https://deploy-preview-425--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-pupil-lesson-oaklessonreviewquiz-oakpupillessonreviewquiz--docs) in `isCompleted` state.
 - [`<InternalReviewAccordion/>`](https://deploy-preview-425--lively-meringue-8ebd43.netlify.app/?path=/docs/components-organisms-pupil-lesson-internalreviewaccordion--docs) verify it still open correctly
