### PR TITLE
[ENG-1255] Put components live on vercel

### DIFF
--- a/infrastructure/project/main.tf
+++ b/infrastructure/project/main.tf
@@ -23,5 +23,5 @@ module "vercel" {
   protection_bypass_for_automation = false
   skew_protection                  = "1 day"
 
-  domains = ["components-vercel.thenational.academy"]
+  domains = ["components.thenational.academy"]
 }


### PR DESCRIPTION
## Description
- Put Components live on `vercel`
- Removed components `netlify` in [cloud-config](https://github.com/oaknational/Cloud-Config/pull/413) so we can make it live on `vercel` as we can have 2 same subdomain existing

## Issue(s)
[ENG-1255](https://www.notion.so/oaknationalacademy/Set-up-CMS-in-Vercel-with-Terraform-21826cc4e1b18082b69febcc9311192f)