### PR TITLE
fix: unit list optionality item heading

### DIFF
--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.tsx
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/OakUnitListOptionalityItem.tsx
@@ -106,7 +106,7 @@ const StyledUnitHeading = ({
       <OakHeading
         $color={unavailable ? "text-disabled" : "text-primary"}
         $font={"heading-7"}
-        tag="h3"
+        tag="h4"
       >
         {children}
       </OakHeading>

--- a/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
+++ b/src/components/organisms/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
@@ -490,7 +490,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
       <div
         className="c7 c8"
       >
-        <h3
+        <h4
           className="c9"
         />
       </div>
@@ -516,7 +516,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
           <div
             className="c7 c8"
           >
-            <h3
+            <h4
               className="c9"
             />
           </div>
@@ -551,7 +551,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
           <div
             className="c7 c8"
           >
-            <h3
+            <h4
               className="c9"
             />
           </div>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

- Update `OakUnitListOptionalityItem` heading to `h4`

## Link to the design doc

## A link to the component in the deployment preview

[OakUnitListOptionalityItem](https://oak-components-storybook-git-fix-lesq-1465unit-list-opti-0927cb.vercel-preview.thenational.academy/?path=/docs/components-organisms-teacher-oakunitlistoptionalityitem--docs)

## Testing instructions

- Check `OakUnitListOptionalityItem` unit heading is `h4`

## ACs
