### PR TITLE
fix: unit list accessibility issues [LESQ-1465]

### DIFF
--- a/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListItem/OakUnitListItem.tsx
@@ -8,6 +8,7 @@ import {
   OakLI,
   OakBox,
   OakIcon,
+  OakSpan,
 } from "@/components/atoms";
 import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
@@ -142,13 +143,12 @@ export const OakUnitListItem = (props: OakUnitListItemProps) => {
             $minWidth="all-spacing-11"
             $alignSelf="stretch"
           >
-            <OakHeading
-              tag="h3"
+            <OakSpan
               $font={"heading-5"}
               $color={unavailable ? "text-disabled" : "text-primary"}
             >
               {index}
-            </OakHeading>
+            </OakSpan>
           </StyledOakIndexBox>
           <OakFlex $pv="inner-padding-l" $pr="inner-padding-m" $flexGrow={1}>
             <OakP

--- a/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c30 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -215,7 +215,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c11 {
+.c30 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -225,6 +225,18 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   -ms-letter-spacing: 0.0115rem;
   letter-spacing: 0.0115rem;
   color: #222222;
+}
+
+.c11 {
+  color: #222222;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1.5rem;
+  line-height: 2rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c0 {
@@ -267,7 +279,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   white-space: nowrap;
 }
 
-.c31 {
+.c32 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -373,11 +385,11 @@ exports[`OakUnitListItem matches snapshot 1`] = `
         <div
           className="c7 c8 c9 c10"
         >
-          <h3
+          <span
             className="c11"
           >
             1
-          </h3>
+          </span>
         </div>
         <div
           className="c12 c13"
@@ -449,7 +461,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
             className="c28 c29"
           >
             <h3
-              className="c11"
+              className="c30"
             >
               1
             </h3>
@@ -465,13 +477,13 @@ exports[`OakUnitListItem matches snapshot 1`] = `
           </div>
         </a>
         <div
-          className="c26 c30"
+          className="c26 c31"
         >
           <p
-            className="c31"
+            className="c32"
           />
           <p
-            className="c31"
+            className="c32"
           >
             0 lessons
           </p>

--- a/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsContainer/__snapshots__/OakUnitsContainer.test.tsx.snap
@@ -420,11 +420,11 @@ exports[`OakUnitsContainer matches snapshot 1`] = `
       <div
         className="c2 c6"
       >
-        <h2
+        <h3
           className="c7"
         >
           maths units
-        </h2>
+        </h3>
         <div
           className="c8 c9 c10"
         >

--- a/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
+++ b/src/components/organisms/teacher/OakUnitsHeader/OakUnitsHeader.tsx
@@ -68,7 +68,7 @@ const UnstyledComponent = (props: OakUnitsHeaderProps) => {
       >
         <OakFlex $gap="space-between-ssx" $flexDirection="column">
           <OakFlex $gap="space-between-ssx">
-            <OakHeading $font="heading-5" tag="h2" $color={"text-primary"}>
+            <OakHeading $font="heading-5" tag="h3" $color={"text-primary"}>
               {isCustomUnit && customHeadingText
                 ? customHeadingText
                 : standardHeadingText}

--- a/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitsHeader/__snapshots__/OakUnitsHeader.test.tsx.snap
@@ -371,11 +371,11 @@ exports[`OakUnitsHeader matches snapshot 1`] = `
     <div
       className="c0 c3"
     >
-      <h2
+      <h3
         className="c4"
       >
         maths units
-      </h2>
+      </h3>
       <div
         className="c5 c6 c7"
       >
@@ -839,11 +839,11 @@ exports[`OakUnitsHeader matches snapshot with banner 1`] = `
       <div
         className="c0 c3"
       >
-        <h2
+        <h3
           className="c4"
         >
           maths units
-        </h2>
+        </h3>
         <div
           className="c5 c6 c7"
         >


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

- Update `OakUnitHeader` heading to h3
- Update `OakUnitListItem` numbers to `OakSpan` (to match existing `OakUnitListOptionalityItem`)

## Link to the design doc

## A link to the component in the deployment preview

[OakUnitsHeader](https://oak-components-storybook-git-fix-lesq-1465unit-listing-headings.vercel-preview.thenational.academy/?path=/docs/components-organisms-teacher-oakunitsheader--docs)
[OakUnitListItem](https://oak-components-storybook-git-fix-lesq-1465unit-listing-headings.vercel-preview.thenational.academy/?path=/docs/components-organisms-teacher-oakunitlistitem--docs)

## Testing instructions

- Check the heading in `OakUnitsHeader` is `h3`
- Check the unit numbers in `OakUnitListItem` are `span`

## ACs
