### PR TITLE
feat: updated OakTagFunctional so you can use span or label element

### DIFF
--- a/src/components/molecules/OakTagFunctional/OakTagFunctional.stories.tsx
+++ b/src/components/molecules/OakTagFunctional/OakTagFunctional.stories.tsx
@@ -10,6 +10,13 @@ const meta: Meta<typeof OakTagFunctional> = {
   tags: ["autodocs"],
   title: "components/molecules/OakTagFunctional",
   args: { label: "Played" },
+  argTypes: {
+    useSpan: {
+      control: "boolean",
+      description:
+        "Whether to use a span element or default label element for label text",
+    },
+  },
   decorators: [
     (Story) => (
       <OakFlex $pa={"inner-padding-xl"} $flexDirection={"row"}>
@@ -25,4 +32,9 @@ type Story = StoryObj<typeof OakTagFunctional>;
 export const Default: Story = {
   render: (args) => <OakTagFunctional {...args} />,
   args: { $background: "bg-neutral", $color: "text-subdued" },
+};
+
+export const Span: Story = {
+  render: (args) => <OakTagFunctional {...args} />,
+  args: { $background: "bg-neutral", $color: "text-subdued", useSpan: true },
 };

--- a/src/components/molecules/OakTagFunctional/OakTagFunctional.tsx
+++ b/src/components/molecules/OakTagFunctional/OakTagFunctional.tsx
@@ -4,9 +4,10 @@ import { OakBox, OakBoxProps, OakLabel } from "@/components/atoms";
 
 export type OakTagFunctionalProps = {
   label: string;
+  useSpan?: boolean;
 } & Omit<OakBoxProps, "onClick" | "label">;
 export const OakTagFunctional = (props: OakTagFunctionalProps) => {
-  const { label, ...oakBoxProps } = props;
+  const { label, useSpan, ...oakBoxProps } = props;
   return (
     <OakBox
       $borderRadius={"border-radius-m"}
@@ -15,7 +16,7 @@ export const OakTagFunctional = (props: OakTagFunctionalProps) => {
       $font={["heading-light-7"]}
       {...oakBoxProps}
     >
-      <OakLabel>{label}</OakLabel>
+      <OakLabel as={useSpan ? "span" : undefined}>{label}</OakLabel>
     </OakBox>
   );
 };


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Added a useSpan property to the OakTagFunctional component.

The purpose is that for accessibility reasons we may not want to use the native `label` element for the tag when the tag is not inside of a form. 

## Link to the design doc

## A link to the component in the deployment preview
${deployment_url}?path=/docs/components-molecules-oaktagfunctional--docs

## Testing instructions
Check that when the useSpan property is set to true, a spen element is used to wrap the text instead of a label element

## ACs
- [ ] useSpan property toggles the native HTML element used
- [ ] Both variants look identical
- [ ] No regressions
