### PR TITLE
fix: added a defaultValue prop from formInput upwards

### DIFF
--- a/src/components/molecules/OakFormInput/OakFormInput.stories.tsx
+++ b/src/components/molecules/OakFormInput/OakFormInput.stories.tsx
@@ -47,3 +47,9 @@ export const Invalid: Story = {
     invalid: true,
   },
 };
+
+export const DefaultText: Story = {
+  args: {
+    defaultValue: "A default text value",
+  },
+};

--- a/src/components/molecules/OakFormInputWithLabels/OakFormInputWithLabels.stories.tsx
+++ b/src/components/molecules/OakFormInputWithLabels/OakFormInputWithLabels.stories.tsx
@@ -67,3 +67,11 @@ export const Disabled: Story = {
     disabled: true,
   },
 };
+
+export const DefaultValue: Story = {
+  args: {
+    label: "Email Address",
+    placeholder: "Enter your email",
+    defaultValue: "test@example.com",
+  },
+};

--- a/src/components/molecules/OakFormInputWithLabels/OakFormInputWithLabels.tsx
+++ b/src/components/molecules/OakFormInputWithLabels/OakFormInputWithLabels.tsx
@@ -31,6 +31,10 @@ export interface OakFormInputWithLabelsProps {
 
   value?: string;
   /**
+   * The initial value of the input field. Use this in controlled components.
+   */
+  defaultValue?: string;
+  /**
    * Disables the input field, preventing user interaction.
    */
   disabled?: boolean;
@@ -64,6 +68,7 @@ export const OakFormInputWithLabels = ({
   inputName,
   disabled = false,
   required = false,
+  defaultValue,
   onChange = () => {},
   onInitialFocus = () => {},
   onBlur = () => {},
@@ -88,6 +93,7 @@ export const OakFormInputWithLabels = ({
         onBlur={onBlur}
         disabled={disabled}
         aria-describedby={invalid ? `error-${inputId}` : undefined}
+        defaultValue={defaultValue}
         required={required}
       />
       {invalid && invalidText && (

--- a/src/components/organisms/create/OakCaptionSearch/OakCaptionSearch.stories.tsx
+++ b/src/components/organisms/create/OakCaptionSearch/OakCaptionSearch.stories.tsx
@@ -43,3 +43,10 @@ export const Loading: Story = {
     isLoading: true,
   },
 };
+
+export const DefaultValue: Story = {
+  render: (args) => <OakCaptionSearch {...args} />,
+  args: {
+    defaultValue: "test-caption-id",
+  },
+};

--- a/src/components/organisms/create/OakCaptionSearch/OakCaptionSearch.tsx
+++ b/src/components/organisms/create/OakCaptionSearch/OakCaptionSearch.tsx
@@ -5,6 +5,7 @@ import { OakPrimaryButton } from "@/components/molecules";
 import { OakFormInputWithLabels } from "@/components/molecules/OakFormInputWithLabels/OakFormInputWithLabels";
 
 export interface OakCaptionSearchProps {
+  defaultValue?: string;
   /**
    * Callback function that is called when the search is submitted.
    * It receives the caption ID string as an argument.
@@ -29,6 +30,7 @@ export const OakCaptionSearch = ({
   hasError,
   errorText,
   isLoading = false,
+  defaultValue,
 }: OakCaptionSearchProps) => {
   const handleFormSubmit = (event: React.FormEvent) => {
     // NB. we don't handle caption ID validation here to remain decoupled from the application logic
@@ -62,6 +64,7 @@ export const OakCaptionSearch = ({
         invalid={hasError}
         invalidText={errorText}
         disabled={isLoading}
+        defaultValue={defaultValue}
         required
       />
       <OakPrimaryButton

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -2,3 +2,4 @@ export * from "./teacher";
 export * from "./pupil";
 export * from "./curriculum";
 export * from "./shared";
+export * from "./create";


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Fixes
- Missing export of create folder in organisms
- Exposed defaultValue prop in OakFormInput, OakFormInputWithLabels, OakCaptionSearch
