### PR TITLE
Add curriculum plan and national curriculum spreadsheet icons

### DIFF
--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -74,6 +74,8 @@ export const icons = {
   "book-steps": "v1749034739/icons/book-steps_qwku6h.svg",
   "free-tag": "v1749033815/icons/free-tag_lijptf.svg",
   threads: "v1749034800/icons/threads_sqlqoe.svg",
+  spreadsheet: "v1754386968/icons/spreadsheet_rsndeb.svg",
+  "curriculum-plan": "v1754386969/icons/curriculum-plan_qygyuo.svg",
   // subject icons
   "subject-art": "v1706616347/subject-icons/art.svg",
   "subject-biology": "v1706616415/subject-icons/biology.svg",


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitive files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Added new icons for the curriculum plan and national curriculum spreadsheet.

## Link to the design doc

[CUR-1152](https://www.notion.so/oaknationalacademy/Icon-on-download-page-incorrect-24126cc4e1b180e8b328cb4da7c5e4a2?v=d9869bab5f8a4e28a7a960d37f6ab31e&source=copy_link)

## A link to the component in the deployment preview

https://oak-components-storybook-git-feat-add-new-curric-plan-sp-7afa07.vercel-preview.thenational.academy/?path=/docs/components-atoms-oakicon--docs

## Testing instructions

Check that the icons exist on the `OakIcons` component in Storybook

## ACs

1. You can select the `spreadsheet` icon and it appears correctly
2. You can select the `curriculum-plan` icon and it appears correctly