### PR TITLE
Add optional prop to override OakLink color

### DIFF
--- a/src/components/molecules/OakLink/OakLink.test.tsx
+++ b/src/components/molecules/OakLink/OakLink.test.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "styled-components";
 import { OakLink } from "./OakLink";
 
 import { oakDefaultTheme } from "@/styles";
+import renderWithTheme from "@/test-helpers/renderWithTheme";
 
 describe("OakLink", () => {
   it("matches snapshot", () => {
@@ -16,5 +17,13 @@ describe("OakLink", () => {
     ).toJSON();
 
     expect(tree).toMatchSnapshot();
+  });
+  it("overrides default colors with colorOverride prop", () => {
+    const { getByText } = renderWithTheme(
+      <OakLink colorOverride="text-primary">Hello</OakLink>,
+    );
+
+    const link = getByText("Hello");
+    expect(link).toHaveStyle("color: rgb(34, 34, 34)");
   });
 });

--- a/src/components/molecules/OakLink/OakLink.tsx
+++ b/src/components/molecules/OakLink/OakLink.tsx
@@ -1,6 +1,6 @@
 import React, { ElementType, forwardRef } from "react";
 
-import { OakAllSpacingToken } from "@/styles";
+import { OakAllSpacingToken, OakCombinedColorToken } from "@/styles";
 import {
   InternalLink,
   InternalLinkProps,
@@ -16,6 +16,11 @@ export type OakLinkProps = Pick<
 > & {
   iconWidth?: OakAllSpacingToken;
   iconHeight?: OakAllSpacingToken;
+  /**
+   * Overrides the default link color and all its states (hover, active, disabled, visited)
+   * with the provided OakCombinedColorToken.
+   */
+  colorOverride?: OakCombinedColorToken;
 };
 
 type OakLinkComponent = <C extends React.ElementType = "a">(
@@ -26,6 +31,8 @@ type OakLinkComponent = <C extends React.ElementType = "a">(
  * A blue link with an optional icon and loading state.
  *
  * Defaulting to a `HTMLAnchorElement` this component is polymorphic and can be rendered as a button or any other element.
+ *
+ * @prop colorOverride - Overrides the default link color and its states (hover, active, disabled, visited) with the provided OakColorToken.
  */
 export const OakLink: OakLinkComponent = forwardRef(
   <C extends ElementType = "a">(
@@ -34,11 +41,19 @@ export const OakLink: OakLinkComponent = forwardRef(
   ) => {
     return (
       <InternalLink
-        color="text-link-active"
-        hoverColor="text-link-hover"
-        activeColor="text-link-pressed"
-        disabledColor="text-disabled"
-        visitedColor="text-link-visited"
+        color={props.colorOverride ? props.colorOverride : "text-link-active"}
+        hoverColor={
+          props.colorOverride ? props.colorOverride : "text-link-hover"
+        }
+        activeColor={
+          props.colorOverride ? props.colorOverride : "text-link-pressed"
+        }
+        disabledColor={
+          props.colorOverride ? props.colorOverride : "text-disabled"
+        }
+        visitedColor={
+          props.colorOverride ? props.colorOverride : "text-link-visited"
+        }
         {...props}
         ref={ref}
       />


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

In order to deprecate `OwaLink` we need to update the `OakLink` component to override the default blue color. I thought about a more granular approach, with props for each state the link can be in, and also a more blunt approach where it accepted a boolean to turn the text black. I settled on this, but open to going a different way.

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
