### PR TITLE
feat: dont show number on mobile sizes

### DIFF
--- a/src/components/molecules/OakSaveCount/OakSaveCount.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.tsx
@@ -35,17 +35,22 @@ const StyledInternalButton = styled(InternalButton)`
 export const OakSaveCount = ({ count, href, loading }: OakSaveCountProps) => {
   const iconName = count === 0 ? "bookmark-outlined" : "bookmark-filled";
   const showTruncatedCount = count > 99;
+  const containerWidth = showTruncatedCount
+    ? "all-spacing-11"
+    : "all-spacing-10";
+
   return (
     <StyledInternalButton as="a" href={href}>
       <OakScreenReader>View my library</OakScreenReader>
       <OakFlex
-        $width={showTruncatedCount ? "all-spacing-11" : "all-spacing-10"}
+        $width={["all-spacing-7", containerWidth]}
         $height="all-spacing-7"
         $background={
           loading ? "bg-btn-secondary-hover" : "bg-decorative1-subdued"
         }
         $alignItems="center"
-        $pa="inner-padding-ssx"
+        $justifyContent={["center", "initial"]}
+        $pa={["inner-padding-none", "inner-padding-ssx"]}
         $borderRadius="border-radius-s"
         $borderColor={
           loading ? "border-neutral-lighter" : "bg-decorative1-main"
@@ -58,7 +63,11 @@ export const OakSaveCount = ({ count, href, loading }: OakSaveCountProps) => {
           data-testid={iconName}
           $width="all-spacing-6"
         />
-        <OakBox $width="all-spacing-6" $textAlign="center">
+        <OakBox
+          $width="all-spacing-6"
+          $textAlign="center"
+          $display={["none", "block"]}
+        >
           <OakSpan
             $font="heading-light-7"
             aria-label={`${count} saved unit${count === 1 ? "" : "s"}`}

--- a/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
+++ b/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`OakSaveCount should match snapshot 1`] = `
 .c3 {
-  width: 3.5rem;
+  width: 2rem;
   height: 2rem;
-  padding: 0.25rem;
+  padding: 0rem;
   background: #dff9de;
   border: 0.063rem solid;
   border-color: #bef2bd;
@@ -23,6 +23,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
 
 .c7 {
   width: 1.5rem;
+  display: none;
   font-family: --var(google-font),Lexend,sans-serif;
   text-align: center;
 }
@@ -40,6 +41,10 @@ exports[`OakSaveCount should match snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -90,6 +95,33 @@ exports[`OakSaveCount should match snapshot 1`] = `
 
 .c1:focus-visible .oak-save-count {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+@media (min-width:750px) {
+  .c3 {
+    width: 3.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c3 {
+    padding: 0.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c7 {
+    display: block;
+  }
+}
+
+@media (min-width:750px) {
+  .c4 {
+    -webkit-box-pack: initial;
+    -webkit-justify-content: initial;
+    -ms-flex-pack: initial;
+    justify-content: initial;
+  }
 }
 
 <div>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- update `OakSaveCount` with new mobile design which removes the number count and reduces the width

## Link to the design doc
https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=14263-4518&p=f&m=dev

## A link to the component in the deployment preview
https://deploy-preview-427--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oaksavecount--docs
<img width="203" alt="Screenshot 2025-05-23 at 10 14 05" src="https://github.com/user-attachments/assets/81b762d5-af73-4d4c-a416-c3fd4ef79d8e" />


## Testing instructions
Test the save count with different number values on desktop and mobile
