### PR TITLE
Feat/decouple link from side nav

### DIFF
--- a/src/components/organisms/shared/OakSideMenuNav/OakSideMenuNav.tsx
+++ b/src/components/organisms/shared/OakSideMenuNav/OakSideMenuNav.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 
-import { OakFlex, OakHeading, OakLI, OakUL } from "@/components/atoms";
 import { MenuItemProps, OakSideMenuNavLink } from "../OakSideMenuNavLink";
+
+import { OakFlex, OakHeading, OakLI, OakUL } from "@/components/atoms";
 
 const StyledNav = styled.nav`
   outline: none;

--- a/src/components/organisms/shared/OakSideMenuNav/OakSideMenuNav.tsx
+++ b/src/components/organisms/shared/OakSideMenuNav/OakSideMenuNav.tsx
@@ -1,59 +1,12 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 
-import {
-  OakFlex,
-  OakHeading,
-  OakIcon,
-  OakLI,
-  OakSpan,
-  OakUL,
-} from "@/components/atoms";
-import { flexStyle, FlexStyleProps } from "@/styles/utils/flexStyle";
-import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
-import { paddingStyle, PaddingStyleProps } from "@/styles/utils/spacingStyle";
-import { parseColor } from "@/styles/helpers/parseColor";
-import { getBreakpoint } from "@/styles/utils/responsiveStyle";
+import { OakFlex, OakHeading, OakLI, OakUL } from "@/components/atoms";
+import { MenuItemProps, OakSideMenuNavLink } from "../OakSideMenuNavLink";
 
 const StyledNav = styled.nav`
   outline: none;
 `;
-
-const StyledLink = styled("a")<
-  FlexStyleProps & PaddingStyleProps & { isSelected: boolean }
->`
-  text-decoration: none;
-  display: flex;
-  outline: none;
-
-  @media (min-width: ${getBreakpoint("small")}px) {
-    border-left: ${(props) =>
-      props.isSelected ? "4px solid #222222" : "4px solid transparent"};
-    :hover {
-      text-decoration: underline;
-      border-color: ${(props) =>
-        props.isSelected
-          ? parseColor("bg-btn-primary-hover")
-          : parseColor("bg-decorative1-main")};
-    }
-  }
-
-  :focus-visible {
-    box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
-      ${parseDropShadow("drop-shadow-centered-grey")};
-    border-color: transparent;
-    border-radius: 4px;
-  }
-
-  ${flexStyle}
-  ${paddingStyle}
-`;
-
-type MenuItemProps = {
-  heading: string;
-  subheading?: string;
-  href: string;
-};
 
 export type OakSideMenuNavProps = {
   heading: string;
@@ -88,37 +41,11 @@ export const OakSideMenuNav = (props: OakSideMenuNavProps) => {
         >
           {menuItems.map((item) => (
             <OakLI key={item.heading}>
-              <StyledLink
-                $alignItems={["center", "flex-start"]}
-                $columnGap="space-between-s"
-                href={item.href}
-                $ph={["inner-padding-none", "inner-padding-s"]}
+              <OakSideMenuNavLink
+                item={item}
                 isSelected={selectedHref === item.href}
-                $flexDirection={["row", "column"]}
                 onClick={() => setSelectedHref(item.href)}
-                aria-current={selectedHref === item.href ? "true" : undefined}
-              >
-                <OakFlex
-                  $flexDirection={["row", "column"]}
-                  $columnGap={["space-between-s", "space-between-sssx"]}
-                  $flexWrap="wrap"
-                >
-                  <OakSpan $font="heading-light-7" $color="text-primary">
-                    {item.heading}
-                  </OakSpan>
-                  {item.subheading && (
-                    <OakSpan $font="body-3" $color="text-subdued">
-                      {item.subheading}
-                    </OakSpan>
-                  )}
-                </OakFlex>
-                <OakIcon
-                  $display={["block", "none"]}
-                  iconName="chevron-right"
-                  $width="all-spacing-6"
-                  $pl="inner-padding-s"
-                />
-              </StyledLink>
+              />
             </OakLI>
           ))}
         </OakUL>

--- a/src/components/organisms/shared/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
+++ b/src/components/organisms/shared/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
@@ -117,10 +117,6 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   gap: 1rem;
 }
 
-.c0 {
-  outline: none;
-}
-
 .c6 {
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -129,27 +125,16 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   display: -ms-flexbox;
   display: flex;
   outline: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-column-gap: 1rem;
-  column-gap: 1rem;
-  padding-left: 0rem;
-  padding-right: 0rem;
 }
 
 .c6:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
   border-color: transparent;
   border-radius: 4px;
+}
+
+.c0 {
+  outline: none;
 }
 
 @media (min-width:750px) {
@@ -194,35 +179,6 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
     -webkit-text-decoration: underline;
     text-decoration: underline;
     border-color: #bef2bd;
-  }
-}
-
-@media (min-width:750px) {
-  .c6 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-  }
-}
-
-@media (min-width:750px) {
-  .c6 {
-    -webkit-align-items: flex-start;
-    -webkit-box-align: flex-start;
-    -ms-flex-align: flex-start;
-    align-items: flex-start;
-  }
-}
-
-@media (min-width:750px) {
-  .c6 {
-    padding-left: 0.75rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c6 {
-    padding-right: 0.75rem;
   }
 }
 

--- a/src/components/organisms/shared/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
+++ b/src/components/organisms/shared/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
@@ -23,10 +23,6 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
-  object-fit: contain;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -51,6 +47,10 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   flex-wrap: wrap;
   -webkit-column-gap: 1rem;
   column-gap: 1rem;
+}
+
+.c12 {
+  object-fit: contain;
 }
 
 .c3 {
@@ -87,6 +87,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   -moz-letter-spacing: -0.005rem;
   -ms-letter-spacing: -0.005rem;
   letter-spacing: -0.005rem;
+  white-space: break-spaces;
 }
 
 .c5 {
@@ -125,6 +126,21 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   display: -ms-flexbox;
   display: flex;
   outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-column-gap: 1rem;
+  column-gap: 1rem;
+  padding-left: 0rem;
+  padding-right: 0rem;
 }
 
 .c6:focus-visible {
@@ -179,6 +195,35 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
     -webkit-text-decoration: underline;
     text-decoration: underline;
     border-color: #bef2bd;
+  }
+}
+
+@media (min-width:750px) {
+  .c6 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:750px) {
+  .c6 {
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@media (min-width:750px) {
+  .c6 {
+    padding-left: 0.75rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c6 {
+    padding-right: 0.75rem;
   }
 }
 

--- a/src/components/organisms/shared/OakSideMenuNavLink/OakSideMenuNavLink.stories.tsx
+++ b/src/components/organisms/shared/OakSideMenuNavLink/OakSideMenuNavLink.stories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { StoryObj, Meta } from "@storybook/react";
+
+import { OakSideMenuNavLink } from "./OakSideMenuNavLink";
+
+const meta: Meta<typeof OakSideMenuNavLink> = {
+  //  "title" is the title of the story and where to look for component in the storybook
+  title: "Components/OakSideMenuNavLink",
+  component: OakSideMenuNavLink,
+  tags: ["autodocs"],
+  argTypes: {
+    item: {
+      control: {
+        type: "object",
+      },
+    },
+    isSelected: {
+      control: {
+        type: "boolean",
+      },
+    },
+    onClick: {
+      action: "clicked",
+    },
+  },
+  parameters: {
+    controls: {
+      include: ["item", "isSelected", "onClick", "type"],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OakSideMenuNavLink>;
+
+export const Default: Story = {
+  render: (args) => <OakSideMenuNavLink {...args} />,
+  args: {
+    item: {
+      heading: "Test Item",
+      subheading: "Test Subheading",
+      href: "#test",
+    },
+    isSelected: false,
+    onClick: () => {
+      // Do nothing
+    },
+  },
+};

--- a/src/components/organisms/shared/OakSideMenuNavLink/OakSideMenuNavLink.stories.tsx
+++ b/src/components/organisms/shared/OakSideMenuNavLink/OakSideMenuNavLink.stories.tsx
@@ -4,8 +4,7 @@ import { StoryObj, Meta } from "@storybook/react";
 import { OakSideMenuNavLink } from "./OakSideMenuNavLink";
 
 const meta: Meta<typeof OakSideMenuNavLink> = {
-  //  "title" is the title of the story and where to look for component in the storybook
-  title: "Components/OakSideMenuNavLink",
+  title: "Components/organisms/shared/OakSideMenuNavLink",
   component: OakSideMenuNavLink,
   tags: ["autodocs"],
   argTypes: {

--- a/src/components/organisms/shared/OakSideMenuNavLink/OakSideMenuNavLink.test.tsx
+++ b/src/components/organisms/shared/OakSideMenuNavLink/OakSideMenuNavLink.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { OakSideMenuNavLink } from "./OakSideMenuNavLink";
+import { create } from "react-test-renderer";
+import { OakThemeProvider } from "@/components/atoms";
+import { oakDefaultTheme } from "@/styles";
+
+describe("OakSideMenuNavLink", () => {
+  it("renders", () => {
+    const { getByText } = renderWithTheme(
+      <OakSideMenuNavLink
+        data-testid="test"
+        isSelected={false}
+        item={{
+          heading: "Test",
+          subheading: "Test Subheading",
+          href: "/test",
+        }}
+        onClick={() => {
+          // Do nothing
+        }}
+      />,
+    );
+    expect(getByText("Test")).toBeInTheDocument();
+  });
+  it("matches snapshot", () => {
+    const tree = create(
+      <OakThemeProvider theme={oakDefaultTheme}>
+        {" "}
+        <OakSideMenuNavLink
+          isSelected={false}
+          item={{
+            heading: "Test",
+            subheading: "Test Subheading",
+            href: "/test",
+          }}
+          onClick={() => {
+            // Do nothing
+          }}
+        />
+      </OakThemeProvider>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/shared/OakSideMenuNavLink/OakSideMenuNavLink.test.tsx
+++ b/src/components/organisms/shared/OakSideMenuNavLink/OakSideMenuNavLink.test.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import renderWithTheme from "@/test-helpers/renderWithTheme";
-import { OakSideMenuNavLink } from "./OakSideMenuNavLink";
 import { create } from "react-test-renderer";
+
+import { OakSideMenuNavLink } from "./OakSideMenuNavLink";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
 import { OakThemeProvider } from "@/components/atoms";
 import { oakDefaultTheme } from "@/styles";
 

--- a/src/components/organisms/shared/OakSideMenuNavLink/OakSideMenuNavLink.tsx
+++ b/src/components/organisms/shared/OakSideMenuNavLink/OakSideMenuNavLink.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import styled, { css } from "styled-components";
+
+import { OakFlex } from "@/components/atoms/OakFlex";
+import { flexStyle, FlexStyleProps } from "@/styles/utils/flexStyle";
+import { paddingStyle, PaddingStyleProps } from "@/styles/utils/spacingStyle";
+import { getBreakpoint } from "@/styles/utils/responsiveStyle";
+import { parseColor } from "@/styles/helpers/parseColor";
+import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
+import { OakIcon, OakSpan } from "@/components/atoms";
+
+export type MenuItemProps = {
+  heading: string;
+  subheading?: string;
+  href: string;
+};
+
+const StyledLink = styled("a")<
+  FlexStyleProps & PaddingStyleProps & { isSelected: boolean }
+>`
+  text-decoration: none;
+  display: flex;
+  outline: none;
+
+  @media (min-width: ${getBreakpoint("small")}px) {
+    border-left: ${(props) =>
+      props.isSelected ? "4px solid #222222" : "4px solid transparent"};
+    :hover {
+      text-decoration: underline;
+      border-color: ${(props) =>
+        props.isSelected
+          ? parseColor("bg-btn-primary-hover")
+          : parseColor("bg-decorative1-main")};
+    }
+  }
+
+  :focus-visible {
+    box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
+      ${parseDropShadow("drop-shadow-centered-grey")};
+    border-color: transparent;
+    border-radius: 4px;
+  }
+  ${flexStyle}
+  ${paddingStyle}
+`;
+
+export type OakSideMenuNavLinkProps = FlexStyleProps &
+  PaddingStyleProps & {
+    item: MenuItemProps;
+    isSelected: boolean;
+    onClick: () => void;
+  };
+
+const OakSideMenuNavLinkCss = css<OakSideMenuNavLinkProps>`
+  ${flexStyle}
+  ${paddingStyle}
+`;
+
+const UnstyledComponent = (props: OakSideMenuNavLinkProps) => {
+  const { item, isSelected, onClick } = props;
+  return (
+    <StyledLink
+      $alignItems={["center", "flex-start"]}
+      $columnGap="space-between-s"
+      href={item.href}
+      $ph={["inner-padding-none", "inner-padding-s"]}
+      isSelected={isSelected}
+      $flexDirection={["row", "column"]}
+      onClick={onClick}
+      aria-current={isSelected ? "true" : undefined}
+    >
+      <OakFlex
+        $flexDirection={["row", "column"]}
+        $columnGap={["space-between-s", "space-between-sssx"]}
+        $flexWrap="wrap"
+      >
+        <OakSpan $font="heading-light-7" $color="text-primary">
+          {item.heading}
+        </OakSpan>
+        {item.subheading && (
+          <OakSpan
+            $font="body-3"
+            $color="text-subdued"
+            $whiteSpace={"break-spaces"}
+          >
+            {item.subheading}
+          </OakSpan>
+        )}
+      </OakFlex>
+      <OakIcon
+        $display={["block", "none"]}
+        iconName="chevron-right"
+        $width="all-spacing-6"
+        $pl="inner-padding-s"
+      />
+    </StyledLink>
+  );
+};
+
+/**
+ *
+ * The OakSideMenuNavLink component is a styled link that represents a navigation item in the side menu.
+ * It is designed to be used within the OakSideMenuNav component, but can also be used independently.
+ * The following callbacks are available for tracking focus events:
+ *
+ * ### Callbacks
+ * - `onClick`: A callback function that is triggered when the link is clicked.
+ *
+ * ### Props
+ * - `item`: An object containing the heading, subheading, and href of the link.
+ * - `isSelected`: A boolean indicating whether the link is currently selected.
+ * - `onClick`: A callback function that is triggered when the link is clicked.
+ */
+export const OakSideMenuNavLink = styled(UnstyledComponent)`
+  ${OakSideMenuNavLinkCss}
+`;

--- a/src/components/organisms/shared/OakSideMenuNavLink/__snapshots__/OakSideMenuNavLink.test.tsx.snap
+++ b/src/components/organisms/shared/OakSideMenuNavLink/__snapshots__/OakSideMenuNavLink.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`OakSideMenuNavLink matches snapshot 1`] = `
   -moz-letter-spacing: -0.005rem;
   -ms-letter-spacing: -0.005rem;
   letter-spacing: -0.005rem;
