### PR TITLE
Feat/update unit card save button

### DIFF
--- a/src/components/molecules/OakSaveButton/OakSaveButton.stories.tsx
+++ b/src/components/molecules/OakSaveButton/OakSaveButton.stories.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { OakSaveButton, OakSaveButtonProps } from "./OakSaveButton";
+
+const meta: Meta<OakSaveButtonProps> = {
+  title: "components/molecules/OakSaveButton",
+  component: OakSaveButton,
+  argTypes: {
+    isLoading: { control: "boolean" },
+    unavailable: { control: "boolean" },
+    isSaved: { control: "boolean" },
+  },
+  parameters: {
+    controls: {
+      include: ["isSaved", "isLoading", "unavailable"],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<OakSaveButtonProps>;
+
+export const Default: Story = {
+  render: (args) => <OakSaveButton {...args} />,
+  args: {
+    isSaved: false,
+    isLoading: false,
+    onSave: () => console.log("Save action triggered"),
+    unavailable: false,
+    saveButtonId: "save-button",
+    title: "Save this unit",
+  },
+};

--- a/src/components/molecules/OakSaveButton/OakSaveButton.test.tsx
+++ b/src/components/molecules/OakSaveButton/OakSaveButton.test.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+
+import { OakSaveButton } from "./OakSaveButton";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+
+const render = renderWithTheme;
+
+describe("OakSaveButton", () => {
+  it("renders correctly with default props", () => {
+    render(
+      <OakSaveButton
+        isSaved={false}
+        isLoading={false}
+        onSave={() => console.log("Save action triggered")}
+        unavailable={false}
+        saveButtonId="save-button"
+        title="Test unit"
+      />,
+    );
+    const button = screen.getByRole("button", {
+      name: "Save this unit: Test unit",
+    });
+
+    expect(button).toBeInTheDocument();
+  });
+  it('renders correctly with "Saved" text when isSaved is true', () => {
+    render(
+      <OakSaveButton
+        isSaved={true}
+        isLoading={false}
+        onSave={() => console.log("Save action triggered")}
+        unavailable={false}
+        saveButtonId="save-button"
+        title="Test unit"
+      />,
+    );
+    const button = screen.getByRole("button", {
+      name: "Unsave this unit: Test unit",
+    });
+
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent("Saved");
+  });
+  it('renders correctly with "Save" text when isSaved is false', () => {
+    render(
+      <OakSaveButton
+        isSaved={false}
+        isLoading={false}
+        onSave={() => console.log("Save action triggered")}
+        unavailable={false}
+        saveButtonId="save-button"
+        title="Test unit"
+      />,
+    );
+    const button = screen.getByRole("button", {
+      name: "Save this unit: Test unit",
+    });
+
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent("Save");
+  });
+  it("disables the button when isLoading is true", () => {
+    render(
+      <OakSaveButton
+        isSaved={false}
+        isLoading={true}
+        onSave={() => console.log("Save action triggered")}
+        unavailable={false}
+        saveButtonId="save-button"
+        title="Test unit"
+      />,
+    );
+    const button = screen.getByRole("button", {
+      name: "Save this unit: Test unit",
+    });
+
+    expect(button).toBeDisabled();
+  });
+  it("disables the button when unavailable is true", () => {
+    render(
+      <OakSaveButton
+        isSaved={false}
+        isLoading={false}
+        onSave={() => console.log("Save action triggered")}
+        unavailable={true}
+        saveButtonId="save-button"
+        title="Test unit"
+      />,
+    );
+    const button = screen.getByRole("button", {
+      name: "Save this unit: Test unit",
+    });
+
+    expect(button).toBeDisabled();
+  });
+  it("calls onSave when the button is clicked", () => {
+    const mockOnSave = jest.fn();
+    render(
+      <OakSaveButton
+        isSaved={false}
+        isLoading={false}
+        onSave={mockOnSave}
+        unavailable={false}
+        saveButtonId="save-button"
+        title="Test unit"
+      />,
+    );
+    const button = screen.getByRole("button", {
+      name: "Save this unit: Test unit",
+    });
+
+    button.click();
+    expect(mockOnSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/molecules/OakSaveButton/OakSaveButton.tsx
+++ b/src/components/molecules/OakSaveButton/OakSaveButton.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { OakSmallTertiaryInvertedButton } from "../OakSmallTertiaryInvertedButton";
+
+export type OakSaveButtonProps = {
+  isSaved: boolean;
+  isLoading: boolean;
+  onSave: () => void;
+  unavailable?: boolean;
+  saveButtonId?: string;
+  title: string;
+};
+
+export const OakSaveButton = (props: OakSaveButtonProps) => {
+  const { isSaved, isLoading, onSave, unavailable, saveButtonId, title } =
+    props;
+  return (
+    <OakSmallTertiaryInvertedButton
+      iconName={isSaved ? "bookmark-filled" : "bookmark-outlined"}
+      isTrailingIcon
+      disabled={isLoading || unavailable}
+      onClick={onSave}
+      width="all-spacing-15"
+      $justifyContent="end"
+      aria-label={`${isSaved ? "Unsave" : "Save"} this unit: ${title} `}
+      id={saveButtonId}
+    >
+      {isSaved ? "Saved" : "Save"}
+    </OakSmallTertiaryInvertedButton>
+  );
+};

--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/atoms";
 import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
-import { OakSmallTertiaryInvertedButton } from "@/components/molecules";
+import { OakSaveButton } from "@/components/molecules/OakSaveButton/OakSaveButton";
 
 const FlexWithFocus = styled(OakFlex)`
   animation-timing-function: ease-out;
@@ -80,6 +80,7 @@ export type OakUnitListItemProps = {
   onClick?: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   onSave?: () => void;
   isSaved?: boolean;
+  isSaving?: boolean;
   saveButtonId?: string;
 };
 
@@ -97,6 +98,7 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
     isLegacy,
     onSave,
     isSaved,
+    isSaving,
     firstItemRef,
     saveButtonId,
     ...rest
@@ -188,22 +190,15 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
             )}
           </OakFlex>
         </FlexWithFocus>
-
         {onSave && (
-          <OakSmallTertiaryInvertedButton
-            iconName={isSaved ? "bookmark-filled" : "bookmark-outlined"}
-            isTrailingIcon
-            disabled={unavailable}
-            onClick={onSave}
-            width="all-spacing-15"
-            $justifyContent="end"
-            aria-label={`${isSaved ? "Unsave" : "Save"} this unit: ${
-              props.title
-            } `}
-            id={saveButtonId}
-          >
-            {isSaved ? "Saved" : "Save"}
-          </OakSmallTertiaryInvertedButton>
+          <OakSaveButton
+            onSave={onSave}
+            isSaved={isSaved ?? false}
+            isLoading={isSaving ?? false}
+            unavailable={unavailable}
+            saveButtonId={saveButtonId}
+            title={props.title}
+          />
         )}
       </StyledUnitListItem>
       {/* Mobile layout */}
@@ -268,17 +263,14 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
               {lessonCount}
             </OakP>
             {onSave && (
-              <OakSmallTertiaryInvertedButton
-                iconName={isSaved ? "bookmark-filled" : "bookmark-outlined"}
-                isTrailingIcon
-                disabled={unavailable}
-                onClick={onSave}
-                aria-label={`${isSaved ? "Unsave" : "Save"} this unit: ${
-                  props.title
-                } `}
-              >
-                {isSaved ? "Saved" : "Save"}
-              </OakSmallTertiaryInvertedButton>
+              <OakSaveButton
+                onSave={onSave}
+                isSaved={isSaved ?? false}
+                isLoading={isSaving ?? false}
+                unavailable={unavailable}
+                saveButtonId={saveButtonId}
+                title={props.title}
+              />
             )}
           </OakFlex>
         </OakFlex>

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.tsx
@@ -122,6 +122,7 @@ export type OakUnitListOptionalityItemProps = {
   firstItemRef: MutableRefObject<HTMLAnchorElement | null> | null | undefined;
   onSave?: (unitSlug: string) => void;
   getIsSaved?: (unitSlug: string) => boolean;
+  getIsSaving?: (unitSlug: string) => boolean;
   optionalityUnits: {
     title: string;
     slug: string;
@@ -150,6 +151,7 @@ export const OakUnitListOptionalityItem = (
     firstItemRef,
     onSave,
     getIsSaved,
+    getIsSaving,
     ...rest
   } = props;
 
@@ -235,6 +237,7 @@ export const OakUnitListOptionalityItem = (
                 unavailable={unavailable}
                 onSave={onSave ?? undefined}
                 isSaved={getIsSaved ? getIsSaved(unit.slug) : undefined}
+                isSaving={getIsSaving ? getIsSaving(unit.slug) : undefined}
               />
             </OakGridArea>
           ))}

--- a/src/components/organisms/teacher/OakUnitListOptionalityItemCard/OakUnitListOptionalityItemCard.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItemCard/OakUnitListOptionalityItemCard.tsx
@@ -4,7 +4,7 @@ import styled, { css } from "styled-components";
 import { OakFlex, OakSpan, OakHeading, OakIcon } from "@/components/atoms";
 import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
-import { OakSmallTertiaryInvertedButton } from "@/components/molecules";
+import { OakSaveButton } from "@/components/molecules/OakSaveButton/OakSaveButton";
 
 const StyledOptionalityListItem = styled(OakFlex)<{ $disabled?: boolean }>`
   outline: none;
@@ -67,6 +67,7 @@ export type OakUnitListOptionalityItemCardProps = {
   onClick?: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
   onSave?: (unitSlug: string) => void;
   isSaved?: boolean;
+  isSaving?: boolean;
 };
 
 const HeadingWithFocus = styled(OakHeading)`
@@ -100,6 +101,7 @@ export const OakUnitListOptionalityItemCard = (
     firstItemRef,
     onClick,
     isSaved,
+    isSaving,
     onSave,
     ...rest
   } = props;
@@ -156,17 +158,14 @@ export const OakUnitListOptionalityItemCard = (
               )}
             </OakFlex>
             {onSave && (
-              <OakSmallTertiaryInvertedButton
-                iconName={isSaved ? "bookmark-filled" : "bookmark-outlined"}
-                isTrailingIcon
-                disabled={unavailable}
-                onClick={() => onSave(props.slug)}
-                aria-label={`${isSaved ? "Unsave" : "Save"} this unit: ${
-                  props.title
-                } `}
-              >
-                {isSaved ? "Saved" : "Save"}
-              </OakSmallTertiaryInvertedButton>
+              <OakSaveButton
+                isSaved={isSaved ?? false}
+                isLoading={isSaving ?? false}
+                onSave={() => onSave(props.slug)}
+                unavailable={unavailable}
+                saveButtonId={`save-button-${props.slug}`}
+                title={props.title}
+              />
             )}
           </OakFlex>
         </OakFlex>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- Adds a loading state (disabled) to the save button on unit listing cards
- Extracted the button into a standalone component

## Link to the design doc

## A link to the component in the deployment preview
https://deploy-preview-444--lively-meringue-8ebd43.netlify.app/?path=/story/components-molecules-oaksavebutton--default

## Testing instructions
Toggle isSaved, isLoading and unavailable to the see the button states
