### PR TITLE
DOM nesting errors

### DIFF
--- a/src/components/CopyPasteThisComponent/__snapshots__/CopyPasteThisComponent.test.tsx.snap
+++ b/src/components/CopyPasteThisComponent/__snapshots__/CopyPasteThisComponent.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CopyPasteThisComponent matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/atoms/InternalAccordion/__snapshots__/InternalAccordion.test.tsx.snap
+++ b/src/components/atoms/InternalAccordion/__snapshots__/InternalAccordion.test.tsx.snap
@@ -1,15 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalAccordion matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2:hover {
+.c2:where(*):hover {
   cursor: pointer;
 }
 

--- a/src/components/atoms/InternalCard/__snapshots__/InternalCard.test.tsx.snap
+++ b/src/components/atoms/InternalCard/__snapshots__/InternalCard.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakBox matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   padding: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;

--- a/src/components/atoms/InternalCardWithBackgroundElement/__snapshots__/InternalCardWithBackgroundElement.test.tsx.snap
+++ b/src/components/atoms/InternalCardWithBackgroundElement/__snapshots__/InternalCardWithBackgroundElement.test.tsx.snap
@@ -1,19 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalStyledSvg matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   padding: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }

--- a/src/components/atoms/InternalCheckBoxWrapper/__snapshots__/InternalCheckBoxWrapper.test.tsx.snap
+++ b/src/components/atoms/InternalCheckBoxWrapper/__snapshots__/InternalCheckBoxWrapper.test.tsx.snap
@@ -2,14 +2,22 @@
 
 exports[`InternalCheckBoxWrapper matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   left: 0rem;

--- a/src/components/atoms/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
+++ b/src/components/atoms/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalTooltip matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   max-width: 22.5rem;
   color: #ffffff;
@@ -34,7 +38,7 @@ exports[`InternalTooltip matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     max-width: 40rem;
   }
 }

