### PR TITLE
Allow wrapped height to stretch in <OakDownloadCard/>

### DIFF
--- a/src/components/atoms/InternalRadioWrapper/InternalRadioWrapper.tsx
+++ b/src/components/atoms/InternalRadioWrapper/InternalRadioWrapper.tsx
@@ -45,6 +45,10 @@ export type InternalRadioWrapperProps = {
    * Allows the width of the radio button border to be customized when the radio button is checked.
    */
   checkedRadioBorderWidth?: OakBorderWidthToken;
+  /**
+   * Allows the borderColor of the radio button border to be customized.
+   */
+  radioBorderColor?: OakCombinedColorToken;
 };
 
 type VisibleRadioButtonInputProps = OakFlexProps & {
@@ -114,6 +118,7 @@ export const InternalRadioWrapper = (props: InternalRadioWrapperProps) => {
     radioInnerSize = "all-spacing-4",
     radioOuterSize = "all-spacing-6",
     radioBorderWidth = "border-solid-m",
+    radioBorderColor = "black",
     radioBackground = "bg-primary",
     checkedRadioBorderWidth = "border-solid-m",
     checked,
@@ -130,7 +135,7 @@ export const InternalRadioWrapper = (props: InternalRadioWrapperProps) => {
           $height={radioOuterSize}
           $width={radioOuterSize}
           $ba={finalRadioBorderWidth}
-          $borderColor={"black"}
+          $borderColor={radioBorderColor}
           $flexGrow={0}
           $flexShrink={0}
           $alignItems={"center"}

--- a/src/components/molecules/OakDownloadCard/OakDownloadCard.stories.tsx
+++ b/src/components/molecules/OakDownloadCard/OakDownloadCard.stories.tsx
@@ -136,6 +136,5 @@ export const WrappingHeight: Story = {
     value: "a test value",
     formatSlot: "PPTX",
     fileSizeSlot: "200kb",
-    checked: true,
   },
 };

--- a/src/components/molecules/OakDownloadCard/OakDownloadCard.stories.tsx
+++ b/src/components/molecules/OakDownloadCard/OakDownloadCard.stories.tsx
@@ -120,3 +120,22 @@ export const Disabled: Story = {
     checked: true,
   },
 };
+
+export const WrappingHeight: Story = {
+  render: (args) => (
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+      <OakDownloadCard
+        {...args}
+        titleSlot="A very very very very very long title on in the card so it wraps"
+      />
+      <OakDownloadCard {...args} titleSlot="Short title" />
+    </div>
+  ),
+  args: {
+    iconName: "book-steps",
+    value: "a test value",
+    formatSlot: "PPTX",
+    fileSizeSlot: "200kb",
+    checked: true,
+  },
+};

--- a/src/components/molecules/OakDownloadCard/OakDownloadCard.tsx
+++ b/src/components/molecules/OakDownloadCard/OakDownloadCard.tsx
@@ -95,9 +95,10 @@ export const OakDownloadCard = (props: OakDownloadCardProps) => {
       $borderRadius={"border-radius-s"}
       $overflow={"hidden"}
       $hoverBackground="bg-btn-secondary-hover"
+      $color={"black"}
     >
       <LabelContainer>
-        <OakFlex $alignItems={"center"} $flexGrow={1}>
+        <OakFlex $alignItems={"flex-start"} $flexGrow={1}>
           <OakFlex
             $background={"lemon"}
             $pa={"inner-padding-s"}
@@ -121,6 +122,8 @@ export const OakDownloadCard = (props: OakDownloadCardProps) => {
             {fileSizeSlot && <OakBox $font={"body-3"}>{fileSizeSlot}</OakBox>}
             <OakBox $font={"body-3"}>{formatSlot}</OakBox>
           </OakFlex>
+        </OakFlex>
+        <OakFlex>
           <OakFlex $alignItems={"center"} $pr={"inner-padding-m"}>
             {asRadio && (
               <InternalRadioWrapper

--- a/src/components/molecules/OakDownloadCard/OakDownloadCard.tsx
+++ b/src/components/molecules/OakDownloadCard/OakDownloadCard.tsx
@@ -25,6 +25,12 @@ export type OakDownloadCardProps = BaseCheckBoxProps & {
   asRadio?: boolean;
 } & InternalCheckBoxLabelProps;
 
+const LabelContainer = styled("label")`
+  flex: 1;
+  cursor: pointer;
+  display: flex;
+`;
+
 const Container = styled(OakFlex)<{ $hoverBackground: OakCombinedColorToken }>`
   cursor: pointer;
 
@@ -90,12 +96,13 @@ export const OakDownloadCard = (props: OakDownloadCardProps) => {
       $overflow={"hidden"}
       $hoverBackground="bg-btn-secondary-hover"
     >
-      <label style={{ flex: 1, cursor: "pointer" }}>
-        <OakFlex>
+      <LabelContainer>
+        <OakFlex $alignItems={"center"} $flexGrow={1}>
           <OakFlex
             $background={"lemon"}
             $pa={"inner-padding-s"}
             $alignItems={"center"}
+            $alignSelf={"stretch"}
           >
             <OakIcon
               iconName={iconName}
@@ -120,6 +127,7 @@ export const OakDownloadCard = (props: OakDownloadCardProps) => {
                 checked={value === radioContext.currentValue}
                 size={checkboxSize}
                 disabled={anyDisabled}
+                radioBorderColor={checkedBorderColor}
                 internalRadio={
                   <InternalRadio
                     {...rest}
@@ -162,7 +170,7 @@ export const OakDownloadCard = (props: OakDownloadCardProps) => {
             )}
           </OakFlex>
         </OakFlex>
-      </label>
+      </LabelContainer>
     </Container>
   );
 };

--- a/src/components/molecules/OakDownloadCard/__snapshots__/OakDownloadCard.test.tsx.snap
+++ b/src/components/molecules/OakDownloadCard/__snapshots__/OakDownloadCard.test.tsx.snap
@@ -10,17 +10,17 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   overflow: hidden;
 }
 
-.c3 {
+.c4 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c6 {
   padding: 0.75rem;
   background: #ffe555;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 3rem;
   min-width: 3rem;
@@ -29,7 +29,7 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c10 {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.75rem;
@@ -37,7 +37,7 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c12 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
@@ -48,7 +48,7 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c11 {
+.c13 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -59,19 +59,19 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c12 {
+.c14 {
   padding-right: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c16 {
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c22 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -81,7 +81,7 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c24 {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -90,11 +90,11 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c9 {
   object-fit: contain;
 }
 
-.c22 {
+.c25 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
@@ -116,9 +116,27 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
-.c9 {
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+}
+
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -134,6 +152,17 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
 }
 
 .c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c18 {
   -webkit-appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -149,26 +178,37 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   border-color: #808080;
 }
 
-.c15:checked {
+.c18:checked {
   background: #222222;
   border-color: #222222;
 }
 
-.c15:disabled {
+.c18:disabled {
   pointer-events: none;
 }
 
-.c17:focus-visible {
+.c20:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c20 {
+.c23 {
   pointer-events: none;
   opacity: 0;
 }
 
-input:checked + .c18 {
+input:checked + .c21 {
   opacity: 1;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c2 {
@@ -180,13 +220,13 @@ input:checked + .c18 {
 }
 
 @media (hover:hover) {
-  .c15:hover:not(:disabled) {
+  .c18:hover:not(:disabled) {
     border-color: #222222;
   }
 }
 
 @media (hover:hover) {
-  .c16:hover:not(.c14:checked):not(.c14:disabled)::after {
+  .c19:hover:not(.c17:checked):not(.c17:disabled)::after {
     content: "";
     position: absolute;
     top: 50%;
@@ -211,25 +251,20 @@ input:checked + .c18 {
   className="c0 c1 c2"
 >
   <label
-    style={
-      {
-        "cursor": "pointer",
-        "flex": 1,
-      }
-    }
+    className="c3"
   >
     <div
-      className="c3 c1"
+      className="c4 c5"
     >
       <div
-        className="c4 c5"
+        className="c6 c7"
       >
         <div
-          className="c6"
+          className="c8"
         >
           <img
             alt=""
-            className="c7"
+            className="c9"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -254,32 +289,32 @@ input:checked + .c18 {
         </div>
       </div>
       <div
-        className="c8 c9"
+        className="c10 c11"
       >
         <div
-          className="c10"
+          className="c12"
         >
           TITLE
         </div>
         <div
-          className="c11"
+          className="c13"
         >
           FILE_SIZE
         </div>
         <div
-          className="c11"
+          className="c13"
         >
           FORMAT
         </div>
       </div>
       <div
-        className="c12 c5"
+        className="c14 c15"
       >
         <div
-          className="c13"
+          className="c16"
         >
           <input
-            className="c14 c15 c16 c17"
+            className="c17 c18 c19 c20"
             disabled={false}
             id="checkbox-1"
             name="default"
@@ -289,14 +324,14 @@ input:checked + .c18 {
             value="Option 1"
           />
           <div
-            className="c18 c19 c20"
+            className="c21 c22 c23"
           >
             <div
-              className="c21"
+              className="c24"
             >
               <img
                 alt=""
-                className="c22"
+                className="c25"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -337,17 +372,17 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   overflow: hidden;
 }
 
-.c3 {
+.c4 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c4 {
+.c6 {
   padding: 0.75rem;
   background: #ffe555;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 3rem;
   min-width: 3rem;
@@ -356,7 +391,7 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c10 {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.75rem;
@@ -364,7 +399,7 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c12 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
@@ -375,7 +410,7 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c11 {
+.c13 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -386,19 +421,19 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c12 {
+.c14 {
   padding-right: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c16 {
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c22 {
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -408,7 +443,7 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c24 {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -417,11 +452,11 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c9 {
   object-fit: contain;
 }
 
-.c22 {
+.c25 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
@@ -443,9 +478,27 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
-.c9 {
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+}
+
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -461,6 +514,17 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
 }
 
 .c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c18 {
   -webkit-appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -476,26 +540,37 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   border-color: #808080;
 }
 
-.c15:checked {
+.c18:checked {
   background: #222222;
   border-color: #222222;
 }
 
-.c15:disabled {
+.c18:disabled {
   pointer-events: none;
 }
 
-.c17:focus-visible {
+.c20:focus-visible {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c20 {
+.c23 {
   pointer-events: none;
   opacity: 0;
 }
 
-input:checked + .c18 {
+input:checked + .c21 {
   opacity: 1;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c2 {
@@ -507,13 +582,13 @@ input:checked + .c18 {
 }
 
 @media (hover:hover) {
-  .c15:hover:not(:disabled) {
+  .c18:hover:not(:disabled) {
     border-color: #222222;
   }
 }
 
 @media (hover:hover) {
-  .c16:hover:not(.c14:checked):not(.c14:disabled)::after {
+  .c19:hover:not(.c17:checked):not(.c17:disabled)::after {
     content: "";
     position: absolute;
     top: 50%;
@@ -538,25 +613,20 @@ input:checked + .c18 {
   className="c0 c1 c2"
 >
   <label
-    style={
-      {
-        "cursor": "pointer",
-        "flex": 1,
-      }
-    }
+    className="c3"
   >
     <div
-      className="c3 c1"
+      className="c4 c5"
     >
       <div
-        className="c4 c5"
+        className="c6 c7"
       >
         <div
-          className="c6"
+          className="c8"
         >
           <img
             alt=""
-            className="c7"
+            className="c9"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -581,27 +651,27 @@ input:checked + .c18 {
         </div>
       </div>
       <div
-        className="c8 c9"
+        className="c10 c11"
       >
         <div
-          className="c10"
+          className="c12"
         >
           TITLE
         </div>
         <div
-          className="c11"
+          className="c13"
         >
           FORMAT
         </div>
       </div>
       <div
-        className="c12 c5"
+        className="c14 c15"
       >
         <div
-          className="c13"
+          className="c16"
         >
           <input
-            className="c14 c15 c16 c17"
+            className="c17 c18 c19 c20"
             disabled={false}
             id="checkbox-1"
             name="default"
@@ -611,14 +681,14 @@ input:checked + .c18 {
             value="Option 1"
           />
           <div
-            className="c18 c19 c20"
+            className="c21 c22 c23"
           >
             <div
-              className="c21"
+              className="c24"
             >
               <img
                 alt=""
-                className="c22"
+                className="c25"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"

--- a/src/components/molecules/OakDownloadCard/__snapshots__/OakDownloadCard.test.tsx.snap
+++ b/src/components/molecules/OakDownloadCard/__snapshots__/OakDownloadCard.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
 .c0 {
   overflow: hidden;
+  color: #222222;
   background: #ffffff;
   border: 0.125rem solid;
   border-radius: 0.25rem;
@@ -112,10 +113,10 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -307,6 +308,10 @@ input:checked + .c21 {
           FORMAT
         </div>
       </div>
+    </div>
+    <div
+      className="c4 c1"
+    >
       <div
         className="c14 c15"
       >
@@ -365,6 +370,7 @@ input:checked + .c21 {
 exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
 .c0 {
   overflow: hidden;
+  color: #222222;
   background: #ffffff;
   border: 0.125rem solid;
   border-radius: 0.25rem;
@@ -474,10 +480,10 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -664,6 +670,10 @@ input:checked + .c21 {
           FORMAT
         </div>
       </div>
+    </div>
+    <div
+      className="c4 c1"
+    >
       <div
         className="c14 c15"
       >


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Allow `<OakDownloadCard/>`s to flex to the full height

<img width="940" height="223" alt="Screenshot 2025-07-31 at 10 13 09" src="https://github.com/user-attachments/assets/5c465038-13b4-4f3f-85b0-a5e20fb21fdc" />

Also fixed color of radio button

## Link to the design doc
https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=14795-5603

## A link to the component in the deployment preview
https://oak-components-storybook-git-fix-cur-618-download-card-r-3cf31a.vercel-preview.thenational.academy/?path=/docs/components-molecules-oakdownloadcard--docs

## Testing instructions
Check over `<OakDownloadCard/>` to check wrapping height works correctly. Check for any regressions in this component.

Also verify color of radio button is correct


## ACs
