### PR TITLE
feat: add optional props to OakHeaderHero component

### DIFF
--- a/src/components/organisms/shared/OakHeaderHero/OakHeaderHero.tsx
+++ b/src/components/organisms/shared/OakHeaderHero/OakHeaderHero.tsx
@@ -12,14 +12,14 @@ import {
 } from "@/components/atoms";
 
 export type OakHeaderHeroProps = {
-  headingTitle: string;
+  authorImageSrc?: string;
+  authorImageAlt?: string;
+  authorName?: string;
+  authorTitle?: string;
   heroImageSrc: string;
-  authorImageSrc: string;
-  authorName: string;
-  authorTitle: string;
-  subHeadingText: string;
   heroImageAlt: string;
-  authorImageAlt: string;
+  headingTitle?: string;
+  subHeadingText: string;
   breadcrumbs: ReactElement;
   cmsImage?: ReactElement;
   children?: ReactNode;
@@ -38,17 +38,21 @@ const OakHeaderHeroCss = css<OakHeaderHeroProps>``;
 
 const UnstyledComponent = (props: OakHeaderHeroProps) => {
   const {
-    headingTitle,
-    breadcrumbs,
     authorName,
     authorTitle,
-    subHeadingText,
-    heroImageSrc,
     authorImageSrc,
-    heroImageAlt,
     authorImageAlt,
+    heroImageSrc,
+    heroImageAlt,
+    headingTitle,
+    breadcrumbs,
+    subHeadingText,
     cmsImage,
   } = props;
+
+  const hasAuthorProps =
+    authorImageSrc && authorImageAlt && authorName && authorTitle;
+
   return (
     <OakBox
       $width={"100%"}
@@ -96,21 +100,23 @@ const UnstyledComponent = (props: OakHeaderHeroProps) => {
               >
                 {headingTitle}
               </OakHeading>
-              <OakFlex
-                $mb={"space-between-m"}
-                $flexDirection={"row"}
-                $alignItems={"center"}
-              >
-                <StyledAuthorImage
-                  alt={authorImageAlt}
-                  src={authorImageSrc}
-                  $zIndex={"in-front"}
-                />
-                <OakBox>
-                  <OakP $font={"heading-7"}>{authorName}</OakP>
-                  <OakP $font={"body-3"}>{authorTitle}</OakP>
-                </OakBox>
-              </OakFlex>
+              {hasAuthorProps && (
+                <OakFlex
+                  $mb={"space-between-m"}
+                  $flexDirection={"row"}
+                  $alignItems={"center"}
+                >
+                  <StyledAuthorImage
+                    alt={authorImageAlt}
+                    src={authorImageSrc}
+                    $zIndex={"in-front"}
+                  />
+                  <OakBox>
+                    <OakP $font={"heading-7"}>{authorName}</OakP>
+                    <OakP $font={"body-3"}>{authorTitle}</OakP>
+                  </OakBox>
+                </OakFlex>
+              )}
               <OakP
                 $font={"body-1"}
                 $mb={["space-between-l", "space-between-none"]}


### PR DESCRIPTION
# How to review this PR

Check to see if the component still renders without author props in the deployment

# Add your PR description below

I've made the author props optional and added some conditional logic, so that the tests in [this PR](https://github.com/oaknational/Oak-Web-Application/pull/3457/files#diff-49c5055ea6c55e3d4f0304c8442b5211579528e7f21d5cdf72b828fb0401771b) pass.

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs

- `OakHeaderHero` must render without `author` props, i.e. if no `author` props are provided that section will be omitted
