### PR TITLE
fix: add learning cycle and played status to oakmediaclip aria label [LESQ-1459]

### DIFF
--- a/src/components/organisms/shared/OakMediaClip/OakMediaClip.tsx
+++ b/src/components/organisms/shared/OakMediaClip/OakMediaClip.tsx
@@ -175,7 +175,11 @@ export const OakMediaClip = ({
 }: OakMediaClipProps) => {
   const buttonStyles = getButtonStyles(muxPlayingState);
   const formattedTimeCode = formatTimeCode(timeCode);
-  const [minutes, seconds] = formattedTimeCode.split(":");
+  const buttonAriaLabel = `${isAudioClip ? "Audio" : "Video"} - ${clipName}${
+    learningCycle ? ` - ${learningCycle}` : ""
+  }, length: ${formattedTimeCode}${
+    muxPlayingState === "played" ? `, Played` : ""
+  }`;
 
   return (
     <OakLI $mb={"space-between-ssx"}>
@@ -223,7 +227,7 @@ export const OakMediaClip = ({
           onClick={onClick}
           $pa={"inner-padding-xs"}
           $muxPlayingState={muxPlayingState}
-          aria-label={`Media clip: ${clipName}, length: ${minutes} minutes and ${seconds} seconds`}
+          aria-label={buttonAriaLabel}
         >
           <OakFlex
             $flexDirection={"row"}

--- a/src/components/organisms/shared/OakMediaClip/__snapshots__/OakMediaClip.test.tsx.snap
+++ b/src/components/organisms/shared/OakMediaClip/__snapshots__/OakMediaClip.test.tsx.snap
@@ -252,7 +252,7 @@ exports[`OakMediaClip matches snapshot 1`] = `
         className="c4 yellow-shadow"
       />
       <button
-        aria-label="Media clip: Test Clip, length: 10 minutes and 57 seconds"
+        aria-label="Video - Test Clip - Cycle 1, length: 10:57"
         className="c5 c6 internal-button"
         onClick={[Function]}
         onMouseEnter={[Function]}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

- Adds learning cycle and played status to button aria-label on `OakMediaClip`

## Link to the design doc

## A link to the component in the deployment preview

[OakMediaClip](https://oak-components-storybook-git-fix-lesq-1459media-clips-ar-b813b2.vercel-preview.thenational.academy/?path=/docs/components-organisms-teacher-oakmediaclip--docs)

## Testing instructions

- aria-label should be in `[Media type] - [clip name] - [subtitle], length: [xx:yy], played` format
- learning cycle and played status are optional and should not appear in the aria-label when there is no learning cycle or when clip has not been played

## ACs
