### PR TITLE
Feat/lesq 1338/oak side menu nav updates

### DIFF
--- a/src/components/organisms/shared/OakSideMenuNav/OakSideMenuNav.test.tsx
+++ b/src/components/organisms/shared/OakSideMenuNav/OakSideMenuNav.test.tsx
@@ -11,6 +11,7 @@ import { oakDefaultTheme } from "@/styles";
 
 const baseProps = {
   heading: "Test Heading",
+  anchorTargetId: "side-menu-header",
   menuItems: [
     {
       heading: "Test Item 1",

--- a/src/components/organisms/shared/OakSideMenuNav/OakSideMenuNav.tsx
+++ b/src/components/organisms/shared/OakSideMenuNav/OakSideMenuNav.tsx
@@ -3,7 +3,13 @@ import styled from "styled-components";
 
 import { MenuItemProps, OakSideMenuNavLink } from "../OakSideMenuNavLink";
 
-import { OakFlex, OakHeading, OakLI, OakUL } from "@/components/atoms";
+import {
+  OakAnchorTarget,
+  OakFlex,
+  OakHeading,
+  OakLI,
+  OakUL,
+} from "@/components/atoms";
 
 const StyledNav = styled.nav`
   outline: none;
@@ -12,14 +18,16 @@ const StyledNav = styled.nav`
 export type OakSideMenuNavProps = {
   heading: string;
   menuItems: MenuItemProps[];
+  anchorTargetId: string;
 };
 
 export const OakSideMenuNav = (props: OakSideMenuNavProps) => {
-  const { heading, menuItems } = props;
+  const { heading, menuItems, anchorTargetId } = props;
   const [selectedHref, setSelectedHref] = useState<string | null>(null);
 
   return (
     <StyledNav aria-labelledby="side-menu-header">
+      <OakAnchorTarget id={anchorTargetId} />
       <OakFlex
         $flexDirection="column"
         $background={["bg-decorative1-subdued", "white"]}

--- a/src/components/organisms/shared/OakSideMenuNav/OakSideMenuNav.tsx
+++ b/src/components/organisms/shared/OakSideMenuNav/OakSideMenuNav.tsx
@@ -41,7 +41,7 @@ export const OakSideMenuNav = (props: OakSideMenuNavProps) => {
           $flexDirection="column"
         >
           {menuItems.map((item) => (
-            <OakLI key={item.heading}>
+            <OakLI key={item.href}>
               <OakSideMenuNavLink
                 item={item}
                 isSelected={selectedHref === item.href}

--- a/src/components/organisms/shared/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
+++ b/src/components/organisms/shared/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
@@ -2,17 +2,17 @@
 
 exports[`OakSideMenuNav matches snapshot 1`] = `
 [
-  .c1 {
+  .c2 {
   padding: 3rem;
   background: #dff9de;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c8 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c12 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -23,7 +23,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -34,7 +34,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   gap: 1rem;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -49,11 +49,16 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   column-gap: 1rem;
 }
 
-.c12 {
+.c1 {
+  position: absolute;
+  top: 0;
+}
+
+.c13 {
   object-fit: contain;
 }
 
-.c3 {
+.c4 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -65,7 +70,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   color: #575757;
 }
 
-.c9 {
+.c10 {
   color: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
@@ -77,7 +82,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c10 {
+.c11 {
   color: #575757;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -90,7 +95,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   white-space: break-spaces;
 }
 
-.c5 {
+.c6 {
   display: revert;
   font-family: --var(google-font),Lexend,sans-serif;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -98,7 +103,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   display: revert;
 }
 
-.c4 {
+.c5 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -118,7 +123,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   gap: 1rem;
 }
 
-.c6 {
+.c7 {
   -webkit-text-decoration: none;
   text-decoration: none;
   display: -webkit-box;
@@ -143,7 +148,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   padding-right: 0rem;
 }
 
-.c6:focus-visible {
+.c7:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
   border-color: transparent;
   border-radius: 4px;
@@ -154,25 +159,25 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c2 {
     padding: 0rem;
   }
 }
 
 @media (min-width:750px) {
-  .c1 {
+  .c2 {
     background: #ffffff;
   }
 }
 
 @media (min-width:750px) {
-  .c11 {
+  .c12 {
     display: none;
   }
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c9 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -180,18 +185,18 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c8 {
+  .c9 {
     -webkit-column-gap: 0.25rem;
     column-gap: 0.25rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c7 {
     border-left: 4px solid transparent;
   }
 
-  .c6:hover {
+  .c7:hover {
     -webkit-text-decoration: underline;
     text-decoration: underline;
     border-color: #bef2bd;
@@ -199,7 +204,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c7 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
@@ -207,7 +212,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c7 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -216,13 +221,13 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c7 {
     padding-left: 0.75rem;
   }
 }
 
 @media (min-width:750px) {
-  .c6 {
+  .c7 {
     padding-right: 0.75rem;
   }
 }
@@ -231,46 +236,50 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
     aria-labelledby="side-menu-header"
     className="c0"
   >
+    <span
+      className="c1"
+      id="side-menu-header"
+    />
     <div
-      className="c1 c2"
+      className="c2 c3"
     >
       <h2
-        className="c3"
+        className="c4"
         id="side-menu-header"
       >
         Test Heading
       </h2>
       <ul
-        className="c4"
+        className="c5"
       >
         <li
-          className="c5"
+          className="c6"
         >
           <a
-            className="c6"
+            className="c7"
             href="#test1"
             onClick={[Function]}
           >
             <div
-              className="c7 c8"
+              className="c8 c9"
             >
               <span
-                className="c9"
+                className="c10"
               >
                 Test Item 1
               </span>
               <span
-                className="c10"
+                className="c11"
               >
                 Test Subheading 1
               </span>
             </div>
             <div
-              className="c11"
+              className="c12"
             >
               <img
                 alt=""
-                className="c12"
+                className="c13"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -296,33 +305,33 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
           </a>
         </li>
         <li
-          className="c5"
+          className="c6"
         >
           <a
-            className="c6"
+            className="c7"
             href="#test2"
             onClick={[Function]}
           >
             <div
-              className="c7 c8"
+              className="c8 c9"
             >
               <span
-                className="c9"
+                className="c10"
               >
                 Test Item 2
               </span>
               <span
-                className="c10"
+                className="c11"
               >
                 Test Subheading 2
               </span>
             </div>
             <div
-              className="c11"
+              className="c12"
             >
               <img
                 alt=""
-                className="c12"
+                className="c13"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
A few things that were missed when creating the component:
- Adds an anchor target to the side menu nav so it can be linked back to ([see design](https://www.figma.com/design/LSjbzdvHo17XqXGBRNJjQP/Teacher-browse?node-id=8280-16467&m=dev))
- Updates the key used for the list to make sure it's unique

