### PR TITLE
feat: add correct header tag to OakCookieSettingsModal

### DIFF
--- a/src/components/molecules/OakAccordion/OakAccordion.tsx
+++ b/src/components/molecules/OakAccordion/OakAccordion.tsx
@@ -16,6 +16,10 @@ export type OakAccordionProps = {
    */
   header: ReactNode;
   /**
+   * The heading tag the header of the accordion is to assume
+   */
+  headerTag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  /**
    * Slot to place content after the header and outside the button
    */
   headerAfterSlot?: ReactNode;
@@ -50,11 +54,13 @@ const StyledOakFlex = styled(InternalAccordionButton)`
 
 const Accordion = ({
   header,
+  headerTag,
   headerAfterSlot,
   children,
   id,
 }: OakAccordionProps) => {
   const { isOpen } = useAccordionContext();
+  const HeaderTag = headerTag || "h3";
 
   return (
     <OakBox
@@ -65,7 +71,7 @@ const Accordion = ({
       $background={isOpen ? "bg-neutral" : "bg-primary"}
     >
       <OakFlex
-        as="h3"
+        as={HeaderTag}
         $font="heading-light-7"
         $textDecoration={isOpen ? "underline" : "none"}
       >

--- a/src/components/organisms/shared/OakCookieSettingsModal/OakCookieSettingsModal.tsx
+++ b/src/components/organisms/shared/OakCookieSettingsModal/OakCookieSettingsModal.tsx
@@ -139,6 +139,7 @@ export const OakCookieSettingsModal = ({
                     {policy.policyLabel}
                   </OakSpan>
                 }
+                headerTag="h4"
                 id={`cookies-settings-${policy.policyId}-accordion`}
                 headerAfterSlot={
                   <OakCheckBox


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Added a prop which allows you to supply the tag of the heading for accordion sections.

Fixes [this](https://www.notion.so/oaknationalacademy/Change-heading-levels-on-cookie-modal-accordion-21626cc4e1b180ba919bc2043a0f5b83?source=copy_link)

## A link to the component in the deployment preview

https://oak-components-storybook-git-feat-add-tag-option-to-cook-4e8820.vercel-preview.thenational.academy/?path=/docs/components-organisms-shared-oakcookiesettingsmodal--docs

## Testing instructions

Navigate to the `OakCookieSettingsModal` component in Storybook and then check that each section heading in the accordion is a `h4`

## ACs
