### PR TITLE
feat: add new curric landing page icons to image map

### DIFF
--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -69,6 +69,10 @@ export const icons = {
   "bookmark-filled": "v1734519491/icons/bookmark-filled_jz828n.svg",
   "microsoft-teams": "v1736429692/microsoft-teams_gelfmi.svg",
   "google-classroom": "v1736429692/google-classroom_pedfpd.svg",
+  clipboard: "v1749031463/icons/clipboard_yll2yj.svg",
+  "book-steps": "v1749034739/icons/book-steps_qwku6h.svg",
+  "free-tag": "v1749033815/icons/free-tag_lijptf.svg",
+  threads: "v1749034800/icons/threads_sqlqoe.svg",
   // subject icons
   "subject-art": "v1706616347/subject-icons/art.svg",
   "subject-biology": "v1706616415/subject-icons/biology.svg",


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

I've added the following icons to the icon map as required for the new Curriculum landing page: 
- `thread`
- `clipboard`
- `book-steps`
- `free-tag`

## Link to the design doc

## A link to the component in the deployment preview

/docs/components-atoms-oakicon--docs

## Testing instructions

Check the OakIcon component in Storybook to see if the icons are present

## ACs