--- a/src/components/atoms/OakBox/OakBox.tsx
+++ b/src/components/atoms/OakBox/OakBox.tsx
@@ -58,26 +58,34 @@ export type OakBoxProps = {
   HTMLProps;
 
 export const oakBoxCss = css<OakBoxProps>`
-  ${positionStyle}
-  ${sizeStyle}
-  ${spacingStyle}
-  ${colorStyle}
-  ${borderStyle}
-  ${displayStyle}
-  ${dropShadowStyle}
-  ${opacityStyle}
-  ${transformStyle}
-  ${transitionStyle}
-  ${typographyStyle}
-  ${zIndexStyle}
-  ${(props) =>
-    /* onClick might be passed in the useClickableCard pattern */
-    props.onClick &&
-    css`
-      :hover {
-        cursor: pointer;
-      }
-    `}
+  // HACK: This is a massive hack because we want <span/>'s to always be block when they are <div/>'s
+  &:where(span) {
+    display: block;
+  }
+
+  // HACK: See above...
+  &:where(*) {
+    ${positionStyle}
+    ${sizeStyle}
+    ${spacingStyle}
+    ${colorStyle}
+    ${borderStyle}
+    ${displayStyle}
+    ${dropShadowStyle}
+    ${opacityStyle}
+    ${transformStyle}
+    ${transitionStyle}
+    ${typographyStyle}
+    ${zIndexStyle}
+    ${(props) =>
+      /* onClick might be passed in the useClickableCard pattern */
+      props.onClick &&
+      css`
+        :hover {
+          cursor: pointer;
+        }
+      `}
+  }
 `;
 
 /**

--- a/src/components/atoms/OakBox/__snapshots__/OakBox.test.tsx.snap
+++ b/src/components/atoms/OakBox/__snapshots__/OakBox.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakBox matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/atoms/OakCloudinaryImage/__snapshots__/OakCloudinaryImage.test.tsx.snap
+++ b/src/components/atoms/OakCloudinaryImage/__snapshots__/OakCloudinaryImage.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakCloudinaryImage matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;

--- a/src/components/atoms/OakFieldset/__snapshots__/OakFieldset.test.tsx.snap
+++ b/src/components/atoms/OakFieldset/__snapshots__/OakFieldset.test.tsx.snap
@@ -5,6 +5,13 @@ exports[`OakFieldset matches snapshot 1`] = `
   border: 0;
   margin: 0;
   padding: 0;
+}
+
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/atoms/OakFlex/__snapshots__/OakFlex.test.tsx.snap
+++ b/src/components/atoms/OakFlex/__snapshots__/OakFlex.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakBox matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/atoms/OakForm/__snapshots__/OakForm.test.tsx.snap
+++ b/src/components/atoms/OakForm/__snapshots__/OakForm.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component OakBox matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/atoms/OakGrid/__snapshots__/OakGrid.test.tsx.snap
+++ b/src/components/atoms/OakGrid/__snapshots__/OakGrid.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakGrid matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/atoms/OakGridArea/__snapshots__/OakGridArea.test.tsx.snap
+++ b/src/components/atoms/OakGridArea/__snapshots__/OakGridArea.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakGrid matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/atoms/OakIcon/OakIcon.tsx
+++ b/src/components/atoms/OakIcon/OakIcon.tsx
@@ -8,7 +8,10 @@ export const oakIconNames = Object.keys(icons) as IconName[];
 
 export type OakIconName = IconName;
 
-export type OakIconProps = Omit<OakImageProps, "alt" | "src"> & {
+export type OakIconProps = Omit<
+  OakImageProps,
+  "alt" | "src" | "containerAs"
+> & {
   /**
    * The name of the icon to display
    *
@@ -61,6 +64,7 @@ export const OakIcon = (props: OakIconProps) => {
   return (
     <OakImage
       src={generateOakIconURL(iconName)}
+      containerAs="span"
       alt={alt ?? ""}
       $width={$width}
       $height={$height}

--- a/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
+++ b/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakIcon matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;

--- a/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
+++ b/src/components/atoms/OakIcon/__snapshots__/OakIcon.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`OakIcon matches snapshot 1`] = `
   object-fit: contain;
 }
 
-<div
+<span
   className="c0"
 >
   <img
@@ -41,5 +41,5 @@ exports[`OakIcon matches snapshot 1`] = `
       }
     }
   />
-</div>
+</span>
 `;

--- a/src/components/atoms/OakImage/OakImage.tsx
+++ b/src/components/atoms/OakImage/OakImage.tsx
@@ -28,6 +28,7 @@ export type OakImageProps<C extends ElementType = typeof Image> = Omit<
   ColorFilterStyleProps &
   HTMLProps & {
     as?: C;
+    containerAs?: "div" | "span";
     /**
      * The placeholder to use while the image is loading
      *
@@ -104,6 +105,7 @@ export const OakImage = <C extends ElementType = typeof Image>({
 }: OakImageProps<C>) => {
   const {
     as,
+    containerAs = "div",
     src,
     alt,
     width,
@@ -128,7 +130,7 @@ export const OakImage = <C extends ElementType = typeof Image>({
   // Use $width and $height to set the width and height of the image container
   if (!width || !height) {
     return (
-      <OakBox $position={$position} $width={$width} {...rest}>
+      <OakBox as={containerAs} $position={$position} $width={$width} {...rest}>
         <StyledFillImage
           ref={setImg}
           as={as ?? Image}
@@ -153,7 +155,12 @@ export const OakImage = <C extends ElementType = typeof Image>({
   // Use $minWidth to set the width with auto height
 
   return (
-    <OakBox $maxWidth={"all-spacing-0"} $position={$position} {...rest}>
+    <OakBox
+      as={containerAs}
+      $maxWidth={"all-spacing-0"}
+      $position={$position}
+      {...rest}
+    >
       <StyledResponsiveImage
         ref={setImg}
         as={as ?? Image}

--- a/src/components/atoms/OakImage/__snapshots__/OakImage.test.tsx.snap
+++ b/src/components/atoms/OakImage/__snapshots__/OakImage.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakImage matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;

--- a/src/components/atoms/OakLI/__snapshots__/OakLI.test.tsx.snap
+++ b/src/components/atoms/OakLI/__snapshots__/OakLI.test.tsx.snap
@@ -2,11 +2,18 @@
 
 exports[`Component OakLI matches snapshot 1`] = `
 .c0 {
-  display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
   display: revert;
   display: revert;
+}
+
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
+  display: revert;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <li

--- a/src/components/atoms/OakMaxWidth/__snapshots__/OakMaxWidth.test.tsx.snap
+++ b/src/components/atoms/OakMaxWidth/__snapshots__/OakMaxWidth.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakMaxWidth matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 100%;
   max-width: 30rem;
   padding-left: 0rem;
@@ -26,19 +30,19 @@ exports[`OakMaxWidth matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-left: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-right: 0.75rem;
   }
 }

--- a/src/components/atoms/OakSvg/__snapshots__/OakSvg.test.tsx.snap
+++ b/src/components/atoms/OakSvg/__snapshots__/OakSvg.test.tsx.snap
@@ -2,9 +2,16 @@
 
 exports[`OakSvg matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
+}
+
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <svg

--- a/src/components/atoms/OakTypography/__snapshots__/OakTypography.test.tsx.snap
+++ b/src/components/atoms/OakTypography/__snapshots__/OakTypography.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTypography matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/atoms/OakUL/__snapshots__/OakUL.test.tsx.snap
+++ b/src/components/atoms/OakUL/__snapshots__/OakUL.test.tsx.snap
@@ -4,6 +4,13 @@ exports[`Component OakUL matches snapshot 1`] = `
 .c0 {
   margin: 0;
   display: block;
+}
+
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
+++ b/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
@@ -1,28 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalChevronAccordion matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3:hover {
+.c3:where(*):hover {
   cursor: pointer;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -31,7 +47,11 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -40,18 +60,30 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c17:where(span) {
+  display: block;
+}
+
+.c17:where(*) {
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -120,9 +152,16 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  position: relative;
+}
+
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
-  position: relative;
 }
 
 .c7:hover {
@@ -135,10 +174,6 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
 }
 
 .c2 {
-  position: relative;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -155,6 +190,17 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
 
 .c2 .c6:focus-visible ~ .c15 {
   visibility: visible;
+}
+
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
+  position: relative;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c18 {

--- a/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
+++ b/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
       <div
         className="c9 shadow"
       />
-      <div
+      <span
         className="c10"
         style={
           {
@@ -220,7 +220,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
   </button>
   <div

--- a/src/components/molecules/InternalLink/InternalLink.tsx
+++ b/src/components/molecules/InternalLink/InternalLink.tsx
@@ -142,6 +142,7 @@ export const InternalLink: InternalLinkComponent = forwardRef(
         case isLoading:
           return (
             <OakBox
+              as="span"
               $width="all-spacing-6"
               $height="all-spacing-6"
               $display={"inline-block"}

--- a/src/components/molecules/InternalShadowIconButton/__snapshots__/InternalShadowIconButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowIconButton/__snapshots__/InternalShadowIconButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalShadowIconButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,25 +13,41 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   padding-left: 0rem;
   padding-right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   color: #ebfbeb;
   border-radius: 6.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: absolute;
   top: 0.25rem;
   left: 0.25rem;
@@ -39,7 +59,11 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: absolute;
   top: 0.125rem;
   left: 0.125rem;
@@ -51,7 +75,11 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/InternalShadowIconButton/__snapshots__/InternalShadowIconButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowIconButton/__snapshots__/InternalShadowIconButton.test.tsx.snap
@@ -202,7 +202,7 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
         <div
           className="c9"
         >
-          <div
+          <span
             className="c10 shadow"
           >
             <img
@@ -229,8 +229,8 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
                 }
               }
             />
-          </div>
-          <div
+          </span>
+          <span
             className="c12 highlight"
           >
             <img
@@ -257,8 +257,8 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
                 }
               }
             />
-          </div>
-          <div
+          </span>
+          <span
             className="c14"
             data-icon-for="button"
           >
@@ -286,7 +286,7 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
       </div>
       <span

--- a/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalShadowRectButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,11 +26,19 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <span
         className="c7"
       >
         <img
@@ -192,7 +192,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <span
         className="c9"
       >

--- a/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
         <div
           className="c9 shadow"
         />
-        <div
+        <span
           className="c10"
           data-icon-for="button"
         >
@@ -206,7 +206,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
       <span
         className="c12"

--- a/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
+++ b/src/components/molecules/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalShadowRoundButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,11 +13,19 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -24,7 +36,11 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -33,7 +49,11 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/OakAccordion/__snapshots__/OakAccordion.test.tsx.snap
+++ b/src/components/molecules/OakAccordion/__snapshots__/OakAccordion.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakAccordion matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding: 1rem;
   background: #f2f2f2;
   border: 0.063rem solid;
@@ -9,7 +13,11 @@ exports[`OakAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -22,15 +30,23 @@ exports[`OakAccordion matches snapshot 1`] = `
   text-decoration: underline;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3:hover {
+.c3:where(*):hover {
   cursor: pointer;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -40,12 +56,20 @@ exports[`OakAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   margin-left: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   padding-left: 1rem;
   margin-left: 1.5rem;
   margin-top: 0.25rem;

--- a/src/components/molecules/OakAccordion/__snapshots__/OakAccordion.test.tsx.snap
+++ b/src/components/molecules/OakAccordion/__snapshots__/OakAccordion.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`OakAccordion matches snapshot 1`] = `
       onClick={[Function]}
       type="button"
     >
-      <div
+      <span
         className="c7"
         style={
           {
@@ -154,7 +154,7 @@ exports[`OakAccordion matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       See more
     </button>
     <div

--- a/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
+++ b/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakBackLink matches snapshot 1`] = `
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;

--- a/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
+++ b/src/components/molecules/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`OakBackLink matches snapshot 1`] = `
   aria-label="Back"
   className="c0"
 >
-  <div
+  <span
     className="c1"
   >
     <img
@@ -98,6 +98,6 @@ exports[`OakBackLink matches snapshot 1`] = `
         }
       }
     />
-  </div>
+  </span>
 </a>
 `;

--- a/src/components/molecules/OakBasicAccordion/__snapshots__/OakBasicAccordion.test.tsx.snap
+++ b/src/components/molecules/OakBasicAccordion/__snapshots__/OakBasicAccordion.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
       <div
         className="c10 shadow"
       />
-      <div
+      <span
         className="c11"
         style={
           {
@@ -215,7 +215,7 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
   </button>
   <div

--- a/src/components/molecules/OakBasicAccordion/__snapshots__/OakBasicAccordion.test.tsx.snap
+++ b/src/components/molecules/OakBasicAccordion/__snapshots__/OakBasicAccordion.test.tsx.snap
@@ -1,28 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakBasicAccordion matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3:hover {
+.c3:where(*):hover {
   cursor: pointer;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -31,7 +47,11 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -40,14 +60,22 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -123,9 +151,16 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  position: relative;
+}
+
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
-  position: relative;
 }
 
 .c7:hover {
@@ -138,10 +173,6 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
 }
 
 .c2 {
-  position: relative;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -158,6 +189,17 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
 
 .c2 .c6:focus-visible ~ .c17 {
   visibility: visible;
+}
+
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
+  position: relative;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 <div

--- a/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
@@ -1,11 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -13,7 +21,11 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;

--- a/src/components/molecules/OakCardWithHandDrawnBorder/__snapshots__/OakCardWithHandDrawnBorder.test.tsx.snap
+++ b/src/components/molecules/OakCardWithHandDrawnBorder/__snapshots__/OakCardWithHandDrawnBorder.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakCardWithHandDrawnBorder matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -10,13 +14,21 @@ exports[`OakCardWithHandDrawnBorder matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }

--- a/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
+++ b/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
@@ -51,14 +51,22 @@ exports[`OakCheckBox matches snapshot 1`] = `
   align-items: center;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -68,7 +76,11 @@ exports[`OakCheckBox matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;

--- a/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
+++ b/src/components/molecules/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
@@ -137,7 +137,7 @@ input:checked + .c7 {
     <div
       className="c7 c8 c9"
     >
-      <div
+      <span
         className="c10"
       >
         <img
@@ -164,7 +164,7 @@ input:checked + .c7 {
             }
           }
         />
-      </div>
+      </span>
     </div>
   </div>
   Option 1

--- a/src/components/molecules/OakCollapsibleContent/__snapshots__/OakCollapsibleContent.test.tsx.snap
+++ b/src/components/molecules/OakCollapsibleContent/__snapshots__/OakCollapsibleContent.test.tsx.snap
@@ -1,12 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakCollapsibleContent matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 1.5rem;
@@ -16,7 +24,11 @@ exports[`OakCollapsibleContent matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   overflow: auto;
   width: 100%;
   max-height: 100%;

--- a/src/components/molecules/OakCopyLinkButton/__snapshots__/OakCopyLinkButton.test.tsx.snap
+++ b/src/components/molecules/OakCopyLinkButton/__snapshots__/OakCopyLinkButton.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
           >
             Copy link
           </span>
-          <div
+          <span
             aria-hidden={true}
             className="c9"
           >
@@ -218,7 +218,7 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
       </button>
     </div>

--- a/src/components/molecules/OakCopyLinkButton/__snapshots__/OakCopyLinkButton.test.tsx.snap
+++ b/src/components/molecules/OakCopyLinkButton/__snapshots__/OakCopyLinkButton.test.tsx.snap
@@ -2,12 +2,20 @@
 
 exports[`OakCopyLinkButton matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -15,7 +23,11 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -24,11 +36,19 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -154,7 +174,7 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     display: block;
   }
 }
@@ -223,7 +243,11 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
       </button>
     </div>
   </div>,
-  .c1 {
+  .c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -231,7 +255,11 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -240,11 +268,19 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -364,7 +400,7 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     display: none;
   }
 }

--- a/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
+++ b/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
@@ -1,11 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakDragAndDropInstructions matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -14,7 +22,11 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;

--- a/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
+++ b/src/components/molecules/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
   <div
     className="c0 c2"
   >
-    <div
+    <span
       className="c3"
     >
       <img
@@ -106,7 +106,7 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
           }
         }
       />
-    </div>
+    </span>
   </div>
   <div
     className="c5 c6"

--- a/src/components/molecules/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
+++ b/src/components/molecules/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`OakDraggable matches snapshot 1`] = `
   <div
     className="c2 c3 c4"
   >
-    <div
+    <span
       className="c5 "
     >
       <img
@@ -145,7 +145,7 @@ exports[`OakDraggable matches snapshot 1`] = `
           }
         }
       />
-    </div>
+    </span>
     <div
       className="c7 c8"
     >

--- a/src/components/molecules/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
+++ b/src/components/molecules/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakDraggable matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   min-height: 3.5rem;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
@@ -13,11 +17,19 @@ exports[`OakDraggable matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -26,7 +38,11 @@ exports[`OakDraggable matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;

--- a/src/components/molecules/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
+++ b/src/components/molecules/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakDraggableFeedback matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   min-height: 3.5rem;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
@@ -15,11 +19,19 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -28,7 +40,11 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;

--- a/src/components/molecules/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
+++ b/src/components/molecules/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
   <div
     className="c2 c3 c4"
   >
-    <div
+    <span
       className="c5 "
     >
       <img
@@ -148,7 +148,7 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
           }
         }
       />
-    </div>
+    </span>
     <div
       className="c7 c8"
     >

--- a/src/components/molecules/OakDroppable/__snapshots__/OakDroppable.test.tsx.snap
+++ b/src/components/molecules/OakDroppable/__snapshots__/OakDroppable.test.tsx.snap
@@ -1,14 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakDroppable matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding: 1rem;
   background: #cee7e5;
   border-radius: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   min-height: 4rem;
   padding: 0.25rem;
   background: #f2f2f2;
@@ -16,7 +24,11 @@ exports[`OakDroppable matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }

--- a/src/components/molecules/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
+++ b/src/components/molecules/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
@@ -1,16 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 300;
 }
 
-.c0:hover {
+.c0:where(*):hover {
   cursor: pointer;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: fixed;
   top: 0rem;
   right: 0rem;
@@ -24,12 +32,20 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   z-index: 300;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   margin: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -37,11 +53,19 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -52,7 +76,11 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -61,7 +89,11 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c21:where(span) {
+  display: block;
+}
+
+.c21:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -70,7 +102,11 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c24:where(span) {
+  display: block;
+}
+
+.c24:where(*) {
   overflow: auto;
   border-top: 0.063rem solid;
   border-color: transparent;
@@ -78,13 +114,21 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   overflow: auto;
 }
 
-.c26 {
+.c26:where(span) {
+  display: block;
+}
+
+.c26:where(*) {
   margin-left: 1.5rem;
   margin-right: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c27 {
+.c27:where(span) {
+  display: block;
+}
+
+.c27:where(*) {
   width: 100%;
   padding: 0.75rem;
   border-top: 0.063rem solid;

--- a/src/components/molecules/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
+++ b/src/components/molecules/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
@@ -427,7 +427,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
                 <div
                   class="c20 shadow"
                 />
-                <div
+                <span
                   class="c21"
                   data-icon-for="button"
                 >
@@ -440,7 +440,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
                     src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895179/icons/xigimrbivcaxt4omxamp.svg"
                     style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                   />
-                </div>
+                </span>
               </div>
               <span
                 class="c23"

--- a/src/components/molecules/OakHandDrawnCard/__snapshots__/OakHandDrawnCard.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnCard/__snapshots__/OakHandDrawnCard.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakHandDrawnCard matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -10,13 +14,21 @@ exports[`OakHandDrawnCard matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }

--- a/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: 5rem;
   height: 5rem;
@@ -9,18 +13,30 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   position: relative;
   width: 4rem;
   min-width: 4rem;
@@ -67,37 +83,37 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     width: 10rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     height: 10rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     width: 7.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     min-width: 7.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     height: 7.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     min-height: 7.5rem;
   }
 }

--- a/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
   <div
     className="c5"
   >
-    <div
+    <span
       className="c6"
     >
       <img
@@ -151,7 +151,7 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
           }
         }
       />
-    </div>
+    </span>
   </div>
 </div>
 `;

--- a/src/components/molecules/OakHandDrawnFocusUnderline/__snapshots__/OakHandDrawnFocusUnderline.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnFocusUnderline/__snapshots__/OakHandDrawnFocusUnderline.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakHandDrawnFocusUnderline matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakHandDrawnHR matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakInfoButton/__snapshots__/OakInfoButton.test.tsx.snap
+++ b/src/components/molecules/OakInfoButton/__snapshots__/OakInfoButton.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
           <div
             className="c10 shadow"
           />
-          <div
+          <span
             className="c11"
             data-icon-for="button"
           >
@@ -220,7 +220,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
         <span
           className="c13"

--- a/src/components/molecules/OakInfoButton/__snapshots__/OakInfoButton.test.tsx.snap
+++ b/src/components/molecules/OakInfoButton/__snapshots__/OakInfoButton.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakInfoButton matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -10,11 +14,19 @@ exports[`OakInfoButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -25,7 +37,11 @@ exports[`OakInfoButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -34,7 +50,11 @@ exports[`OakInfoButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;

--- a/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding: 1rem;
   background: #e3e9fb;
   border: 0.063rem solid;
@@ -15,17 +19,29 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -34,7 +50,11 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -42,7 +62,11 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -53,7 +77,11 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -62,7 +90,11 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c17:where(span) {
+  display: block;
+}
+
+.c17:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -71,12 +103,20 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c19:where(span) {
+  display: block;
+}
+
+.c19:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -87,7 +127,11 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c23 {
+.c23:where(span) {
+  display: block;
+}
+
+.c23:where(*) {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -510,7 +554,11 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
 `;
 
 exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding: 1.5rem;
   background: #e3e9fb;
   border: 0.063rem solid;
@@ -524,17 +572,29 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -543,14 +603,22 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: absolute;
   top: 0rem;
   right: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -558,7 +626,11 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -569,7 +641,11 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c17:where(span) {
+  display: block;
+}
+
+.c17:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -578,7 +654,11 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -587,12 +667,20 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c23 {
+.c23:where(span) {
+  display: block;
+}
+
+.c23:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -603,7 +691,11 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c24 {
+.c24:where(span) {
+  display: block;
+}
+
+.c24:where(*) {
   margin-top: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -1026,7 +1118,11 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
 `;
 
 exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding: 1rem;
   background: #e3e9fb;
   border: 0.063rem solid;
@@ -1040,17 +1136,29 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -1059,7 +1167,11 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -1067,7 +1179,11 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -1078,7 +1194,11 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -1087,7 +1207,11 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c17:where(span) {
+  display: block;
+}
+
+.c17:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -1096,12 +1220,20 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c19:where(span) {
+  display: block;
+}
+
+.c19:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c21:where(span) {
+  display: block;
+}
+
+.c21:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;

--- a/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/molecules/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -358,7 +358,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
     <div
       className="c4"
     >
-      <div
+      <span
         className="c5"
         data-testid="inline-banner-icon"
       >
@@ -386,7 +386,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
     <div
       className="c4 c7"
@@ -411,7 +411,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
               <div
                 className="c16 shadow"
               />
-              <div
+              <span
                 className="c17"
                 data-icon-for="button"
               >
@@ -439,7 +439,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
                     }
                   }
                 />
-              </div>
+              </span>
             </div>
             <span
               className="c18"
@@ -474,7 +474,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
           >
             Link
           </span>
-          <div
+          <span
             className="c17 "
           >
             <img
@@ -501,7 +501,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </a>
       </div>
     </div>
@@ -874,7 +874,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
     <div
       className="c4"
     >
-      <div
+      <span
         className="c5"
         data-testid="inline-banner-icon"
       >
@@ -902,7 +902,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
     <div
       className="c7 c8"
@@ -927,7 +927,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
               <div
                 className="c17 shadow"
               />
-              <div
+              <span
                 className="c18"
                 data-icon-for="button"
               >
@@ -955,7 +955,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
                     }
                   }
                 />
-              </div>
+              </span>
             </div>
             <span
               className="c19"
@@ -990,7 +990,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
           >
             Link
           </span>
-          <div
+          <span
             className="c18 "
           >
             <img
@@ -1017,7 +1017,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </a>
       </div>
     </div>
@@ -1367,7 +1367,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
     <div
       className="c4"
     >
-      <div
+      <span
         className="c5"
         data-testid="inline-banner-icon"
       >
@@ -1395,7 +1395,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
             }
           }
         />
-      </div>
+      </span>
     </div>
     <div
       className="c4 c7"
@@ -1420,7 +1420,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
               <div
                 className="c16 shadow"
               />
-              <div
+              <span
                 className="c17"
                 data-icon-for="button"
               >
@@ -1448,7 +1448,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
                     }
                   }
                 />
-              </div>
+              </span>
             </div>
             <span
               className="c18"
@@ -1477,7 +1477,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
           >
             Link
           </span>
-          <div
+          <span
             className="c17 "
           >
             <img
@@ -1504,7 +1504,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
                 }
               }
             />
-          </div>
+          </span>
         </a>
       </div>
     </div>

--- a/src/components/molecules/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
+++ b/src/components/molecules/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakjauntyAngleLabel matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   padding-top: 0.25rem;
@@ -21,25 +25,25 @@ exports[`OakjauntyAngleLabel matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     font-size: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;

--- a/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
+++ b/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
@@ -1,18 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakLessonInfoCard component test matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;

--- a/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
+++ b/src/components/molecules/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
   <div
     className="c2 c3"
   >
-    <div
+    <span
       className="c4"
     >
       <img
@@ -92,7 +92,7 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
           }
         }
       />
-    </div>
+    </span>
     <h1
       className="c6"
     >

--- a/src/components/molecules/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
+++ b/src/components/molecules/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakLinkCard matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 100%;
   padding: 1.5rem;
   background: #ffffff;
@@ -10,21 +14,37 @@ exports[`OakLinkCard matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: 5rem;
   height: 5rem;
@@ -32,13 +52,21 @@ exports[`OakLinkCard matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: relative;
   width: 4rem;
   min-width: 4rem;
@@ -139,37 +167,37 @@ exports[`OakLinkCard matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     width: 10rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     height: 10rem;
   }
 }
 
 @media (min-width:750px) {
-  .c14 {
+  .c14:where(*) {
     width: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c14 {
+  .c14:where(*) {
     min-width: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c14 {
+  .c14:where(*) {
     height: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c14 {
+  .c14:where(*) {
     min-height: 6.25rem;
   }
 }

--- a/src/components/molecules/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
+++ b/src/components/molecules/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
@@ -238,7 +238,7 @@ exports[`OakLinkCard matches snapshot 1`] = `
       <div
         className="c8"
       >
-        <div
+        <span
           className="c14"
         >
           <img
@@ -265,7 +265,7 @@ exports[`OakLinkCard matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
     </div>
   </div>

--- a/src/components/molecules/OakMediaClipListAccordion/__snapshots__/OakMediaClipListAccordion.test.tsx.snap
+++ b/src/components/molecules/OakMediaClipListAccordion/__snapshots__/OakMediaClipListAccordion.test.tsx.snap
@@ -1,12 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakMediaClipListAccordion matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   padding-top: 0rem;
   padding-bottom: 0rem;
@@ -17,21 +25,33 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6:hover {
+.c6:where(*):hover {
   cursor: pointer;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -40,7 +60,11 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -49,18 +73,30 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -139,9 +175,16 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  position: relative;
+}
+
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
-  position: relative;
 }
 
 .c10:hover {
@@ -154,14 +197,6 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
 }
 
 .c5 {
-  position: relative;
-  padding-top: 0rem;
-  padding-bottom: 0rem;
-  border: 0.125rem solid;
-  border-left: 0.125rem solid;
-  border-color: #222222;
-  border-style: solid;
-  font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -178,6 +213,21 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
 
 .c5 .c9:focus-visible ~ .c18 {
   visibility: visible;
+}
+
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
+  position: relative;
+  padding-top: 0rem;
+  padding-bottom: 0rem;
+  border: 0.125rem solid;
+  border-left: 0.125rem solid;
+  border-color: #222222;
+  border-style: solid;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c21 {
@@ -199,25 +249,25 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     border-left: 0.125rem solid;
   }
 }
 
 @media (min-width:1280px) {
-  .c3 {
+  .c3:where(*) {
     border-left: 0rem solid;
   }
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     border-left: 0.125rem solid;
   }
 }
 
 @media (min-width:1280px) {
-  .c5 {
+  .c5:where(*) {
     border-left: 0rem solid;
   }
 }

--- a/src/components/molecules/OakMediaClipListAccordion/__snapshots__/OakMediaClipListAccordion.test.tsx.snap
+++ b/src/components/molecules/OakMediaClipListAccordion/__snapshots__/OakMediaClipListAccordion.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
         <div
           className="c12 shadow"
         />
-        <div
+        <span
           className="c13"
           style={
             {
@@ -275,7 +275,7 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
     </button>
     <div

--- a/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
+++ b/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
@@ -1,12 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakModal matches snapshot when mounted 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 300;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: fixed;
   top: 0rem;
   bottom: 0rem;
@@ -20,19 +28,31 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   z-index: 300;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   margin: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 2rem;
   height: 2.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -40,11 +60,19 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -55,7 +83,11 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -64,7 +96,11 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c19:where(span) {
+  display: block;
+}
+
+.c19:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -73,7 +109,11 @@ exports[`OakModal matches snapshot when mounted 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   overflow: auto;
   border-top: 0.063rem solid;
   border-color: transparent;

--- a/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
+++ b/src/components/molecules/OakModal/__snapshots__/OakModal.test.tsx.snap
@@ -320,7 +320,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
                 <div
                   class="c18 shadow"
                 />
-                <div
+                <span
                   class="c19"
                   data-icon-for="button"
                 >
@@ -333,7 +333,7 @@ exports[`OakModal matches snapshot when mounted 1`] = `
                     src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699895179/icons/xigimrbivcaxt4omxamp.svg"
                     style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                   />
-                </div>
+                </span>
               </div>
               <span
                 class="c21"

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
@@ -1,14 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakModalCenter matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: fixed;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 300;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: fixed;
   inset: 0rem;
   background: #22222240;
@@ -16,14 +24,22 @@ exports[`OakModalCenter matches snapshot 1`] = `
   z-index: -1;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   width: 100%;
   max-width: 60rem;
   padding: 1.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 100%;
   background: #ffffff;
@@ -31,20 +47,32 @@ exports[`OakModalCenter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   min-height: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -52,11 +80,19 @@ exports[`OakModalCenter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -67,7 +103,11 @@ exports[`OakModalCenter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c19:where(span) {
+  display: block;
+}
+
+.c19:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -76,7 +116,11 @@ exports[`OakModalCenter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -85,7 +129,11 @@ exports[`OakModalCenter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c23 {
+.c23:where(span) {
+  display: block;
+}
+
+.c23:where(*) {
   overflow: auto;
   padding-left: 3.5rem;
   padding-right: 3.5rem;
@@ -231,7 +279,11 @@ exports[`OakModalCenter matches snapshot 1`] = `
   background: transparent;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
@@ -316,7 +316,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
                     <div
                       className="c19 shadow"
                     />
-                    <div
+                    <span
                       className="c20"
                       data-icon-for="button"
                     >
@@ -344,7 +344,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
                           }
                         }
                       />
-                    </div>
+                    </span>
                   </div>
                   <span
                     className="c22"

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
@@ -1,13 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakModalCenterBody matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 100%;
   padding-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   width: 6.25rem;
   min-width: 6.25rem;

--- a/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
+++ b/src/components/molecules/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
 <div
   className="c0 c1"
 >
-  <div
+  <span
     className="c2"
     data-testid="icon"
   >
@@ -137,7 +137,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
         }
       }
     />
-  </div>
+  </span>
   <h1
     className="c4"
     data-testid="OakHeading-id"

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -1,37 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakOutlineAccordion matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8:hover {
+.c8:where(*):hover {
   cursor: pointer;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -40,7 +64,11 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -49,14 +77,22 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c17:where(span) {
+  display: block;
+}
+
+.c17:where(*) {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -135,9 +171,16 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  position: relative;
+}
+
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
-  position: relative;
 }
 
 .c12:hover {
@@ -150,10 +193,6 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
 }
 
 .c7 {
-  position: relative;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -170,6 +209,17 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
 
 .c7 .c11:focus-visible ~ .c18 {
   visibility: visible;
+}
+
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
+  position: relative;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c21 {

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -239,7 +239,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
         <div
           className="c14 shadow"
         />
-        <div
+        <span
           className="c15"
           style={
             {
@@ -272,7 +272,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
     </button>
     <div

--- a/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <span
         className="c7"
       >
         <img
@@ -192,7 +192,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <span
         className="c9"
       >

--- a/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPrimaryButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,11 +26,19 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,11 +26,19 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <span
         className="c7"
       >
         <img
@@ -192,7 +192,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <span
         className="c9"
       >

--- a/src/components/molecules/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
+++ b/src/components/molecules/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPromoTag matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: 2.5rem;
   display: -webkit-box;
@@ -11,7 +15,11 @@ exports[`OakPromoTag matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -54,13 +62,13 @@ exports[`OakPromoTag matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     width: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c0 {
+  .c0:where(*) {
     width: 3.5rem;
   }
 }

--- a/src/components/molecules/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
+++ b/src/components/molecules/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
@@ -1,16 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RadioGroup matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   width: 1.5rem;
   height: 1.5rem;
   background: #ffffff;

--- a/src/components/molecules/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
@@ -1,16 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RadioGroup matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   width: 1.5rem;
   height: 1.5rem;
   background: #ffffff;

--- a/src/components/molecules/OakRadioTile/__snapshots__/OakRadioTile.test.tsx.snap
+++ b/src/components/molecules/OakRadioTile/__snapshots__/OakRadioTile.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakRadioTile matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   padding: 0.75rem;
   color: #222222;
@@ -12,7 +16,11 @@ exports[`OakRadioTile matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   width: 1.5rem;
   height: 1.5rem;
   background: #ffffff;

--- a/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
+++ b/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`OakRoundIcon matches snapshot 1`] = `
 <div
   className="c0"
 >
-  <div
+  <span
     className="c1"
   >
     <img
@@ -53,6 +53,6 @@ exports[`OakRoundIcon matches snapshot 1`] = `
         }
       }
     />
-  </div>
+  </span>
 </div>
 `;

--- a/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
+++ b/src/components/molecules/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakRoundIcon matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 3rem;
   height: 3rem;
   padding: 0.25rem;
@@ -10,7 +14,11 @@ exports[`OakRoundIcon matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;

--- a/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
+++ b/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
     <div
       class="c3 c4 oak-save-count"
     >
-      <div
+      <span
         class="c5"
         data-testid="bookmark-outlined"
       >
@@ -150,7 +150,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
           src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1734519491/icons/bookmark-outlined_rxe5v0.svg"
           style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
         />
-      </div>
+      </span>
       <div
         class="c7"
       >

--- a/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
+++ b/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSaveCount should match snapshot 1`] = `
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   width: 2rem;
   height: 2rem;
   padding: 0rem;
@@ -12,7 +16,11 @@ exports[`OakSaveCount should match snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -21,7 +29,11 @@ exports[`OakSaveCount should match snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   width: 1.5rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -98,19 +110,19 @@ exports[`OakSaveCount should match snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     width: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     padding: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c7 {
+  .c7:where(*) {
     display: block;
   }
 }

--- a/src/components/molecules/OakScaleImageButton/__snapshots__/OakScaleImageButton.test.tsx.snap
+++ b/src/components/molecules/OakScaleImageButton/__snapshots__/OakScaleImageButton.test.tsx.snap
@@ -1,13 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakScaleImageButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -16,11 +24,19 @@ exports[`OakScaleImageButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/OakScaleImageButton/__snapshots__/OakScaleImageButton.test.tsx.snap
+++ b/src/components/molecules/OakScaleImageButton/__snapshots__/OakScaleImageButton.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`OakScaleImageButton matches snapshot 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <span
         className="c7"
       >
         <img
@@ -195,7 +195,7 @@ exports[`OakScaleImageButton matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <span
         className="c9"
       />

--- a/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSecondaryButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,11 +26,19 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <span
         className="c7"
       >
         <img
@@ -192,7 +192,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <span
         className="c9"
       >

--- a/src/components/molecules/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
+++ b/src/components/molecules/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,7 +26,11 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakSignLanguageButton/__snapshots__/OakSignLanguageButton.test.tsx.snap
+++ b/src/components/molecules/OakSignLanguageButton/__snapshots__/OakSignLanguageButton.test.tsx.snap
@@ -2,12 +2,20 @@
 
 exports[`OakSignLanguageButton matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -15,7 +23,11 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -24,11 +36,19 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -154,7 +174,7 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     display: block;
   }
 }
@@ -222,7 +242,11 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
       </button>
     </div>
   </div>,
-  .c1 {
+  .c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -230,7 +254,11 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -239,11 +267,19 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -363,7 +399,7 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     display: none;
   }
 }

--- a/src/components/molecules/OakSignLanguageButton/__snapshots__/OakSignLanguageButton.test.tsx.snap
+++ b/src/components/molecules/OakSignLanguageButton/__snapshots__/OakSignLanguageButton.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
           >
             Show sign language
           </span>
-          <div
+          <span
             className="c9"
           >
             <img
@@ -217,7 +217,7 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
       </button>
     </div>

--- a/src/components/molecules/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <span
         className="c7"
       >
         <img
@@ -192,7 +192,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <span
         className="c9"
       >

--- a/src/components/molecules/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSmallPrimaryButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,11 +26,19 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/OakSmallPrimaryInvertedButton/__snapshots__/OakSmallPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallPrimaryInvertedButton/__snapshots__/OakSmallPrimaryInvertedButton.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <span
         className="c7"
       >
         <img
@@ -192,7 +192,7 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <span
         className="c9"
       >

--- a/src/components/molecules/OakSmallPrimaryInvertedButton/__snapshots__/OakSmallPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallPrimaryInvertedButton/__snapshots__/OakSmallPrimaryInvertedButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,11 +26,19 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <span
         className="c7"
       >
         <img
@@ -192,7 +192,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <span
         className="c9"
       >

--- a/src/components/molecules/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSmallSecondaryButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,11 +26,19 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/OakSmallSecondaryToggleButton/__snapshots__/OakSmallSecondaryToggleButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallSecondaryToggleButton/__snapshots__/OakSmallSecondaryToggleButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSmallSecondaryToggleButton component matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakSmallSecondaryToggleButton component matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,7 +26,11 @@ exports[`OakSmallSecondaryToggleButton component matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakSmallTertiaryInvertedButton/__snapshots__/OakSmallTertiaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallTertiaryInvertedButton/__snapshots__/OakSmallTertiaryInvertedButton.test.tsx.snap
@@ -202,7 +202,7 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
         <div
           className="c9"
         >
-          <div
+          <span
             className="c10 shadow"
           >
             <img
@@ -229,8 +229,8 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
                 }
               }
             />
-          </div>
-          <div
+          </span>
+          <span
             className="c12 highlight"
           >
             <img
@@ -257,8 +257,8 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
                 }
               }
             />
-          </div>
-          <div
+          </span>
+          <span
             className="c14"
             data-icon-for="button"
           >
@@ -286,7 +286,7 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
       </div>
       <span

--- a/src/components/molecules/OakSmallTertiaryInvertedButton/__snapshots__/OakSmallTertiaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakSmallTertiaryInvertedButton/__snapshots__/OakSmallTertiaryInvertedButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,25 +13,41 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   padding-left: 0rem;
   padding-right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   color: #222222;
   border-radius: 6.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: absolute;
   top: 0.25rem;
   left: 0.25rem;
@@ -39,7 +59,11 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: absolute;
   top: 0.125rem;
   left: 0.125rem;
@@ -51,7 +75,11 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/molecules/OakTagFunctional/__snapshots__/OakTagFunctional.test.tsx.snap
+++ b/src/components/molecules/OakTagFunctional/__snapshots__/OakTagFunctional.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTagFunctional matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   padding-top: 0.25rem;

--- a/src/components/molecules/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/molecules/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTertiaryButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakTertiaryInvertedButton/__snapshots__/OakTertiaryInvertedButton.test.tsx.snap
+++ b/src/components/molecules/OakTertiaryInvertedButton/__snapshots__/OakTertiaryInvertedButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTertiaryInvertedButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakTertiaryInvertedButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/molecules/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -49,7 +49,11 @@ exports[`OakTextInput matches snapshot 1`] = `
   cursor: not-allowed;
 }
 
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -64,11 +68,15 @@ exports[`OakTextInput matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c0:hover {
+.c0:where(*):hover {
   cursor: pointer;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/molecules/OakTimer/__snapshots__/OakTimer.test.tsx.snap
+++ b/src/components/molecules/OakTimer/__snapshots__/OakTimer.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTimer matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   color: #ffffff;
   background: #222222;
   border-radius: 0.125rem;

--- a/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
+++ b/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakToast matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -22,12 +26,20 @@ exports[`OakToast matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: absolute;
   width: 1.25rem;
   height: 1.25rem;
@@ -36,7 +48,11 @@ exports[`OakToast matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -45,7 +61,11 @@ exports[`OakToast matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -53,20 +73,32 @@ exports[`OakToast matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   padding-left: 0rem;
   padding-right: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   position: relative;
   color: transparent;
   border-radius: 6.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c17:where(span) {
+  display: block;
+}
+
+.c17:where(*) {
   position: absolute;
   top: 0.25rem;
   left: 0.25rem;
@@ -78,7 +110,11 @@ exports[`OakToast matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c19:where(span) {
+  display: block;
+}
+
+.c19:where(*) {
   position: absolute;
   top: 0.125rem;
   left: 0.125rem;
@@ -90,7 +126,11 @@ exports[`OakToast matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c21:where(span) {
+  display: block;
+}
+
+.c21:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -258,7 +298,7 @@ exports[`OakToast matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     max-width: 22.5rem;
   }
 }

--- a/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
+++ b/src/components/molecules/OakToast/__snapshots__/OakToast.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`OakToast matches snapshot 1`] = `
     <div
       className="c4 c5"
     />
-    <div
+    <span
       className="c6"
     >
       <img
@@ -300,7 +300,7 @@ exports[`OakToast matches snapshot 1`] = `
           }
         }
       />
-    </div>
+    </span>
   </div>
   <span>
     This is a toast message
@@ -324,7 +324,7 @@ exports[`OakToast matches snapshot 1`] = `
           <div
             className="c3"
           >
-            <div
+            <span
               className="c17 shadow"
             >
               <img
@@ -351,8 +351,8 @@ exports[`OakToast matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
-            <div
+            </span>
+            <span
               className="c19 highlight"
             >
               <img
@@ -379,8 +379,8 @@ exports[`OakToast matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
-            <div
+            </span>
+            <span
               className="c21"
               data-icon-for="button"
             >
@@ -408,7 +408,7 @@ exports[`OakToast matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
         </div>
         <span

--- a/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
+++ b/src/components/molecules/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
@@ -2,14 +2,22 @@
 
 exports[`OakTooltip matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: fixed;
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 300;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   position: absolute;
   right: 0rem;
   bottom: 0rem;
@@ -25,7 +33,11 @@ exports[`OakTooltip matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   max-width: 22.5rem;
   padding-left: 1.5rem;
@@ -71,7 +83,7 @@ exports[`OakTooltip matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     max-width: 40rem;
   }
 }

--- a/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -1,11 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   max-width: 40rem;
   padding: 1rem;
   background: #e3e9fb;
@@ -20,13 +28,21 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -35,12 +51,20 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -51,7 +75,11 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   width: 1.5rem;
   height: 1.5rem;
   background: #ffffff;
@@ -60,7 +88,11 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c21:where(span) {
+  display: block;
+}
+
+.c21:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -68,7 +100,11 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c23 {
+.c23:where(span) {
+  display: block;
+}
+
+.c23:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -77,7 +113,11 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c28 {
+.c28:where(span) {
+  display: block;
+}
+
+.c28:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -386,7 +386,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
       <div
         className="c0"
       >
-        <div
+        <span
           className="c6"
           data-testid="inline-banner-icon"
         >
@@ -414,7 +414,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
       <div
         className="c8 c9"
@@ -588,7 +588,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
         >
           Next
         </span>
-        <div
+        <span
           className="c28"
         >
           <img
@@ -615,7 +615,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
     </button>
   </div>

--- a/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`OakRadioAsButton matches snapshot 1`] = `
         type="radio"
         value="history"
       />
-      <div
+      <span
         className="c7 "
       >
         <img
@@ -205,7 +205,7 @@ exports[`OakRadioAsButton matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <label
         className="c9 c10 c11 c12"
         htmlFor=":r0:"

--- a/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakRadioAsButton/__snapshots__/OakRadioAsButton.test.tsx.snap
@@ -2,13 +2,21 @@
 
 exports[`OakRadioAsButton matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   min-height: 2.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0.25rem;
@@ -20,11 +28,15 @@ exports[`OakRadioAsButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2:hover {
+.c2:where(*):hover {
   cursor: pointer;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneyHeader/__snapshots__/OakPupilJourneyHeader.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyHeader/__snapshots__/OakPupilJourneyHeader.test.tsx.snap
@@ -233,7 +233,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
       <div
         className="c7"
       >
-        <div
+        <span
           className="c8"
         >
           <img
@@ -260,7 +260,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
     </div>
     <div

--- a/src/components/organisms/pupil/browse/OakPupilJourneyHeader/__snapshots__/OakPupilJourneyHeader.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyHeader/__snapshots__/OakPupilJourneyHeader.test.tsx.snap
@@ -3,11 +3,19 @@
 exports[`OakPupilJourneyHeader matches snapshot 1`] = `
 [
   " ",
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   width: 4rem;
   height: 4rem;
@@ -15,18 +23,30 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: 3rem;
   min-width: 3rem;
@@ -110,73 +130,73 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     width: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c2 {
+  .c2:where(*) {
     width: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     height: 5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c2 {
+  .c2:where(*) {
     height: 5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     width: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c8 {
+  .c8:where(*) {
     width: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     min-width: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c8 {
+  .c8:where(*) {
     min-width: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c8 {
+  .c8:where(*) {
     height: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     min-height: 3.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c8 {
+  .c8:where(*) {
     min-height: 3.5rem;
   }
 }

--- a/src/components/organisms/pupil/browse/OakPupilJourneyLayout/__snapshots__/OakPupilJourneyLayout.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyLayout/__snapshots__/OakPupilJourneyLayout.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPupilJourneyLayout matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -22,13 +26,13 @@ exports[`OakPupilJourneyLayout matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-right: 1.5rem;
   }
 }

--- a/src/components/organisms/pupil/browse/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
@@ -1,18 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPupilJourneyList matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 100%;
   background: #f5e9f2;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding-top: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   padding: 1rem;
   background: #e5d1e0;
   border-radius: 1rem;
@@ -49,13 +61,13 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     width: 40rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c0 {
+  .c0:where(*) {
     width: 60rem;
   }
 }

--- a/src/components/organisms/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
@@ -2,11 +2,19 @@
 
 exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   padding: 1.25rem;
   color: #222222;
   background: #ffffff;
@@ -16,7 +24,11 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -30,7 +42,11 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   text-decoration: none;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -42,7 +58,11 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   width: 3rem;
   height: 3rem;
   padding: 0.25rem;
@@ -51,7 +71,11 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -171,31 +195,31 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c1:where(*) {
     padding: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -204,25 +228,25 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
@@ -288,7 +288,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
         <div
           className="c10 c11 c12"
         >
-          <div
+          <span
             className="c13"
           >
             <img
@@ -315,7 +315,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
       </div>
     </a>

--- a/src/components/organisms/pupil/browse/OakPupilJourneyListItemSubheading/__snapshots__/OakPupilJourneyListItemSubheading.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyListItemSubheading/__snapshots__/OakPupilJourneyListItemSubheading.test.tsx.snap
@@ -3,7 +3,11 @@
 exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
 [
   " ",
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
@@ -2,13 +2,21 @@
 
 exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   color: #222222;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -17,22 +25,38 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -44,7 +68,11 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
@@ -56,7 +84,11 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   width: 2rem;
   height: 2rem;
   padding: 0.25rem;
@@ -65,7 +97,11 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -153,25 +189,25 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c11 {
+  .c11:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c11 {
+  .c11:where(*) {
     font-size: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c11 {
+  .c11:where(*) {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c11 {
+  .c11:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
@@ -231,7 +231,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
             <div
               className="c14"
             >
-              <div
+              <span
                 className="c15"
               >
                 <img
@@ -258,7 +258,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
                     }
                   }
                 />
-              </div>
+              </span>
             </div>
           </div>
         </div>

--- a/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
@@ -1,18 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -26,7 +38,11 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   text-decoration: none;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -38,13 +54,21 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   color: #222222;
   background: #ffffff;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -53,18 +77,30 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -76,7 +112,11 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
@@ -88,7 +128,11 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c21 {
+.c21:where(span) {
+  display: block;
+}
+
+.c21:where(*) {
   width: 2rem;
   height: 2rem;
   padding: 0.25rem;
@@ -97,7 +141,11 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -225,25 +273,25 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     font-size: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -252,25 +300,25 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -279,25 +327,25 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c18 {
+  .c18:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c18 {
+  .c18:where(*) {
     font-size: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c18 {
+  .c18:where(*) {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c18 {
+  .c18:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
@@ -389,7 +389,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
               <div
                 className="c21"
               >
-                <div
+                <span
                   className="c22"
                 >
                   <img
@@ -416,7 +416,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
                       }
                     }
                   />
-                </div>
+                </span>
               </div>
             </div>
           </div>
@@ -470,7 +470,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
               <div
                 className="c21"
               >
-                <div
+                <span
                   className="c22"
                 >
                   <img
@@ -497,7 +497,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
                       }
                     }
                   />
-                </div>
+                </span>
               </div>
             </div>
           </div>

--- a/src/components/organisms/pupil/browse/OakPupilJourneyProgrammeOptions/__snapshots__/OakPupilJourneyProgrammeOptions.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyProgrammeOptions/__snapshots__/OakPupilJourneyProgrammeOptions.test.tsx.snap
@@ -1,13 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPupilJourneyList matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 100%;
   background: #f5e9f2;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding: 1.5rem;
   background: #ffffff;
   border: 0.125rem solid;
@@ -16,13 +24,21 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -78,13 +94,13 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     width: 40rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c0 {
+  .c0:where(*) {
     width: 60rem;
   }
 }

--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,12 +26,20 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   width: 7.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 2rem;
   min-width: 4.5rem;

--- a/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneySubjectButton/__snapshots__/OakPupilJourneySubjectButton.test.tsx.snap
@@ -164,7 +164,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <span
         aria-hidden="true"
         className="c7"
         data-testid="subject-english"
@@ -193,7 +193,7 @@ exports[`OakPupilJourneySubjectButton matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <span
         className="c9"
       >

--- a/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -478,7 +478,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
             <div
               className="c17 shadow"
             />
-            <div
+            <span
               className="c18"
               style={
                 {
@@ -511,7 +511,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
         </button>
         <div

--- a/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -2,42 +2,70 @@
 
 exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10:hover {
+.c10:where(*):hover {
   cursor: pointer;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c17:where(span) {
+  display: block;
+}
+
+.c17:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -46,7 +74,11 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -55,14 +87,22 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -342,9 +382,16 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  position: relative;
+}
+
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
-  position: relative;
 }
 
 .c14:hover {
@@ -357,10 +404,6 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 .c9 {
-  position: relative;
-  padding-top: 1.5rem;
-  padding-bottom: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -379,6 +422,17 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   visibility: visible;
 }
 
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
+  position: relative;
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
 .c6 {
   height: 0.125rem;
   width: 100%;
@@ -393,7 +447,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     display: none;
   }
 }
@@ -690,11 +744,19 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
       </div>
     </div>
   </div>,
-  .c8 {
+  .c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -703,7 +765,11 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -711,12 +777,20 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -935,7 +1009,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;

--- a/src/components/organisms/pupil/browse/OakPupilJourneyYearButton/__snapshots__/OakPupilJourneyYearButton.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyYearButton/__snapshots__/OakPupilJourneyYearButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,7 +26,11 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
@@ -2,12 +2,20 @@
 
 exports[`InternalReviewAccordion matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding-top: 1.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -15,11 +23,19 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -30,7 +46,11 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -39,7 +59,11 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -191,10 +215,17 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5:hover {
+.c5:where(*):hover {
   cursor: pointer;
 }
 
@@ -207,7 +238,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-top: 0rem;
   }
 }
@@ -274,11 +305,19 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
       </button>
     </div>
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   min-width: 100%;
   padding-left: 1.5rem;
   padding-right: 1.5rem;

--- a/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
             <div
               className="c13 shadow"
             />
-            <div
+            <span
               className="c14"
               data-icon-for="button"
             >
@@ -268,7 +268,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
         </div>
       </button>

--- a/src/components/organisms/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -2,22 +2,38 @@
 
 exports[`OakLessonBottomNav matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   min-height: 3rem;
   padding: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -25,7 +41,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -36,7 +56,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,7 +69,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -54,7 +82,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c19:where(span) {
+  display: block;
+}
+
+.c19:where(*) {
   width: 100%;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -233,7 +265,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c19 {
+  .c19:where(*) {
     width: auto;
   }
 }
@@ -338,17 +370,29 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       className="c19 c20"
     />
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   min-height: 3rem;
   padding: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   width: 100%;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -356,7 +400,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
@@ -365,7 +413,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -457,7 +509,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c11 {
+  .c11:where(*) {
     width: auto;
   }
 }
@@ -544,17 +596,29 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       className="c11 c12"
     />
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   min-height: 3rem;
   padding: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   width: 100%;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -562,7 +626,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -571,7 +639,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
@@ -663,7 +735,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c11 {
+  .c11:where(*) {
     width: auto;
   }
 }
@@ -750,17 +822,29 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       className="c11 c12"
     />
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   min-height: 3rem;
   padding: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   width: 100%;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -768,7 +852,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
@@ -777,7 +865,11 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -869,7 +961,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c11 {
+  .c11:where(*) {
     width: auto;
   }
 }

--- a/src/components/organisms/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -294,7 +294,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
                 <div
                   className="c15 shadow"
                 />
-                <div
+                <span
                   className="c16"
                   data-icon-for="button"
                 >
@@ -322,7 +322,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
                       }
                     }
                   />
-                </div>
+                </span>
               </div>
               <span
                 className="c18"
@@ -496,7 +496,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
           <div
             className="c6"
           >
-            <div
+            <span
               className="c7"
             >
               <img
@@ -523,7 +523,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
           <span
             className="c9"
@@ -702,7 +702,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
           <div
             className="c6"
           >
-            <div
+            <span
               className="c7"
             >
               <img
@@ -729,7 +729,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
           <span
             className="c9"
@@ -908,7 +908,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
           <div
             className="c6"
           >
-            <div
+            <span
               className="c7"
             >
               <img
@@ -935,7 +935,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
           <span
             className="c9"

--- a/src/components/organisms/pupil/lesson/OakLessonLayout/__snapshots__/OakLessonLayout.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonLayout/__snapshots__/OakLessonLayout.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakLessonLayout matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 100%;
   min-height: 100%;
   padding-left: 0rem;
@@ -15,7 +19,11 @@ exports[`OakLessonLayout matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   max-width: 80rem;
   min-height: 100%;
@@ -25,19 +33,31 @@ exports[`OakLessonLayout matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   min-height: 100%;
   padding-top: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 1;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
   padding-left: 1rem;
@@ -47,11 +67,19 @@ exports[`OakLessonLayout matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   margin-left: 0rem;
   margin-right: 0rem;
   background: #ffffff;
@@ -97,85 +125,85 @@ exports[`OakLessonLayout matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     background: transparent;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     padding-top: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c7 {
+  .c7:where(*) {
     padding-left: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c7 {
+  .c7:where(*) {
     padding-right: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c7 {
+  .c7:where(*) {
     margin-right: 3rem;
   }
 }
 
 @media (min-width:750px) {
-  .c7 {
+  .c7:where(*) {
     background: transparent;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     margin-left: 0rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c9 {
+  .c9:where(*) {
     margin-left: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     margin-right: 0rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c9 {
+  .c9:where(*) {
     margin-right: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     background: #ffffff;
   }
 }

--- a/src/components/organisms/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakLessonNavItem matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 1.25rem;
@@ -15,12 +19,20 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   width: 5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -29,11 +41,19 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -45,7 +65,11 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -56,7 +80,11 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   width: 3rem;
   height: 3rem;
   padding: 0.25rem;
@@ -65,7 +93,11 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -143,37 +175,37 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -182,25 +214,25 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;

--- a/src/components/organisms/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
     <div
       className="c3 c4"
     >
-      <div
+      <span
         className="c5"
       >
         <img
@@ -252,7 +252,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
     <div
       className="c7 c8"
@@ -271,7 +271,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
     <div
       className="c11 c12 c13"
     >
-      <div
+      <span
         className="c14"
       >
         <img
@@ -298,7 +298,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
   </a>,
   ",",

--- a/src/components/organisms/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
       <div
         className="c5"
       >
-        <div
+        <span
           className="c6"
         >
           <img
@@ -232,7 +232,7 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
       <div
         className="c3 c8"

--- a/src/components/organisms/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 1.25rem;
@@ -14,11 +18,19 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   width: 3.5rem;
   height: 3.5rem;
   padding: 0.25rem;
@@ -27,7 +39,11 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -36,7 +52,11 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -48,7 +68,11 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -115,37 +139,37 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -154,25 +178,25 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;

--- a/src/components/organisms/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
     <div
       className="c3"
     >
-      <div
+      <span
         className="c4"
       >
         <img
@@ -196,7 +196,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
     <div
       className="c6 c7"

--- a/src/components/organisms/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakLessonReviewItem matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 1.25rem;
@@ -14,7 +18,11 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   width: 3.5rem;
   height: 3.5rem;
   padding: 0.25rem;
@@ -23,7 +31,11 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -32,11 +44,19 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -48,7 +68,11 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -98,37 +122,37 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -137,25 +161,25 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;

--- a/src/components/organisms/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
       <div
         className="c5"
       >
-        <div
+        <span
           className="c6"
         >
           <img
@@ -232,7 +232,7 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
       <div
         className="c3 c8"

--- a/src/components/organisms/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakLessonReviewQuiz matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 1.25rem;
@@ -14,11 +18,19 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   width: 3.5rem;
   height: 3.5rem;
   padding: 0.25rem;
@@ -27,7 +39,11 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -36,7 +52,11 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -48,7 +68,11 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -115,37 +139,37 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-left: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     padding-right: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;
@@ -154,25 +178,25 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     font-size: 1.125rem;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;

--- a/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -219,7 +219,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
       className="c3"
       type="button"
     >
-      <div
+      <span
         className="c4"
       >
         <img
@@ -246,7 +246,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </a>
   </div>
   <div
@@ -255,7 +255,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
     <div
       className="c7"
     >
-      <div
+      <span
         className="c8"
       >
         <img
@@ -282,7 +282,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
   </div>
   <div

--- a/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -1,16 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakLessonTopNav matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding-left: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -19,7 +31,11 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   width: 2.5rem;
   height: 2.5rem;
   padding: 0.25rem;
@@ -28,7 +44,11 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -37,7 +57,11 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -164,13 +188,13 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     padding-left: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c14 {
+  .c14:where(*) {
     display: block;
   }
 }

--- a/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
@@ -217,7 +217,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
               <div
                 className="c11 shadow"
               />
-              <div
+              <span
                 className="c12"
                 data-icon-for="button"
               >
@@ -245,7 +245,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
                     }
                   }
                 />
-              </div>
+              </span>
             </div>
           </div>
         </button>

--- a/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
@@ -2,11 +2,19 @@
 
 exports[`OakLessonVideoTranscript matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -14,7 +22,11 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -25,7 +37,11 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -34,7 +50,11 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -252,12 +272,20 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
       </div>
     </div>
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   max-height: 60rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -276,7 +304,11 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   overflow: auto;
   width: 100%;
   max-height: 100%;

--- a/src/components/organisms/pupil/quiz/InternalDroppableHoldingPen/__snapshots__/InternalDroppableHoldingPen.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/InternalDroppableHoldingPen/__snapshots__/InternalDroppableHoldingPen.test.tsx.snap
@@ -1,13 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InternalDroppableHoldingPen matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   margin-bottom: 2rem;
   border-radius: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   min-height: 5rem;
   padding: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;

--- a/src/components/organisms/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`OakHintButton matches snapshot 1`] = `
         <div
           className="c10 shadow"
         />
-        <div
+        <span
           className="c11"
           data-icon-for="button"
         >
@@ -216,7 +216,7 @@ exports[`OakHintButton matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
       <span
         className="c13"

--- a/src/components/organisms/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakHintButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,11 +13,19 @@ exports[`OakHintButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -24,7 +36,11 @@ exports[`OakHintButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -33,7 +49,11 @@ exports[`OakHintButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/organisms/pupil/quiz/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
@@ -2,13 +2,21 @@
 
 exports[`OakQuizCheckBox matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding: 1.25rem;
   background: #ffffff;
   border-color: #222222;
@@ -16,18 +24,26 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2:hover {
+.c2:where(*):hover {
   cursor: pointer;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: 2rem;
   height: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -37,14 +53,22 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   width: 100%;
   height: 100%;
   background: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   width: 100%;
   height: 100%;
   border: 0.125rem solid;

--- a/src/components/organisms/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakQuizCounter matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/organisms/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
@@ -2,11 +2,19 @@
 
 exports[`OakQuizFeedback matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
@@ -15,7 +23,11 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -116,11 +128,19 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
       Well done!
     </p>
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -129,7 +149,11 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
@@ -230,11 +254,19 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
       Keep trying
     </p>
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
@@ -243,7 +275,11 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   width: 100%;
   min-width: 100%;

--- a/src/components/organisms/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
       <div
         className="c2"
       >
-        <div
+        <span
           className="c3"
         >
           <img
@@ -100,7 +100,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
       <span
         className="c5"
@@ -187,7 +187,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
       <div
         className="c2"
       >
-        <div
+        <span
           className="c3"
         >
           <img
@@ -214,7 +214,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
       <span
         className="c5"
@@ -301,7 +301,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
       <div
         className="c2"
       >
-        <div
+        <span
           className="c3"
         >
           <img
@@ -328,7 +328,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </div>
       <span
         className="c5"

--- a/src/components/organisms/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
             <div
               className="c10 shadow"
             />
-            <div
+            <span
               className="c11"
               data-icon-for="button"
             >
@@ -235,7 +235,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
           <span
             className="c13"

--- a/src/components/organisms/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakQuizHint matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -13,7 +17,11 @@ exports[`OakQuizHint matches snapshot 1`] = `
   >
     The answer is right in front of your eyes
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -21,11 +29,19 @@ exports[`OakQuizHint matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -36,7 +52,11 @@ exports[`OakQuizHint matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,7 +65,11 @@ exports[`OakQuizHint matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;

--- a/src/components/organisms/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
     <div
       className="c2 c3"
     >
-      <div
+      <span
         className="c4"
       >
         <img
@@ -124,7 +124,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
     <div
       className="c6 c7"
@@ -354,7 +354,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
         <div
           className="c6 c7 c8"
         >
-          <div
+          <span
             className="c9 "
           >
             <img
@@ -381,7 +381,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
           <div
             className="c11 c12"
           >
@@ -409,7 +409,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
         <div
           className="c6 c7 c8"
         >
-          <div
+          <span
             className="c9 "
           >
             <img
@@ -436,7 +436,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
           <div
             className="c11 c12"
           >
@@ -464,7 +464,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
         <div
           className="c6 c7 c8"
         >
-          <div
+          <span
             className="c9 "
           >
             <img
@@ -491,7 +491,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
           <div
             className="c11 c12"
           >

--- a/src/components/organisms/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
@@ -2,16 +2,28 @@
 
 exports[`OakQuizMatch matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   margin-bottom: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -20,7 +32,11 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -163,11 +179,19 @@ exports[`OakQuizMatch matches snapshot 1`] = `
        arrows on your keyboard.
     </div>
   </div>,
-  .c6 {
+  .c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -176,19 +200,31 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   margin-bottom: 2rem;
   border-radius: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   min-height: 5rem;
   padding: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   min-height: 3.5rem;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
@@ -200,7 +236,11 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
@@ -501,18 +541,30 @@ exports[`OakQuizMatch matches snapshot 1`] = `
       </div>
     </div>
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding: 1rem;
   background: #cee7e5;
   border-radius: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   min-height: 4rem;
   padding: 0.25rem;
   background: #cee7e5;
@@ -520,12 +572,20 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   width: 100%;
   min-height: 3.5rem;
   padding-left: 1.25rem;

--- a/src/components/organisms/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
@@ -2,16 +2,28 @@
 
 exports[`OakQuizOrder matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   margin-bottom: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -20,7 +32,11 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -163,11 +179,19 @@ exports[`OakQuizOrder matches snapshot 1`] = `
        arrows on your keyboard.
     </div>
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -176,14 +200,22 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding: 1rem;
   background: #cee7e5;
   border-radius: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   min-height: 4rem;
   padding: 0.25rem;
   background: #f2f2f2;
@@ -191,12 +223,20 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   min-height: 3.5rem;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
@@ -208,7 +248,11 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;

--- a/src/components/organisms/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
     <div
       className="c2 c3"
     >
-      <div
+      <span
         className="c4"
       >
         <img
@@ -124,7 +124,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
     <div
       className="c6 c7"
@@ -387,7 +387,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
             <div
               className="c0 c10 c11"
             >
-              <div
+              <span
                 className="c12 "
               >
                 <img
@@ -414,7 +414,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
                     }
                   }
                 />
-              </div>
+              </span>
               <div
                 className="c14 c15"
               >
@@ -456,7 +456,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
             <div
               className="c0 c10 c11"
             >
-              <div
+              <span
                 className="c12 "
               >
                 <img
@@ -483,7 +483,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
                     }
                   }
                 />
-              </div>
+              </span>
               <div
                 className="c14 c15"
               >
@@ -525,7 +525,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
             <div
               className="c0 c10 c11"
             >
-              <div
+              <span
                 className="c12 "
               >
                 <img
@@ -552,7 +552,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
                     }
                   }
                 />
-              </div>
+              </span>
               <div
                 className="c14 c15"
               >

--- a/src/components/organisms/pupil/quiz/OakQuizPrintableHeader/__snapshots__/OakQuizPrintableHeader.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizPrintableHeader/__snapshots__/OakQuizPrintableHeader.test.tsx.snap
@@ -3,11 +3,19 @@
 exports[`OakQuizPrintableHeader matches snapshot 1`] = `
 [
   " ",
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   width: 3.5rem;
   height: 3.5rem;
@@ -15,18 +23,30 @@ exports[`OakQuizPrintableHeader matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: 3.5rem;
   min-width: 3.5rem;
@@ -35,7 +55,11 @@ exports[`OakQuizPrintableHeader matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   padding-top: 0.25rem;

--- a/src/components/organisms/pupil/quiz/OakQuizPrintableHeader/__snapshots__/OakQuizPrintableHeader.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizPrintableHeader/__snapshots__/OakQuizPrintableHeader.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`OakQuizPrintableHeader matches snapshot 1`] = `
         <div
           className="c8"
         >
-          <div
+          <span
             className="c9"
           >
             <img
@@ -222,7 +222,7 @@ exports[`OakQuizPrintableHeader matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
       </div>
       <div

--- a/src/components/organisms/pupil/quiz/OakQuizPrintableSubHeader/__snapshots__/OakQuizPrintableSubHeader.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizPrintableSubHeader/__snapshots__/OakQuizPrintableSubHeader.test.tsx.snap
@@ -3,11 +3,19 @@
 exports[`OakQuizPrintableSubHeader matches snapshot 1`] = `
 [
   " ",
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0.25rem;

--- a/src/components/organisms/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakQuizRadioButton matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   padding: 1.25rem;
   background: #ffffff;
@@ -9,15 +13,23 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c0:hover {
+.c0:where(*):hover {
   cursor: pointer;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   width: 2rem;
   height: 2rem;
   background: #ffffff;

--- a/src/components/organisms/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
@@ -2,11 +2,19 @@
 
 exports[`OakQuizResultItem matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -15,7 +23,11 @@ exports[`OakQuizResultItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   min-height: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }

--- a/src/components/organisms/pupil/quiz/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakQuizTextInput matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -17,11 +21,15 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c0:hover {
+.c0:where(*):hover {
   cursor: pointer;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/organisms/shared/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
+++ b/src/components/organisms/shared/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
@@ -602,7 +602,7 @@ have_homework =
               <div
                 className="c29 shadow"
               />
-              <div
+              <span
                 className="c30"
                 data-icon-for="button"
               >
@@ -630,7 +630,7 @@ have_homework =
                     }
                   }
                 />
-              </div>
+              </span>
             </div>
             <span
               className="c19"

--- a/src/components/organisms/shared/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
+++ b/src/components/organisms/shared/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
@@ -1,11 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakCodeRenderer matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   padding-top: 0rem;
@@ -24,7 +32,11 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0.5rem;
@@ -44,14 +56,22 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   white-space: pre-wrap;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   padding-right: 0.75rem;
   border-right: 0.063rem solid;
   border-color: #808080;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -59,12 +79,20 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -72,7 +100,11 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c27 {
+.c27:where(span) {
+  display: block;
+}
+
+.c27:where(*) {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -83,7 +115,11 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c29 {
+.c29:where(span) {
+  display: block;
+}
+
+.c29:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -92,7 +128,11 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c30 {
+.c30:where(span) {
+  display: block;
+}
+
+.c30:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -230,11 +270,18 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
 }
 
 .c18 {
-  display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
   display: revert;
   display: revert;
+}
+
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
+  display: revert;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -246,6 +293,13 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   padding: 0;
   margin: 0;
   display: block;
+}
+
+.c17:where(span) {
+  display: block;
+}
+
+.c17:where(*) {
   padding-left: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -325,49 +379,49 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     padding-left: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     padding-right: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     padding-top: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     padding-bottom: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     font-size: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     line-height: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;

--- a/src/components/organisms/shared/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
+++ b/src/components/organisms/shared/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakCookieBanner matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -9,13 +13,21 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -23,7 +35,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -34,11 +50,19 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -50,7 +74,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   white-space: nowrap;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -58,7 +86,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -335,49 +367,49 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c2 {
+  .c2:where(*) {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c2 {
+  .c2:where(*) {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;

--- a/src/components/organisms/shared/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
+++ b/src/components/organisms/shared/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakCookieConsent matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   color: #222222;
   background: #f2f2f2;
   border-top: 0.063rem solid;
@@ -9,13 +13,21 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   margin-left: auto;
   margin-right: auto;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   margin-left: 1rem;
@@ -23,7 +35,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -34,11 +50,19 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -50,7 +74,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   white-space: nowrap;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -58,7 +86,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -335,49 +367,49 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     margin-left: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c2 {
+  .c2:where(*) {
     margin-left: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     margin-right: 1.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c2 {
+  .c2:where(*) {
     margin-right: 3.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     font-weight: 300;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     font-size: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     -webkit-letter-spacing: -0.005rem;
     -moz-letter-spacing: -0.005rem;
     -ms-letter-spacing: -0.005rem;

--- a/src/components/organisms/shared/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
+++ b/src/components/organisms/shared/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
@@ -640,7 +640,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
         <div
           className="c25 c26"
         >
-          <div
+          <span
             className="c27"
           >
             <img
@@ -667,7 +667,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
       </div>
       <div

--- a/src/components/organisms/shared/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
+++ b/src/components/organisms/shared/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
@@ -1,14 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakHeaderHero matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   overflow-x: hidden;
   width: 100%;
   background: #a0b6f2;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   width: 100%;
   max-width: 30rem;
   padding-left: 0rem;
@@ -18,7 +26,11 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   min-width: 100%;
   min-height: 22.5rem;
   background: #a0b6f2;
@@ -26,48 +38,80 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   z-index: 0;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   height: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   max-width: 40rem;
   min-height: 0rem;
   margin-bottom: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   margin-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   position: relative;
   min-height: 11.25rem;
   margin-bottom: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c24:where(span) {
+  display: block;
+}
+
+.c24:where(*) {
   position: relative;
   width: 100%;
   min-width: 15rem;
@@ -79,7 +123,11 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   z-index: 1;
 }
 
-.c25 {
+.c25:where(span) {
+  display: block;
+}
+
+.c25:where(*) {
   position: absolute;
   top: 0rem;
   bottom: 0rem;
@@ -87,7 +135,11 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c27 {
+.c27:where(span) {
+  display: block;
+}
+
+.c27:where(*) {
   position: absolute;
   width: 100%;
   min-width: 100%;
@@ -96,7 +148,11 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c28 {
+.c28:where(span) {
+  display: block;
+}
+
+.c28:where(*) {
   padding-top: 1.5rem;
   margin-left: 1.5rem;
   display: block;
@@ -311,133 +367,133 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c1:where(*) {
     max-width: 80rem;
   }
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c1:where(*) {
     padding-left: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c1:where(*) {
     padding-right: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c7 {
+  .c7:where(*) {
     display: none;
   }
 }
 
 @media (min-width:1280px) {
-  .c7 {
+  .c7:where(*) {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     min-height: 0rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c10 {
+  .c10:where(*) {
     min-height: 22.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     margin-bottom: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c10 {
+  .c10:where(*) {
     margin-bottom: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c22:where(*) {
     min-height: 30rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c22 {
+  .c22:where(*) {
     min-height: 30rem;
   }
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c22:where(*) {
     margin-bottom: 2rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c22 {
+  .c22:where(*) {
     margin-bottom: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c24 {
+  .c24:where(*) {
     min-width: 40rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c24 {
+  .c24:where(*) {
     min-width: 30rem;
   }
 }
 
 @media (min-width:750px) {
-  .c24 {
+  .c24:where(*) {
     min-height: 22.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c24 {
+  .c24:where(*) {
     min-height: 22.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c25 {
+  .c25:where(*) {
     width: 60rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c25 {
+  .c25:where(*) {
     width: 60rem;
   }
 }
 
 @media (min-width:750px) {
-  .c28 {
+  .c28:where(*) {
     padding-bottom: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c28 {
+  .c28:where(*) {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c28 {
+  .c28:where(*) {
     display: none;
   }
 }

--- a/src/components/organisms/shared/OakHomepageTabButton/__snapshots__/OakHomepageTabButton.test.tsx.snap
+++ b/src/components/organisms/shared/OakHomepageTabButton/__snapshots__/OakHomepageTabButton.test.tsx.snap
@@ -223,7 +223,7 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
   <div
     className="c2 c3"
   >
-    <div
+    <span
       className="c4"
     >
       <img
@@ -250,7 +250,7 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
           }
         }
       />
-    </div>
+    </span>
     <div
       className="c6 c7"
     >

--- a/src/components/organisms/shared/OakHomepageTabButton/__snapshots__/OakHomepageTabButton.test.tsx.snap
+++ b/src/components/organisms/shared/OakHomepageTabButton/__snapshots__/OakHomepageTabButton.test.tsx.snap
@@ -19,12 +19,20 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
   cursor: default;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   height: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: relative;
   width: 3rem;
   min-width: 3rem;
@@ -33,13 +41,21 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   position: relative;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: absolute;
   bottom: 0rem;
   width: 100%;
@@ -131,55 +147,55 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     width: 5.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c4 {
+  .c4:where(*) {
     width: 5.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     min-width: 5.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c4 {
+  .c4:where(*) {
     min-width: 5.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     height: 5.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c4 {
+  .c4:where(*) {
     height: 5.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     min-height: 5.75rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c4 {
+  .c4:where(*) {
     min-height: 5.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     padding-bottom: 1.5rem;
   }
 }

--- a/src/components/organisms/shared/OakInfo/__snapshots__/OakInfo.test.tsx.snap
+++ b/src/components/organisms/shared/OakInfo/__snapshots__/OakInfo.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakInfo matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -13,7 +17,11 @@ exports[`OakInfo matches snapshot 1`] = `
   >
     The answer is right in front of your eyes
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -21,11 +29,19 @@ exports[`OakInfo matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -36,7 +52,11 @@ exports[`OakInfo matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,7 +65,11 @@ exports[`OakInfo matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;

--- a/src/components/organisms/shared/OakInfo/__snapshots__/OakInfo.test.tsx.snap
+++ b/src/components/organisms/shared/OakInfo/__snapshots__/OakInfo.test.tsx.snap
@@ -210,7 +210,7 @@ exports[`OakInfo matches snapshot 1`] = `
             <div
               className="c10 shadow"
             />
-            <div
+            <span
               className="c11"
               data-icon-for="button"
             >
@@ -238,7 +238,7 @@ exports[`OakInfo matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
           <span
             className="c13"

--- a/src/components/organisms/shared/OakMediaClip/__snapshots__/OakMediaClip.test.tsx.snap
+++ b/src/components/organisms/shared/OakMediaClip/__snapshots__/OakMediaClip.test.tsx.snap
@@ -2,13 +2,21 @@
 
 exports[`OakMediaClip matches snapshot 1`] = `
 [
-  .c1 {
+  .c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   position: relative;
   border-radius: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -17,12 +25,20 @@ exports[`OakMediaClip matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: 6.25rem;
   height: 3.5rem;
@@ -31,13 +47,21 @@ exports[`OakMediaClip matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   position: absolute;
   right: 0.25rem;
   bottom: 0.25rem;
@@ -107,12 +131,19 @@ exports[`OakMediaClip matches snapshot 1`] = `
 }
 
 .c0 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  display: revert;
+  display: revert;
+}
+
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   margin-bottom: 0.5rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
-  display: revert;
-  display: revert;
 }
 
 .c16 {

--- a/src/components/organisms/shared/OakMediaClipList/__snapshots__/OakMediaClipList.test.tsx.snap
+++ b/src/components/organisms/shared/OakMediaClipList/__snapshots__/OakMediaClipList.test.tsx.snap
@@ -2,12 +2,20 @@
 
 exports[`OakMediaClipList matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   max-height: 30rem;
   padding-top: 0rem;
@@ -19,15 +27,23 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6:hover {
+.c6:where(*):hover {
   cursor: pointer;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.75rem;
@@ -36,7 +52,11 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   text-align: left;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   margin-bottom: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -48,7 +68,11 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   margin-bottom: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -60,7 +84,11 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -71,13 +99,21 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c17 {
+.c17:where(span) {
+  display: block;
+}
+
+.c17:where(*) {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -86,7 +122,11 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c19:where(span) {
+  display: block;
+}
+
+.c19:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -95,18 +135,30 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c21:where(span) {
+  display: block;
+}
+
+.c21:where(*) {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c27 {
+.c27:where(span) {
+  display: block;
+}
+
+.c27:where(*) {
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -181,6 +233,13 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   padding: 0;
   margin: 0;
   display: block;
+}
+
+.c23:where(span) {
+  display: block;
+}
+
+.c23:where(*) {
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0.5rem;
@@ -218,9 +277,16 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  position: relative;
+}
+
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
-  position: relative;
 }
 
 .c10:hover {
@@ -233,15 +299,6 @@ exports[`OakMediaClipList matches snapshot 1`] = `
 }
 
 .c5 {
-  position: relative;
-  max-height: 30rem;
-  padding-top: 0rem;
-  padding-bottom: 0rem;
-  border: 0.125rem solid;
-  border-left: 0.125rem solid;
-  border-color: #222222;
-  border-style: solid;
-  font-family: --var(google-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -258,6 +315,22 @@ exports[`OakMediaClipList matches snapshot 1`] = `
 
 .c5 .c9:focus-visible ~ .c25 {
   visibility: visible;
+}
+
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
+  position: relative;
+  max-height: 30rem;
+  padding-top: 0rem;
+  padding-bottom: 0rem;
+  border: 0.125rem solid;
+  border-left: 0.125rem solid;
+  border-color: #222222;
+  border-style: solid;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c28 {
@@ -279,25 +352,25 @@ exports[`OakMediaClipList matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c3 {
+  .c3:where(*) {
     border-left: 0.125rem solid;
   }
 }
 
 @media (min-width:1280px) {
-  .c3 {
+  .c3:where(*) {
     border-left: 0rem solid;
   }
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     border-left: 0.125rem solid;
   }
 }
 
 @media (min-width:1280px) {
-  .c5 {
+  .c5:where(*) {
     border-left: 0rem solid;
   }
 }

--- a/src/components/organisms/shared/OakMediaClipList/__snapshots__/OakMediaClipList.test.tsx.snap
+++ b/src/components/organisms/shared/OakMediaClipList/__snapshots__/OakMediaClipList.test.tsx.snap
@@ -343,7 +343,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
           <div
             className="c18 shadow"
           />
-          <div
+          <span
             className="c19"
             style={
               {
@@ -376,7 +376,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
       </button>
       <div

--- a/src/components/organisms/shared/OakMediaClipStackListItem/__snapshots__/OakMediaClipStackListItem.test.tsx.snap
+++ b/src/components/organisms/shared/OakMediaClipStackListItem/__snapshots__/OakMediaClipStackListItem.test.tsx.snap
@@ -310,7 +310,7 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
           }
         />
       </div>
-      <div
+      <span
         className="c9"
         id="play-icon"
       >
@@ -338,7 +338,7 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
     </div>
   </div>
   <div

--- a/src/components/organisms/shared/OakMediaClipStackListItem/__snapshots__/OakMediaClipStackListItem.test.tsx.snap
+++ b/src/components/organisms/shared/OakMediaClipStackListItem/__snapshots__/OakMediaClipStackListItem.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakMediaClipStackListItem matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
@@ -12,11 +16,19 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: relative;
   width: 6.25rem;
   height: 4rem;
@@ -25,13 +37,21 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -40,12 +60,20 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   margin-bottom: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   color: #575757;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -165,49 +193,49 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     width: 6.25rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c4 {
+  .c4:where(*) {
     width: 11.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     height: 4rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c4 {
+  .c4:where(*) {
     height: 6.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     margin-bottom: 0rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c4 {
+  .c4:where(*) {
     margin-bottom: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     margin-bottom: 0rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c10 {
+  .c10:where(*) {
     margin-bottom: 1rem;
   }
 }

--- a/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -264,7 +264,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
       <span
         className="c4"
       >
-        <div
+        <span
           className="c5 c6"
           disabled={true}
         >
@@ -292,7 +292,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </span>
     </button>
     <ul
@@ -446,7 +446,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
       <span
         className="c4"
       >
-        <div
+        <span
           className="c5 "
           disabled={false}
         >
@@ -474,7 +474,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
               }
             }
           />
-        </div>
+        </span>
       </span>
     </a>
   </div>

--- a/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/organisms/shared/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -1,12 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPagination Component matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -40,13 +48,20 @@ exports[`OakPagination Component matches snapshot 1`] = `
 }
 
 .c9 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  display: revert;
+  display: revert;
+}
+
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   margin-left: 0.25rem;
   margin-right: 0.25rem;
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
-  display: revert;
-  display: revert;
 }
 
 .c8 {
@@ -58,11 +73,18 @@ exports[`OakPagination Component matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -207,25 +229,25 @@ exports[`OakPagination Component matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c9 {
+  .c9:where(*) {
     margin-left: 0.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c9 {
+  .c9:where(*) {
     margin-right: 0.5rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c9 {
+  .c9:where(*) {
     margin-right: 0.5rem;
   }
 }

--- a/src/components/organisms/shared/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
+++ b/src/components/organisms/shared/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPrimaryNav matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding-left: 0rem;
   padding-right: 0rem;
   margin-left: 0rem;
@@ -11,7 +15,11 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -19,7 +27,11 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -28,7 +40,11 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -75,12 +91,19 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
 }
 
 .c2 {
-  display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
   list-style: none;
   display: revert;
   display: revert;
+}
+
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
+  display: revert;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {

--- a/src/components/organisms/shared/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
+++ b/src/components/organisms/shared/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakPrimaryNavItem matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -9,7 +13,11 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -18,7 +26,11 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 

--- a/src/components/organisms/shared/OakQuote/__snapshots__/OakQuote.test.tsx.snap
+++ b/src/components/organisms/shared/OakQuote/__snapshots__/OakQuote.test.tsx.snap
@@ -1,24 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakQuote component matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 100%;
   max-width: 40rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   width: 0.5rem;
   margin-right: 1.5rem;
   background: #bef2bd;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -30,7 +46,11 @@ exports[`OakQuote component matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -134,25 +154,25 @@ exports[`OakQuote component matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     font-weight: 600;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     font-size: 1.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c6:where(*) {
     -webkit-letter-spacing: 0.0115rem;
     -moz-letter-spacing: 0.0115rem;
     -ms-letter-spacing: 0.0115rem;

--- a/src/components/organisms/shared/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
+++ b/src/components/organisms/shared/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
@@ -2,17 +2,29 @@
 
 exports[`OakSideMenuNav matches snapshot 1`] = `
 [
-  .c1 {
+  .c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   padding: 3rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -91,11 +103,18 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 }
 
 .c5 {
-  display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
   display: revert;
   display: revert;
+}
+
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
+  display: revert;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -107,15 +126,22 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   gap: 1rem;
+}
+
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -154,19 +180,19 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c1:where(*) {
     padding: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c1:where(*) {
     background: #ffffff;
   }
 }
 
 @media (min-width:750px) {
-  .c11 {
+  .c11:where(*) {
     display: none;
   }
 }

--- a/src/components/organisms/shared/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
+++ b/src/components/organisms/shared/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
@@ -265,7 +265,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
                 Test Subheading 1
               </span>
             </div>
-            <div
+            <span
               className="c11"
             >
               <img
@@ -292,7 +292,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </a>
         </li>
         <li
@@ -317,7 +317,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
                 Test Subheading 2
               </span>
             </div>
-            <div
+            <span
               className="c11"
             >
               <img
@@ -344,7 +344,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </a>
         </li>
       </ul>

--- a/src/components/organisms/shared/OakSideMenuNavLink/__snapshots__/OakSideMenuNavLink.test.tsx.snap
+++ b/src/components/organisms/shared/OakSideMenuNavLink/__snapshots__/OakSideMenuNavLink.test.tsx.snap
@@ -3,11 +3,19 @@
 exports[`OakSideMenuNavLink matches snapshot 1`] = `
 [
   " ",
-  .c1 {
+  .c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -94,7 +102,7 @@ exports[`OakSideMenuNavLink matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     display: none;
   }
 }

--- a/src/components/organisms/shared/OakSideMenuNavLink/__snapshots__/OakSideMenuNavLink.test.tsx.snap
+++ b/src/components/organisms/shared/OakSideMenuNavLink/__snapshots__/OakSideMenuNavLink.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`OakSideMenuNavLink matches snapshot 1`] = `
         Test Subheading
       </span>
     </div>
-    <div
+    <span
       className="c5"
     >
       <img
@@ -201,7 +201,7 @@ exports[`OakSideMenuNavLink matches snapshot 1`] = `
           }
         }
       />
-    </div>
+    </span>
   </a>,
 ]
 `;

--- a/src/components/organisms/shared/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/shared/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
             >
               Show transcript
             </span>
-            <div
+            <span
               className="c10"
             >
               <img
@@ -252,7 +252,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
         </button>
       </div>

--- a/src/components/organisms/shared/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
+++ b/src/components/organisms/shared/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
@@ -2,16 +2,28 @@
 
 exports[`OakVideoTranscript matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -19,7 +31,11 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -28,7 +44,11 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -37,7 +57,11 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -173,13 +197,13 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c12 {
+  .c12:where(*) {
     display: none;
   }
 }
@@ -304,12 +328,20 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
       </p>
     </div>
   </div>,
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   max-height: 60rem;
   padding: 0.75rem;
   padding-left: 1rem;
@@ -330,7 +362,11 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   overflow: auto;
   width: 100%;
   max-height: 100%;
@@ -371,7 +407,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c1:where(*) {
     margin-top: 2rem;
   }
 }

--- a/src/components/organisms/teacher/OakInlineRegistrationBanner/__snapshots__/OakInlineRegistrationBanner.test.tsx.snap
+++ b/src/components/organisms/teacher/OakInlineRegistrationBanner/__snapshots__/OakInlineRegistrationBanner.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding: 2rem;
   margin-bottom: 1.5rem;
   background: #bef2bd;
@@ -9,29 +13,49 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: 100%;
   margin-top: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: absolute;
   top: -15px;
   left: 8px;
@@ -59,7 +83,11 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   z-index: 1;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: relative;
   width: 100%;
   height: -webkit-fit-content;
@@ -75,11 +103,15 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12:hover {
+.c12:where(*):hover {
   cursor: pointer;
 }
 
-.c17 {
+.c17:where(span) {
+  display: block;
+}
+
+.c17:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -87,7 +119,11 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c19:where(span) {
+  display: block;
+}
+
+.c19:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -96,14 +132,22 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c25 {
+.c25:where(span) {
+  display: block;
+}
+
+.c25:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -345,31 +389,31 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c0 {
+  .c0:where(*) {
     margin-bottom: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     display: none;
   }
 }
 
 @media (min-width:1280px) {
-  .c5 {
+  .c5:where(*) {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c25 {
+  .c25:where(*) {
     display: block;
   }
 }
 
 @media (min-width:1280px) {
-  .c25 {
+  .c25:where(*) {
     display: block;
   }
 }

--- a/src/components/organisms/teacher/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
+++ b/src/components/organisms/teacher/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
@@ -176,7 +176,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
         type="checkbox"
         value="Option 1"
       />
-      <div
+      <span
         className="c7 "
       >
         <img
@@ -203,7 +203,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
             }
           }
         />
-      </div>
+      </span>
       <label
         className="c9 c10 c11 c12"
         htmlFor="checkbox-1"

--- a/src/components/organisms/teacher/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
+++ b/src/components/organisms/teacher/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
@@ -2,13 +2,21 @@
 
 exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: relative;
   min-height: 2.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0.25rem;
@@ -20,11 +28,15 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2:hover {
+.c2:where(*):hover {
   cursor: pointer;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;

--- a/src/components/organisms/teacher/OakTeacherNotesInline/__snapshots__/OakTeacherNotesInline.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTeacherNotesInline/__snapshots__/OakTeacherNotesInline.test.tsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTeacherNotesInline matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   padding-right: 1.5rem;
@@ -11,7 +15,11 @@ exports[`OakTeacherNotesInline matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c1 {
+.c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   overflow: scroll;
   height: 4.5rem;
   padding-left: 1.5rem;

--- a/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
@@ -935,7 +935,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
                     <div
                       className="c19 shadow"
                     />
-                    <div
+                    <span
                       className="c20"
                       data-icon-for="button"
                     >
@@ -963,7 +963,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
                           }
                         }
                       />
-                    </div>
+                    </span>
                   </div>
                   <span
                     className="c22"
@@ -1118,7 +1118,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
                           >
                             Share link
                           </span>
-                          <div
+                          <span
                             className="c50"
                           >
                             <img
@@ -1145,7 +1145,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
                                 }
                               }
                             />
-                          </div>
+                          </span>
                         </div>
                       </button>
                     </div>
@@ -1165,7 +1165,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
                   <div
                     className="c16"
                   >
-                    <div
+                    <span
                       className="c20"
                       data-testid="inline-banner-icon"
                     >
@@ -1193,7 +1193,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
                           }
                         }
                       />
-                    </div>
+                    </span>
                   </div>
                   <div
                     className="c46 c58"

--- a/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
@@ -1,14 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakTeacherNotesModal matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   position: fixed;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
   z-index: 300;
 }
 
-.c3 {
+.c3:where(span) {
+  display: block;
+}
+
+.c3:where(*) {
   position: fixed;
   inset: 0rem;
   background: #22222240;
@@ -16,14 +24,22 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   z-index: -1;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   width: 100%;
   max-width: 60rem;
   padding: 1.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 100%;
   background: #ffffff;
@@ -31,20 +47,32 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: relative;
   min-height: 3.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -52,11 +80,19 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -67,7 +103,11 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c19:where(span) {
+  display: block;
+}
+
+.c19:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -76,7 +116,11 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -85,7 +129,11 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c23 {
+.c23:where(span) {
+  display: block;
+}
+
+.c23:where(*) {
   overflow: auto;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -96,19 +144,31 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   overflow: auto;
 }
 
-.c24 {
+.c24:where(span) {
+  display: block;
+}
+
+.c24:where(*) {
   padding-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c27 {
+.c27:where(span) {
+  display: block;
+}
+
+.c27:where(*) {
   padding: 0.75rem;
   background: #f2f2f2;
   border-radius: 0.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c29 {
+.c29:where(span) {
+  display: block;
+}
+
+.c29:where(*) {
   overflow-y: scroll;
   height: 15rem;
   min-height: 4.5rem;
@@ -120,7 +180,11 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c37 {
+.c37:where(span) {
+  display: block;
+}
+
+.c37:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -129,17 +193,29 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c42 {
+.c42:where(span) {
+  display: block;
+}
+
+.c42:where(*) {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c46 {
+.c46:where(span) {
+  display: block;
+}
+
+.c46:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c50 {
+.c50:where(span) {
+  display: block;
+}
+
+.c50:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -148,7 +224,11 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c52 {
+.c52:where(span) {
+  display: block;
+}
+
+.c52:where(*) {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -156,7 +236,11 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c54 {
+.c54:where(span) {
+  display: block;
+}
+
+.c54:where(*) {
   padding: 1rem;
   background: #fff7cc;
   border: 0.063rem solid;
@@ -170,13 +254,21 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c56 {
+.c56:where(span) {
+  display: block;
+}
+
+.c56:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c59 {
+.c59:where(span) {
+  display: block;
+}
+
+.c59:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
@@ -691,7 +783,11 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   color: #808080;
 }
 
-.c6 {
+.c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -787,25 +883,25 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c23 {
+  .c23:where(*) {
     padding-left: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c23 {
+  .c23:where(*) {
     padding-right: 2rem;
   }
 }
 
 @media (min-width:750px) {
-  .c42 {
+  .c42:where(*) {
     display: block;
   }
 }
 
 @media (min-width:750px) {
-  .c52 {
+  .c52:where(*) {
     display: none;
   }
 }

--- a/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
+++ b/src/components/organisms/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
@@ -7,15 +7,6 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
 }
 
 .c2 {
-  display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -26,6 +17,22 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
   display: revert;
   display: revert;
+}
+
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
+  display: revert;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c4 {

--- a/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakUnitListItem matches snapshot 1`] = `
 [
-  .c1 {
+  .c1:where(span) {
+  display: block;
+}
+
+.c1:where(*) {
   width: 100%;
   padding-right: 1rem;
   background: #ffffff;
@@ -11,7 +15,11 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   width: 100%;
   height: 100%;
   padding-right: 0rem;
@@ -19,25 +27,41 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   min-width: 4rem;
   background: #a0b6f2;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
   padding-right: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   min-width: 5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   min-width: 10rem;
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -50,7 +74,11 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -59,7 +87,11 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   width: 100%;
   padding: 1rem;
   background: #ffffff;
@@ -71,16 +103,28 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c24:where(span) {
+  display: block;
+}
+
+.c24:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c26 {
+.c26:where(span) {
+  display: block;
+}
+
+.c26:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c28 {
+.c28:where(span) {
+  display: block;
+}
+
+.c28:where(*) {
   width: 2.5rem;
   min-width: 2.5rem;
   height: 2.5rem;
@@ -228,13 +272,20 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 .c0 {
-  width: 100%;
-  display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
   list-style: none;
   display: revert;
   display: revert;
+}
+
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
+  width: 100%;
+  display: revert;
+  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -314,7 +365,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c1:where(*) {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -323,7 +374,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c22:where(*) {
     display: none;
   }
 }

--- a/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -403,7 +403,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
           >
             0 lessons
           </p>
-          <div
+          <span
             className="c20"
           >
             <img
@@ -430,7 +430,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
       </a>
     </div>

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
@@ -2,14 +2,22 @@
 
 exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 100%;
   background: #ffffff;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 1rem;
@@ -20,7 +28,11 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   width: 2.5rem;
   min-width: 2.5rem;
   height: 2.5rem;
@@ -32,13 +44,21 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   max-width: 30rem;
   margin-right: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   width: 2.5rem;
   min-width: 2.5rem;
   height: 2.5rem;
@@ -49,28 +69,48 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   width: 100%;
   padding: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   margin-bottom: 1rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c15:where(span) {
+  display: block;
+}
+
+.c15:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c18:where(span) {
+  display: block;
+}
+
+.c18:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   padding-top: 0.25rem;
@@ -83,7 +123,11 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c24:where(span) {
+  display: block;
+}
+
+.c24:where(*) {
   width: 100%;
   margin-bottom: 1rem;
   display: -webkit-box;
@@ -93,7 +137,11 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c26 {
+.c26:where(span) {
+  display: block;
+}
+
+.c26:where(*) {
   margin-bottom: 1rem;
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -277,79 +325,79 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c2 {
+  .c2:where(*) {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     width: 4rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c4 {
+  .c4:where(*) {
     width: auto;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     min-width: 4rem;
   }
 }
 
 @media (min-width:750px) {
-  .c4 {
+  .c4:where(*) {
     height: auto;
   }
 }
 
 @media (min-width:1280px) {
-  .c4 {
+  .c4:where(*) {
     height: auto;
   }
 }
 
 @media (min-width:750px) {
-  .c7 {
+  .c7:where(*) {
     margin-right: 1rem;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     width: 4rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c10 {
+  .c10:where(*) {
     width: auto;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     min-width: 4rem;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     height: auto;
   }
 }
 
 @media (min-width:1280px) {
-  .c10 {
+  .c10:where(*) {
     height: auto;
   }
 }
 
 @media (min-width:750px) {
-  .c10 {
+  .c10:where(*) {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -358,7 +406,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c10 {
+  .c10:where(*) {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -367,7 +415,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c13 {
+  .c13:where(*) {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -376,31 +424,31 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c18 {
+  .c18:where(*) {
     width: 15rem;
   }
 }
 
 @media (min-width:750px) {
-  .c24 {
+  .c24:where(*) {
     display: none;
   }
 }
 
 @media (min-width:1280px) {
-  .c24 {
+  .c24:where(*) {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c26 {
+  .c26:where(*) {
     display: auto;
   }
 }
 
 @media (min-width:1280px) {
-  .c26 {
+  .c26:where(*) {
     display: auto;
   }
 }

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,7 +14,11 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 1rem;
@@ -22,17 +30,29 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
             >
               0 lessons
             </span>
-            <div
+            <span
               className="c12"
             >
               <img
@@ -226,7 +226,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
@@ -1,18 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakUnitsContainer matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   padding: 1rem;
   background: #e3e9fb;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c8:where(span) {
+  display: block;
+}
+
+.c8:where(*) {
   position: relative;
   width: 2.5rem;
   display: -webkit-box;
@@ -22,13 +34,21 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c12:where(span) {
+  display: block;
+}
+
+.c12:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c14:where(span) {
+  display: block;
+}
+
+.c14:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -40,7 +60,11 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c16 {
+.c16:where(span) {
+  display: block;
+}
+
+.c16:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -48,7 +72,11 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c23 {
+.c23:where(span) {
+  display: block;
+}
+
+.c23:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -59,7 +87,11 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c24 {
+.c24:where(span) {
+  display: block;
+}
+
+.c24:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -68,7 +100,11 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c25 {
+.c25:where(span) {
+  display: block;
+}
+
+.c25:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -229,6 +265,13 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
   padding: 0;
   margin: 0;
   display: block;
+}
+
+.c27:where(span) {
+  display: block;
+}
+
+.c27:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -320,13 +363,13 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c8:where(*) {
     width: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c8 {
+  .c8:where(*) {
     width: 3.5rem;
   }
 }

--- a/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
@@ -480,7 +480,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
             <div
               className="c24 shadow"
             />
-            <div
+            <span
               className="c25"
               data-icon-for="button"
             >
@@ -508,7 +508,7 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
         </div>
       </a>

--- a/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
@@ -1,11 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OakUnitsHeader matches snapshot 1`] = `
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 2.5rem;
   display: -webkit-box;
@@ -15,13 +23,21 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -33,7 +49,11 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -41,7 +61,11 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -52,7 +76,11 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c21:where(span) {
+  display: block;
+}
+
+.c21:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -61,7 +89,11 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -274,13 +306,13 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     width: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c5 {
+  .c5:where(*) {
     width: 3.5rem;
   }
 }
@@ -469,11 +501,19 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
 
 exports[`OakUnitsHeader matches snapshot with banner 1`] = `
 [
-  .c0 {
+  .c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c5:where(span) {
+  display: block;
+}
+
+.c5:where(*) {
   position: relative;
   width: 2.5rem;
   display: -webkit-box;
@@ -483,13 +523,21 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c9:where(span) {
+  display: block;
+}
+
+.c9:where(*) {
   position: absolute;
   inset: 0rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c11:where(span) {
+  display: block;
+}
+
+.c11:where(*) {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -501,7 +549,11 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c13 {
+.c13:where(span) {
+  display: block;
+}
+
+.c13:where(*) {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -509,7 +561,11 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c20:where(span) {
+  display: block;
+}
+
+.c20:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -520,7 +576,11 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c21:where(span) {
+  display: block;
+}
+
+.c21:where(*) {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -529,7 +589,11 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c22:where(span) {
+  display: block;
+}
+
+.c22:where(*) {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -742,13 +806,13 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
 }
 
 @media (min-width:750px) {
-  .c5 {
+  .c5:where(*) {
     width: 3rem;
   }
 }
 
 @media (min-width:1280px) {
-  .c5 {
+  .c5:where(*) {
     width: 3.5rem;
   }
 }
@@ -933,16 +997,28 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
       </a>
     </div>
   </div>,
-  .c6 {
+  .c6:where(span) {
+  display: block;
+}
+
+.c6:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c0 {
+.c0:where(span) {
+  display: block;
+}
+
+.c0:where(*) {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c2:where(span) {
+  display: block;
+}
+
+.c2:where(*) {
   width: 100%;
   padding: 1rem;
   background: #f2f2f2;
@@ -957,13 +1033,21 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c4:where(span) {
+  display: block;
+}
+
+.c4:where(*) {
   position: relative;
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c7:where(span) {
+  display: block;
+}
+
+.c7:where(*) {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -972,7 +1056,11 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c10:where(span) {
+  display: block;
+}
+
+.c10:where(*) {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;

--- a/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
@@ -431,7 +431,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
           <div
             className="c21 shadow"
           />
-          <div
+          <span
             className="c22"
             data-icon-for="button"
           >
@@ -459,7 +459,7 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
       </div>
     </a>
@@ -899,7 +899,7 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
             <div
               className="c21 shadow"
             />
-            <div
+            <span
               className="c22"
               data-icon-for="button"
             >
@@ -927,7 +927,7 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
                   }
                 }
               />
-            </div>
+            </span>
           </div>
         </div>
       </a>
@@ -1116,7 +1116,7 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
         <div
           className="c6"
         >
-          <div
+          <span
             className="c7"
             data-testid="inline-banner-icon"
           >
@@ -1144,7 +1144,7 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
                 }
               }
             />
-          </div>
+          </span>
         </div>
         <div
           className="c0 c9"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Currently `<OakIcon/>` is often used within `<OakP/>` (for example within `<OakLink icon="book" />`, the issue is that `<OakIcon/>` renders as a `<div/>`, so you end up with the following DOM nesting

```
<p>
  <div>
     THE ICON HERE...
  </div>
</p>
```

Unfortunately that's invalid DOM nesting, so what actually gets rendered is

<img width="451" alt="Screenshot 2025-05-27 at 11 35 37" src="https://github.com/user-attachments/assets/fcd9f887-6c0d-439f-b8a6-8aa6030570f1" />

Which as well as being incorrect, messes with react's DOM hydration. So react has to throw away the entire DOM and start again.

So because `<p/>` elements cannot contain another block element (like `<div/>`) we need to use something else like `<span/>`


## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
