### PR TITLE
fix: pass fn to return focus on element from modal

### DIFF
--- a/src/components/molecules/OakModalCenter/OakModalCenter.tsx
+++ b/src/components/molecules/OakModalCenter/OakModalCenter.tsx
@@ -65,6 +65,10 @@ export type OakModalCenterProps = {
    * Slot for the footer of the modal
    */
   footerSlot?: ReactNode;
+  /**
+   * Override for returnFocus behavior of FocusOn
+   */
+  returnFocus?: (returnTo: Element) => boolean | FocusOptions;
 };
 
 const FocusOnBox = styled(FocusOn)`
@@ -119,6 +123,7 @@ export const OakModalCenter = ({
   modalInnerFlexProps,
   backdropFlexProps,
   footerSlot,
+  returnFocus,
 }: OakModalCenterProps) => {
   const [scrollBorders, setScrollBorders] = useState({
     top: false,
@@ -201,7 +206,7 @@ export const OakModalCenter = ({
             <FocusOnBox
               onEscapeKey={() => !disableEscapeKey && onClose()}
               onClickOutside={() => !disableBackdropClick && onClose()}
-              returnFocus
+              returnFocus={returnFocus ?? true}
               autoFocus
               $width="100%"
             >

--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
@@ -80,6 +80,7 @@ export type OakUnitListItemProps = {
   onClick?: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   onSave?: () => void;
   isSaved?: boolean;
+  saveButtonId?: string;
 };
 
 /**
@@ -97,6 +98,7 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
     onSave,
     isSaved,
     firstItemRef,
+    saveButtonId,
     ...rest
   } = props;
 
@@ -198,6 +200,7 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
             aria-label={`${isSaved ? "Unsave" : "Save"} this unit: ${
               props.title
             } `}
+            id={saveButtonId}
           >
             {isSaved ? "Saved" : "Save"}
           </OakSmallTertiaryInvertedButton>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- when using OakModalCenter with `FocusOn` the suggested node to return focus to is not always correct, so adding an optional override function to manually control the return to behaviour fixes this

## A link to the component in the deployment preview
https://deploy-preview-434--lively-meringue-8ebd43.netlify.app/?path=/story/components-molecules-oakmodalcenter--default

## Testing instructions
There should be no difference in behaviour in storybook for the modal
You should be able to open the modal with keyboard, and focus should return to the button on close