### PR TITLE
[ENG1244] Monolith sensitive variables

### DIFF
--- a/infrastructure/project/locals.tf
+++ b/infrastructure/project/locals.tf
@@ -16,14 +16,20 @@ locals {
     ]
   ])
 
+sensitive_env_vars = {
+    shared = {}
+    prod    = {}
+    preview = {}
+  }
+
   sensitive_vars = flatten([
     for group, target in local.env_groups : [
-      for key, value in var.sensitive_env_vars[group] : {
+      for key, value in local.sensitive_env_vars[group] : {
         key       = key
         value     = value
         target    = target
         sensitive = true
-      }
+      } if value != null
     ]
   ])
 

--- a/infrastructure/project/main.tf
+++ b/infrastructure/project/main.tf
@@ -12,7 +12,7 @@ resource "terraform_data" "workspace_validation" {
 }
 
 module "vercel" {
-  source                           = "github.com/oaknational/oak-terraform-modules//modules/vercel_project?ref=v1.2.1"
+  source                           = "github.com/oaknational/oak-terraform-modules//modules/vercel_project?ref=v1.2.6"
   build_command                    = "npm run build-storybook"
   build_type                       = "storybook"
   cloudflare_zone_domain           = var.cloudflare_zone_domain

--- a/infrastructure/project/variables.tf
+++ b/infrastructure/project/variables.tf
@@ -14,12 +14,3 @@ variable "env_vars" {
     preview = object({})
   })
 }
-
-variable "sensitive_env_vars" {
-  type = object({
-    shared  = object({})
-    prod    = object({})
-    preview = object({})
-  })
-  sensitive = true
-}


### PR DESCRIPTION
## Description

- Currently, we need to know all the values of `sensitive env var` object when we add/update a single var because TFC hides sensitive values. This ticket breaks down the monolithic `sensitive env vars` object into individual variables, making it easier to update single sensitive values without knowing all others

## Issue(s)

[ENG-1244 ](https://www.notion.so/oaknationalacademy/Better-sensitive-variable-handling-in-Vercel-projects-21826cc4e1b1804897f6ea2237d0fab0)

## How to test

1. You should see `no changes `when you run `terraform plan`

## Checklist

- [ ] terraform apply