### PR TITLE
fix: remove id from hidden mobile button to prevent a11y duplicate error

### DIFF
--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
@@ -268,7 +268,6 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
                 isSaved={isSaved ?? false}
                 isLoading={isSaving ?? false}
                 unavailable={unavailable}
-                saveButtonId={saveButtonId}
                 title={props.title}
               />
             )}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
- I'm not sure why, but extracting the save button into its own component caused an issue with the [id not being unique anymore](https://github.com/oaknational/Oak-Web-Application/actions/runs/16022652423/job/45203060422#step:6:125) - we do have two buttons with the id in the dom but one is the child of a parent with `display:none` (one desktop, one mobile) so I don't think it should be causing an issue a11y wise 🤷‍♀️ 
- luckily we don't need the id on mobile as it's to handle focus on desktop, so removing the mobile id should fix this


