### PR TITLE
Fix size/spacing of `<OakRadioButton/>` when styled

### DIFF
--- a/src/components/molecules/OakRadioButton/OakRadioButton.tsx
+++ b/src/components/molecules/OakRadioButton/OakRadioButton.tsx
@@ -119,6 +119,7 @@ export const OakRadioButton = forwardRef<HTMLInputElement, OakRadioButtonProps>(
             radioInnerSize={radioInnerSize}
             radioOuterSize={radioOuterSize}
             radioBorderWidth={radioBorderWidth}
+            size={radioOuterSize}
             radioBackground={radioBackground}
             checkedRadioBorderWidth={checkedRadioBorderWidth}
             internalRadio={

--- a/src/components/organisms/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
@@ -19,8 +19,8 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
 
 .c6 {
   position: relative;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 2rem;
+  height: 2rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Fixes a bug with spacing introduced in #454

Before

https://oak-components-storybook-git-fix-internalradiowrapper-sp-84c85c.vercel-preview.thenational.academy/?path=/docs/components-organisms-pupil-quiz-oakquizradiobutton--docs

<img width="1013" height="206" alt="Screenshot 2025-07-30 at 14 48 49" src="https://github.com/user-attachments/assets/d1176a8b-cca8-41b2-8370-f0194da9232d" />

After https://components.thenational.academy/?path=/docs/components-organisms-pupil-quiz-oakquizradiobutton--docs

<img width="1013" height="206" alt="Screenshot 2025-07-30 at 14 48 34" src="https://github.com/user-attachments/assets/e6b141ed-1bb4-4c70-9a70-5408f6870dd5" />

## Link to the design doc
n/a

## A link to the component in the deployment preview
https://oak-components-storybook-git-fix-internalradiowrapper-sp-84c85c.vercel-preview.thenational.academy/

## Testing instructions

## ACs
