### PR TITLE
Fix/lesq 1557/radio button input

### DIFF
--- a/src/components/atoms/InternalRadioWrapper/InternalRadioWrapper.tsx
+++ b/src/components/atoms/InternalRadioWrapper/InternalRadioWrapper.tsx
@@ -126,7 +126,14 @@ export const InternalRadioWrapper = (props: InternalRadioWrapperProps) => {
     : radioBorderWidth;
 
   return (
-    <OakFlex $position="relative" $width={size} $height={size} $flexShrink={0}>
+    <OakFlex
+      $position="relative"
+      $width={size}
+      $height={size}
+      $flexShrink={0}
+      $justifyContent={"center"}
+      $alignItems={"center"}
+    >
       {internalRadio}
       {!disabled ? (
         <VisibleRadioButtonInput

--- a/src/components/atoms/InternalRadioWrapper/__snapshots__/InternalRadioWrapper.test.tsx.snap
+++ b/src/components/atoms/InternalRadioWrapper/__snapshots__/InternalRadioWrapper.test.tsx.snap
@@ -26,6 +26,14 @@ exports[`InternalRadioWrapper matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;

--- a/src/components/molecules/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
+++ b/src/components/molecules/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
@@ -42,6 +42,14 @@ exports[`RadioGroup matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;

--- a/src/components/molecules/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
+++ b/src/components/molecules/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
@@ -42,6 +42,14 @@ exports[`RadioGroup matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;

--- a/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/organisms/curriculum/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -190,6 +190,14 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;

--- a/src/components/organisms/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
@@ -55,6 +55,14 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Align items in InternalRadioWrapper to prevent internal radio input growing in size and becoming visible. Now it is small and hidden behind the input circle. 
This could be seen in the previous curriculum download radio buttons
Before:  
<img width="500" height="495" alt="Screenshot 2025-09-05 at 09 13 00" src="https://github.com/user-attachments/assets/5175fb72-19ee-4ae7-a514-4b8657e76c03" />
  
Now:
<img width="500" height="492" alt="Screenshot 2025-09-05 at 09 39 42" src="https://github.com/user-attachments/assets/5872f688-332f-4034-a7e2-21a994754b6d" />

