### PR TITLE
Added missing `alt="Error"` to `<OakFieldError/>`

### DIFF
--- a/src/components/molecules/OakFieldError/OakFieldError.tsx
+++ b/src/components/molecules/OakFieldError/OakFieldError.tsx
@@ -24,7 +24,7 @@ export const OakFieldError = (props: OakFieldErrorProps) => {
   return (
     <OakFlex $alignItems={"center"} $flexDirection={"row"}>
       <OakFlex $alignSelf={"flex-start"} $mr={"space-between-s"}>
-        <OakIcon iconName="content-guidance" $colorFilter={"red"} />
+        <OakIcon alt="Error" iconName="content-guidance" $colorFilter={"red"} />
       </OakFlex>
       <OakSpan $color="red">{children}</OakSpan>
     </OakFlex>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions
Check that the error icon in the `<OakFieldError/>` has alt text "Error"

## ACs

 - `<OakFieldError/>` has alt text "Error"
