### PR TITLE
Feat: hasAnimation prop for OakLinkCard component

### DIFF
--- a/src/components/molecules/OakLinkCard/OakLinkCard.stories.tsx
+++ b/src/components/molecules/OakLinkCard/OakLinkCard.stories.tsx
@@ -39,6 +39,11 @@ const meta: Meta<typeof OakLinkCard> = {
         type: "boolean",
       },
     },
+    hasAnimation: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
   parameters: {
     controls: {
@@ -75,6 +80,7 @@ const meta: Meta<typeof OakLinkCard> = {
     href: "https://www.example.com",
     showNew: true,
     narrow: false,
+    hasAnimation: false,
   },
 };
 
@@ -116,5 +122,32 @@ export const WithLongText: Story = {
     iconName: "books",
     href: "https://www.example.com",
     showNew: false,
+  },
+};
+
+export const WithAnimation: Story = {
+  args: {
+    hasAnimation: true,
+    mainSection: (
+      <OakFlex $flexDirection="column" $gap="space-between-xs">
+        <OakHeading tag="h1" $font="heading-5">
+          Explore our cool animations that happen on mount
+        </OakHeading>
+        <OakP>
+          Dive into this smooth transition from bg-decorative1-main to
+          bg-primary. It eases in an out for a delightful user experience.
+          Discover more subtle ways to call attention to components.
+        </OakP>
+        <OakTertiaryButton iconName="chevron-right" isTrailingIcon>
+          Find out more
+        </OakTertiaryButton>
+      </OakFlex>
+    ),
+    iconName: "question-mark",
+    iconAlt: "Illustration of interactive lessons",
+    iconColor: "black",
+    iconFill: "bg-decorative1-main",
+    href: "https://www.example.com",
+    narrow: false,
   },
 };

