### PR TITLE
fix: nested li in OWA

### DIFF
--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/OakUnitListOptionalityItemCard.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/OakUnitListOptionalityItemCard.tsx
@@ -115,9 +115,6 @@ export const OakUnitListOptionalityItemCard = (
         $ba="border-solid-m"
         $disabled={unavailable}
         $flexGrow={1}
-        as={onSave ? "li" : "a"}
-        href={unavailable ? undefined : href}
-        ref={firstItemRef}
         {...rest}
       >
         <OakFlex

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
@@ -174,9 +174,8 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
 <div
     className="c0 c1"
   >
-    <a
+    <div
       className="c2 c1 c3"
-      href=""
       title="Lesson 1"
     >
       <div
@@ -230,7 +229,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
           </div>
         </div>
       </div>
-    </a>
+    </div>
   </div>,
   ",",
 ]


### PR DESCRIPTION


# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- remove dynamic element typing as save is no longer behind a ff

## A link to the component in the deployment preview

## Testing instructions
- check the element structure in the deployment
- check the component looks and behaves as expected