+  white-space: break-spaces;
 }
 
 .c0 {
@@ -69,6 +70,21 @@ exports[`OakSideMenuNavLink matches snapshot 1`] = `
   display: -ms-flexbox;
   display: flex;
   outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-column-gap: 1rem;
+  column-gap: 1rem;
+  padding-left: 0rem;
+  padding-right: 0rem;
 }
 
 .c0:focus-visible {
@@ -107,6 +123,35 @@ exports[`OakSideMenuNavLink matches snapshot 1`] = `
     -webkit-text-decoration: underline;
     text-decoration: underline;
     border-color: #bef2bd;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    padding-left: 0.75rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    padding-right: 0.75rem;
   }
 }
 

--- a/src/components/organisms/shared/OakSideMenuNavLink/__snapshots__/OakSideMenuNavLink.test.tsx.snap
+++ b/src/components/organisms/shared/OakSideMenuNavLink/__snapshots__/OakSideMenuNavLink.test.tsx.snap
@@ -1,0 +1,162 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OakSideMenuNavLink matches snapshot 1`] = `
+[
+  " ",
+  .c1 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c5 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 2rem;
+  min-height: 2rem;
+  padding-left: 0.75rem;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-column-gap: 1rem;
+  column-gap: 1rem;
+}
+
+.c6 {
+  object-fit: contain;
+}
+
+.c3 {
+  color: #222222;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c4 {
+  color: #575757;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c0 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  outline: none;
+}
+
+.c0:focus-visible {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+  border-color: transparent;
+  border-radius: 4px;
+}
+
+@media (min-width:750px) {
+  .c5 {
+    display: none;
+  }
+}
+
+@media (min-width:750px) {
+  .c2 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:750px) {
+  .c2 {
+    -webkit-column-gap: 0.25rem;
+    column-gap: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c0 {
+    border-left: 4px solid transparent;
+  }
+
+  .c0:hover {
+    -webkit-text-decoration: underline;
+    text-decoration: underline;
+    border-color: #bef2bd;
+  }
+}
+
+<a
+    className="c0"
+    href="/test"
+    onClick={[Function]}
+  >
+    <div
+      className="c1 c2"
+    >
+      <span
+        className="c3"
+      >
+        Test
+      </span>
+      <span
+        className="c4"
+      >
+        Test Subheading
+      </span>
+    </div>
+    <div
+      className="c5"
+    >
+      <img
+        alt=""
+        className="c6"
+        data-nimg="fill"
+        decoding="async"
+        loading="lazy"
+        onError={[Function]}
+        onLoad={[Function]}
+        src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+        style={
+          {
+            "bottom": 0,
+            "color": "transparent",
+            "height": "100%",
+            "left": 0,
+            "objectFit": undefined,
+            "objectPosition": undefined,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "100%",
+          }
+        }
+      />
+    </div>
+  </a>,
+]
+`;

--- a/src/components/organisms/shared/OakSideMenuNavLink/index.ts
+++ b/src/components/organisms/shared/OakSideMenuNavLink/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakSideMenuNavLink";

--- a/src/components/organisms/shared/index.ts
+++ b/src/components/organisms/shared/index.ts
@@ -16,3 +16,4 @@ export * from "./OakMediaClipList";
 export * from "./OakVideoTranscript";
 export * from "./OakCodeRenderer";
 export * from "./OakSideMenuNav";
+export * from "./OakSideMenuNavLink";


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
decouple OakSideNavMenuLink  from the nav menu so that it can be used in isolation

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions
go to /iframe.html?viewMode=docs&id=components-oaksidemenunavlink--docs&globals=#test

## ACs
