### PR TITLE
fix: move aria label to `a` from `span`

### DIFF
--- a/src/components/molecules/OakSaveCount/OakSaveCount.tsx
+++ b/src/components/molecules/OakSaveCount/OakSaveCount.tsx
@@ -40,7 +40,11 @@ export const OakSaveCount = ({ count, href, loading }: OakSaveCountProps) => {
     : "all-spacing-10";
 
   return (
-    <StyledInternalButton as="a" href={href}>
+    <StyledInternalButton
+      as="a"
+      href={href}
+      aria-label={`${count} saved unit${count === 1 ? "" : "s"}`}
+    >
       <OakScreenReader>View my library</OakScreenReader>
       <OakFlex
         $width={["all-spacing-7", containerWidth]}
@@ -68,10 +72,7 @@ export const OakSaveCount = ({ count, href, loading }: OakSaveCountProps) => {
           $textAlign="center"
           $display={["none", "block"]}
         >
-          <OakSpan
-            $font="heading-light-7"
-            aria-label={`${count} saved unit${count === 1 ? "" : "s"}`}
-          >
+          <OakSpan $font="heading-light-7">
             {showTruncatedCount ? "99+" : count}
           </OakSpan>
         </OakBox>

--- a/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
+++ b/src/components/molecules/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
@@ -126,6 +126,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
 
 <div>
   <a
+    aria-label="0 saved units"
     class="c0 c1"
     href="#"
   >
@@ -155,7 +156,6 @@ exports[`OakSaveCount should match snapshot 1`] = `
         class="c7"
       >
         <span
-          aria-label="0 saved units"
           class="c8"
         >
           0


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- move aria label as it does nothing on a span
- this didn't get flagged before as the component was behind a feature flag disabled by default

## A link to the component in the deployment preview
https://deploy-preview-436--lively-meringue-8ebd43.netlify.app/?path=/docs/components-molecules-oaksavecount--docs

## Testing instructions
- the OakSaveCount component should appear the same
- you should be able to see the aria label on the link
- the label should be accurate to the value displayed