--- a/src/components/molecules/OakLinkCard/OakLinkCard.test.tsx
+++ b/src/components/molecules/OakLinkCard/OakLinkCard.test.tsx
@@ -98,7 +98,7 @@ describe("OakLinkCard", () => {
     );
 
     expect(containerWithAnimation.firstChild).toHaveStyle({
-      animation: "background-fade 0.9s ease-in-out",
+      animation: "background-fade 2s ease-in-out",
     });
 
     expect(containerWithoutAnimation.firstChild).toHaveStyle({

--- a/src/components/molecules/OakLinkCard/OakLinkCard.test.tsx
+++ b/src/components/molecules/OakLinkCard/OakLinkCard.test.tsx
@@ -88,4 +88,21 @@ describe("OakLinkCard", () => {
     renderWithTheme(<OakLinkCard {...defaultProps} showNew={false} />);
     expect(screen.queryByTestId("oak-new-promo-tag")).not.toBeInTheDocument();
   });
+
+  it("applies an animation only when hasAnimation is true", () => {
+    const { container: containerWithAnimation } = renderWithTheme(
+      <OakLinkCard {...defaultProps} hasAnimation={true} />,
+    );
+    const { container: containerWithoutAnimation } = renderWithTheme(
+      <OakLinkCard {...defaultProps} hasAnimation={false} />,
+    );
+
+    expect(containerWithAnimation.firstChild).toHaveStyle({
+      animation: "background-fade 0.9s ease-in-out",
+    });
+
+    expect(containerWithoutAnimation.firstChild).toHaveStyle({
+      animation: "none",
+    });
+  });
 });

--- a/src/components/molecules/OakLinkCard/OakLinkCard.tsx
+++ b/src/components/molecules/OakLinkCard/OakLinkCard.tsx
@@ -20,7 +20,8 @@ type OakFlexPropsWithAnimation = OakFlexProps & {
 };
 const StyledOakFlexAsLink = styled(OakFlex)<OakFlexPropsWithAnimation>`
   animation: ${({ hasAnimation }) =>
-    hasAnimation ? "background-fade 0.9s ease-in-out" : "none"};
+    hasAnimation ? "background-fade 2s ease-in-out" : "none"};
+  animation-delay: 0.5s;
   cursor: pointer;
   outline: none;
   &:focus-visible {

--- a/src/components/molecules/OakLinkCard/OakLinkCard.tsx
+++ b/src/components/molecules/OakLinkCard/OakLinkCard.tsx
@@ -4,16 +4,37 @@ import styled from "styled-components";
 import { OakHandDrawnCardWithIcon } from "../OakHandDrawnCardWithIcon";
 import { OakPromoTag } from "../OakPromoTag";
 
-import { OakFlex, OakBox, OakIconName, OakIconProps } from "@/components/atoms";
+import {
+  OakFlex,
+  OakBox,
+  OakIconName,
+  OakIconProps,
+  OakFlexProps,
+} from "@/components/atoms";
 import { InternalStyledSvgProps } from "@/components/atoms/InternalStyledSvg";
+import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 
-const StyledOakFlexAsLink = styled(OakFlex)`
+type OakFlexPropsWithAnimation = OakFlexProps & {
+  hasAnimation?: boolean;
+};
+const StyledOakFlexAsLink = styled(OakFlex)<OakFlexPropsWithAnimation>`
+  animation: ${({ hasAnimation }) =>
+    hasAnimation ? "background-fade 0.9s ease-in-out" : "none"};
   cursor: pointer;
   outline: none;
   &:focus-visible {
     box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
       ${parseDropShadow("drop-shadow-centered-grey")};
+  }
+
+  @keyframes background-fade {
+    from {
+      background-color: ${parseColor("bg-decorative1-main")};
+    }
+    to {
+      transform: ${parseColor("bg-primary")};
+    }
   }
 `;
 
@@ -50,6 +71,10 @@ export type OakLinkCardProps = {
    * Whether to display the card in a narrow layout.
    */
   narrow?: boolean;
+  /**
+   * Whether to apply a background animation effect.
+   */
+  hasAnimation?: boolean;
 };
 
 /**
@@ -74,17 +99,19 @@ export const OakLinkCard = ({
   iconFill = "bg-decorative1-main",
   href,
   showNew = false,
+  hasAnimation = false,
   narrow = false,
 }: OakLinkCardProps) => {
   return (
     <StyledOakFlexAsLink
+      hasAnimation={hasAnimation}
       as="a"
       href={href}
       $flexDirection={narrow ? "column-reverse" : ["column-reverse", "row"]}
       $alignItems={narrow ? "flex-start" : ["flex-start", "center"]}
       $justifyContent="space-between"
       $gap={"space-between-m2"}
-      $background="bg-primary"
+      $background={"bg-primary"}
       $pa="inner-padding-xl"
       $borderRadius="border-radius-m2"
       $width="100%"

--- a/src/components/molecules/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
+++ b/src/components/molecules/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
@@ -132,6 +132,8 @@ exports[`OakLinkCard matches snapshot 1`] = `
 .c2 {
   -webkit-animation: none;
   animation: none;
+  -webkit-animation-delay: 0.5s;
+  animation-delay: 0.5s;
   cursor: pointer;
   outline: none;
 }

--- a/src/components/molecules/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
+++ b/src/components/molecules/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
@@ -130,6 +130,8 @@ exports[`OakLinkCard matches snapshot 1`] = `
 }
 
 .c2 {
+  -webkit-animation: none;
+  animation: none;
   cursor: pointer;
   outline: none;
 }


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

https://www.notion.so/oaknationalacademy/I-want-animations-on-the-curriculum-download-banner-20d26cc4e1b18061a302f7820ecdfe6e

This PR adds a hasAnimation prop the the OakLinkCard component so that it renders with an animation on mount according to the designs.

I couldn't override the bg color from within OWA because it's hard-coded in this component. After a chat with Monika where she mentioned this was more of an experiment and might not become a common pattern, I wondered whether this was the right approach. Another way to do it would be to just us an OakFlex with as="link" within OWA. Not sure which way to go.

## Link to the design doc

https://www.figma.com/design/LSjbzdvHo17XqXGBRNJjQP/Teacher-browse?node-id=8871-17459&m=dev

## A link to the component in the deployment preview

https://deploy-preview-437--lively-meringue-8ebd43.netlify.app/?path=/story/components-molecules-oaklinkcard--with-animation

## Testing instructions

1. visit the storybook deploy
2. check the animation renders as expected
3. check that it doesn't render on the other versions, e.g. https://deploy-preview-437--lively-meringue-8ebd43.netlify.app/?path=/story/components-molecules-oaklinkcard--default

## ACs
- [ ]  The banner should fade in from green to white
- [ ]  There should be some subtle animation, check with Monika for details