### PR TITLE
Add slots to InternalChecvronAccordion outside button interact area

### DIFF
--- a/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.stories.tsx
+++ b/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.stories.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import styled from "styled-components";
 
 import { InternalChevronAccordion } from "./InternalChevronAccordion";
 
+import { OakCheckBox } from "@/components/molecules/OakCheckBox";
 import { OakHandDrawnHR } from "@/components/molecules/OakHandDrawnHR";
 import { OakFlex } from "@/components/atoms";
 import { PositionStyleProps } from "@/styles/utils/positionStyle";
@@ -86,6 +87,48 @@ export const FillAccordion: Story = {
     );
   },
   args: {},
+};
+
+export const BeforeAfterSlotsAccordion: Story = {
+  render: () => {
+    const [checked, setChecked] = useState([false, false]);
+    return (
+      <InternalChevronAccordion
+        beforeButtonSlot={
+          <OakCheckBox
+            checked={checked[0]}
+            value={""}
+            onChange={() =>
+              setChecked((prev) => {
+                const newChecked = [...prev];
+                newChecked[0] = !newChecked[0];
+                return newChecked;
+              })
+            }
+            id={"checkbox-1"}
+          />
+        }
+        afterButtonSlot={
+          <OakCheckBox
+            checked={checked[1]}
+            value={""}
+            onChange={() =>
+              setChecked((prev) => {
+                const newChecked = [...prev];
+                newChecked[1] = !newChecked[1];
+                return newChecked;
+              })
+            }
+            id={"checkbox-2"}
+          />
+        }
+        header={"Title"}
+        id={"before-after-slot-accordion"}
+      >
+        Subcopy area
+      </InternalChevronAccordion>
+    );
+  },
 };
 
 export const MultipleAccordions: Story = {

--- a/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.stories.tsx
+++ b/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.stories.tsx
@@ -97,7 +97,7 @@ export const BeforeAfterSlotsAccordion: Story = {
         beforeButtonSlot={
           <OakCheckBox
             checked={checked[0]}
-            value={""}
+            value={"checkbox1"}
             onChange={() =>
               setChecked((prev) => {
                 const newChecked = [...prev];
@@ -106,12 +106,13 @@ export const BeforeAfterSlotsAccordion: Story = {
               })
             }
             id={"checkbox-1"}
+            displayValue="Before slot checkbox"
           />
         }
         afterButtonSlot={
           <OakCheckBox
             checked={checked[1]}
-            value={""}
+            value={"checkbox2"}
             onChange={() =>
               setChecked((prev) => {
                 const newChecked = [...prev];
@@ -120,6 +121,7 @@ export const BeforeAfterSlotsAccordion: Story = {
               })
             }
             id={"checkbox-2"}
+            displayValue="After slot checkbox"
           />
         }
         header={"Title"}

--- a/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.test.tsx
+++ b/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.test.tsx
@@ -154,4 +154,20 @@ describe(InternalChevronAccordion, () => {
     expect(useRefSpy).toHaveBeenCalled();
     expect(styles.opacity).toBe("1");
   });
+
+  it("renders the beforeButtonSlot and afterButtonSlot when provided", () => {
+    const { getByText } = renderWithTheme(
+      <InternalChevronAccordion
+        header="See more"
+        id="see-more"
+        beforeButtonSlot={<div>Before slot content</div>}
+        afterButtonSlot={<div>After slot content</div>}
+      >
+        Here it is
+      </InternalChevronAccordion>,
+    );
+
+    expect(getByText("Before slot content")).toBeInTheDocument();
+    expect(getByText("After slot content")).toBeInTheDocument();
+  });
 });

--- a/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.tsx
+++ b/src/components/molecules/InternalChevronAccordion/InternalChevronAccordion.tsx
@@ -43,6 +43,14 @@ export type InternalChevronAccordionProps = {
    * The id of the accordion
    */
   id: string;
+  /**
+   * A slot before header outside of the button's interact area
+   */
+  beforeButtonSlot?: ReactNode;
+  /**
+   * A slot after the header outside of the button's interact area
+   */
+  afterButtonSlot?: ReactNode;
 } & FlexStyleProps &
   OakBoxProps &
   ColorStyleProps;
@@ -112,6 +120,8 @@ const Accordion = ({
   children,
   id,
   subheading,
+  beforeButtonSlot,
+  afterButtonSlot,
   ...styleProps
 }: InternalChevronAccordionProps) => {
   const [shouldDisplayShadow, setShouldDisplayShadow] = useState(false);
@@ -154,35 +164,39 @@ const Accordion = ({
       $gap={"all-spacing-1"}
       {...styleProps}
     >
-      <StyledAccordionButton
-        id={id}
-        $width={"100%"}
-        $justifyContent={"space-between"}
-        $alignItems={"center"}
-      >
-        {header}
+      <OakFlex $alignItems={"center"} $justifyContent={"center"}>
+        {beforeButtonSlot}
+        <StyledAccordionButton
+          id={id}
+          $width={"100%"}
+          $justifyContent={"space-between"}
+          $alignItems={"center"}
+        >
+          {header}
 
-        <OakBox $position={"relative"} $mr={"space-between-xs"}>
-          <OakBox
-            className="shadow"
-            $position={"absolute"}
-            $borderRadius={"border-radius-s"}
-            $width={"100%"}
-            $height={"100%"}
-            $top="all-spacing-0"
-          />
-          <OakIcon
-            iconName="chevron-down"
-            $width="all-spacing-7"
-            $height="all-spacing-7"
-            alt="An arrow to indicate whether the item is open or closed"
-            style={{
-              transform: isOpen ? "rotate(180deg)" : "none",
-              transition: "all 0.3s ease 0s",
-            }}
-          />
-        </OakBox>
-      </StyledAccordionButton>
+          <OakBox $position={"relative"} $mr={"space-between-xs"}>
+            <OakBox
+              className="shadow"
+              $position={"absolute"}
+              $borderRadius={"border-radius-s"}
+              $width={"100%"}
+              $height={"100%"}
+              $top="all-spacing-0"
+            />
+            <OakIcon
+              iconName="chevron-down"
+              $width="all-spacing-7"
+              $height="all-spacing-7"
+              alt="An arrow to indicate whether the item is open or closed"
+              style={{
+                transform: isOpen ? "rotate(180deg)" : "none",
+                transition: "all 0.3s ease 0s",
+              }}
+            />
+          </OakBox>
+        </StyledAccordionButton>
+        {afterButtonSlot}
+      </OakFlex>
       {!isOpen && subheading}
       <OakBox
         ref={scrollBox}

--- a/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
+++ b/src/components/molecules/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
@@ -12,17 +12,21 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3:hover {
+.c5 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c5:hover {
   cursor: pointer;
 }
 
-.c8 {
+.c10 {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c11 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -31,7 +35,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c12 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -40,23 +44,19 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c14 {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c17 {
+.c18 {
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c13 {
   object-fit: contain;
 }
 
@@ -76,20 +76,35 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c5 {
+.c7 {
   font: inherit;
   color: inherit;
   border: none;
@@ -101,13 +116,13 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   padding: 0;
 }
 
-.c16 {
+.c17 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c7 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -125,12 +140,12 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   position: relative;
 }
 
-.c7:hover {
+.c9:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c7:focus-visible .shadow {
+.c9:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -149,15 +164,15 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c2 .c15 {
+.c2 .c16 {
   visibility: hidden;
 }
 
-.c2 .c6:focus-visible ~ .c15 {
+.c2 .c8:focus-visible ~ .c16 {
   visibility: visible;
 }
 
-.c18 {
+.c19 {
   position: absolute;
   bottom: 0;
   width: 100%;
@@ -173,64 +188,68 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
 <div
   className="c0 c1 c2"
 >
-  <button
-    aria-expanded={true}
-    className="c3 c4 c5 c6  c7"
-    id="see-more"
-    onClick={[Function]}
-    type="button"
+  <div
+    className="c3 c4"
   >
-    See more
-    <div
-      className="c8"
+    <button
+      aria-expanded={true}
+      className="c5 c6 c7 c8  c9"
+      id="see-more"
+      onClick={[Function]}
+      type="button"
     >
-      <div
-        className="c9 shadow"
-      />
+      See more
       <div
         className="c10"
-        style={
-          {
-            "transform": "rotate(180deg)",
-            "transition": "all 0.3s ease 0s",
-          }
-        }
       >
-        <img
-          alt="An arrow to indicate whether the item is open or closed"
-          className="c11"
-          data-nimg="fill"
-          decoding="async"
-          loading="lazy"
-          onError={[Function]}
-          onLoad={[Function]}
-          src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
+        <div
+          className="c11 shadow"
+        />
+        <div
+          className="c12"
           style={
             {
-              "bottom": 0,
-              "color": "transparent",
-              "height": "100%",
-              "left": 0,
-              "objectFit": undefined,
-              "objectPosition": undefined,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-              "width": "100%",
+              "transform": "rotate(180deg)",
+              "transition": "all 0.3s ease 0s",
             }
           }
-        />
+        >
+          <img
+            alt="An arrow to indicate whether the item is open or closed"
+            className="c13"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
+            style={
+              {
+                "bottom": 0,
+                "color": "transparent",
+                "height": "100%",
+                "left": 0,
+                "objectFit": undefined,
+                "objectPosition": undefined,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": "100%",
+              }
+            }
+          />
+        </div>
       </div>
-    </div>
-  </button>
+    </button>
+  </div>
   <div
-    className="c12"
+    className="c14"
     data-testid="scrollable-content"
     onScroll={[Function]}
   >
     <div
       aria-labelledby="see-more"
-      className="c13"
+      className="c3"
       hidden={false}
       role="region"
     >
@@ -238,7 +257,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
     </div>
   </div>
   <div
-    className="c13 c14 c15 c16"
+    className="c3 c15 c16 c17"
   >
     <svg
       className=""
@@ -259,7 +278,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
     </svg>
   </div>
   <div
-    className="c17 c18"
+    className="c18 c19"
     data-testid="bottom-box-shadow"
   />
 </div>

--- a/src/components/molecules/OakBasicAccordion/OakBasicAccordion.tsx
+++ b/src/components/molecules/OakBasicAccordion/OakBasicAccordion.tsx
@@ -25,6 +25,14 @@ export type OakBasicAccordionProps = {
    * The id of the accordion
    */
   id: string;
+  /**
+   * A slot before header outside of the button's interact area
+   */
+  beforeButtonSlot?: ReactNode;
+  /**
+   * A slot after the header outside of the button's interact area
+   */
+  afterButtonSlot?: ReactNode;
 } & BorderStyleProps &
   FlexStyleProps;
 
@@ -34,6 +42,8 @@ export const OakBasicAccordion = ({
   id,
   initialOpen,
   subheading,
+  beforeButtonSlot,
+  afterButtonSlot,
   ...styleProps
 }: OakBasicAccordionProps) => {
   return (
@@ -42,6 +52,8 @@ export const OakBasicAccordion = ({
       id={id}
       initialOpen={initialOpen}
       subheading={subheading}
+      beforeButtonSlot={beforeButtonSlot}
+      afterButtonSlot={afterButtonSlot}
       {...styleProps}
     >
       {children}

--- a/src/components/molecules/OakBasicAccordion/__snapshots__/OakBasicAccordion.test.tsx.snap
+++ b/src/components/molecules/OakBasicAccordion/__snapshots__/OakBasicAccordion.test.tsx.snap
@@ -12,17 +12,21 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c3:hover {
+.c5 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c5:hover {
   cursor: pointer;
 }
 
-.c9 {
+.c11 {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c12 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -31,7 +35,7 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c13 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -40,7 +44,7 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c15 {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
@@ -48,10 +52,6 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
 }
 
 .c14 {
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c12 {
   object-fit: contain;
 }
 
@@ -71,28 +71,43 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c16 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c8 {
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c16 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c7 {
   font: inherit;
   color: inherit;
   border: none;
@@ -104,13 +119,13 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   padding: 0;
 }
 
-.c18 {
+.c19 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c7 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -128,12 +143,12 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   position: relative;
 }
 
-.c7:hover {
+.c9:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c7:focus-visible .shadow {
+.c9:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -152,11 +167,11 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c2 .c17 {
+.c2 .c18 {
   visibility: hidden;
 }
 
-.c2 .c6:focus-visible ~ .c17 {
+.c2 .c8:focus-visible ~ .c18 {
   visibility: visible;
 }
 
@@ -164,80 +179,84 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   className="c0 c1 c2"
   data-testid="test"
 >
-  <button
-    aria-expanded={false}
-    className="c3 c4 c5 c6  c7"
-    id="1"
-    onClick={[Function]}
-    type="button"
+  <div
+    className="c3 c4"
   >
-    <h1
-      className="c8"
+    <button
+      aria-expanded={false}
+      className="c5 c6 c7 c8  c9"
+      id="1"
+      onClick={[Function]}
+      type="button"
     >
-      Heading
-    </h1>
-    <div
-      className="c9"
-    >
-      <div
-        className="c10 shadow"
-      />
+      <h1
+        className="c10"
+      >
+        Heading
+      </h1>
       <div
         className="c11"
-        style={
-          {
-            "transform": "none",
-            "transition": "all 0.3s ease 0s",
-          }
-        }
       >
-        <img
-          alt="An arrow to indicate whether the item is open or closed"
-          className="c12"
-          data-nimg="fill"
-          decoding="async"
-          loading="lazy"
-          onError={[Function]}
-          onLoad={[Function]}
-          src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
+        <div
+          className="c12 shadow"
+        />
+        <div
+          className="c13"
           style={
             {
-              "bottom": 0,
-              "color": "transparent",
-              "height": "100%",
-              "left": 0,
-              "objectFit": undefined,
-              "objectPosition": undefined,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-              "width": "100%",
+              "transform": "none",
+              "transition": "all 0.3s ease 0s",
             }
           }
-        />
+        >
+          <img
+            alt="An arrow to indicate whether the item is open or closed"
+            className="c14"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            onError={[Function]}
+            onLoad={[Function]}
+            src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
+            style={
+              {
+                "bottom": 0,
+                "color": "transparent",
+                "height": "100%",
+                "left": 0,
+                "objectFit": undefined,
+                "objectPosition": undefined,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": "100%",
+              }
+            }
+          />
+        </div>
       </div>
-    </div>
-  </button>
+    </button>
+  </div>
   <div
-    className="c13"
+    className="c15"
     data-testid="scrollable-content"
     onScroll={[Function]}
   >
     <div
       aria-labelledby="1"
-      className="c14"
+      className="c3"
       hidden={true}
       role="region"
     >
       <p
-        className="c15"
+        className="c16"
       >
         Body
       </p>
     </div>
   </div>
   <div
-    className="c14 c16 c17 c18"
+    className="c3 c17 c18 c19"
   >
     <svg
       className=""

--- a/src/components/molecules/OakMediaClipListAccordion/__snapshots__/OakMediaClipListAccordion.test.tsx.snap
+++ b/src/components/molecules/OakMediaClipListAccordion/__snapshots__/OakMediaClipListAccordion.test.tsx.snap
@@ -21,17 +21,21 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6:hover {
+.c8 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c8:hover {
   cursor: pointer;
 }
 
-.c11 {
+.c13 {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c14 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -40,7 +44,7 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c15 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -49,23 +53,19 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c17 {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c20 {
+.c21 {
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c16 {
   object-fit: contain;
 }
 
@@ -95,20 +95,35 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c8 {
+.c10 {
   font: inherit;
   color: inherit;
   border: none;
@@ -120,13 +135,13 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   padding: 0;
 }
 
-.c19 {
+.c20 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -144,12 +159,12 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   position: relative;
 }
 
-.c10:hover {
+.c12:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c10:focus-visible .shadow {
+.c12:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -172,15 +187,15 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c5 .c18 {
+.c5 .c19 {
   visibility: hidden;
 }
 
-.c5 .c9:focus-visible ~ .c18 {
+.c5 .c11:focus-visible ~ .c19 {
   visibility: visible;
 }
 
-.c21 {
+.c22 {
   position: absolute;
   bottom: 0;
   width: 100%;
@@ -228,64 +243,68 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   <div
     className="c3 c4 c5"
   >
-    <button
-      aria-expanded={true}
-      className="c6 c7 c8 c9  c10"
-      id="see-more"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="c6 c7"
     >
-      See more
-      <div
-        className="c11"
+      <button
+        aria-expanded={true}
+        className="c8 c9 c10 c11  c12"
+        id="see-more"
+        onClick={[Function]}
+        type="button"
       >
-        <div
-          className="c12 shadow"
-        />
+        See more
         <div
           className="c13"
-          style={
-            {
-              "transform": "rotate(180deg)",
-              "transition": "all 0.3s ease 0s",
-            }
-          }
         >
-          <img
-            alt="An arrow to indicate whether the item is open or closed"
-            className="c14"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            onError={[Function]}
-            onLoad={[Function]}
-            src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
+          <div
+            className="c14 shadow"
+          />
+          <div
+            className="c15"
             style={
               {
-                "bottom": 0,
-                "color": "transparent",
-                "height": "100%",
-                "left": 0,
-                "objectFit": undefined,
-                "objectPosition": undefined,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "width": "100%",
+                "transform": "rotate(180deg)",
+                "transition": "all 0.3s ease 0s",
               }
             }
-          />
+          >
+            <img
+              alt="An arrow to indicate whether the item is open or closed"
+              className="c16"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
+              style={
+                {
+                  "bottom": 0,
+                  "color": "transparent",
+                  "height": "100%",
+                  "left": 0,
+                  "objectFit": undefined,
+                  "objectPosition": undefined,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </div>
         </div>
-      </div>
-    </button>
+      </button>
+    </div>
     <div
-      className="c15"
+      className="c17"
       data-testid="scrollable-content"
       onScroll={[Function]}
     >
       <div
         aria-labelledby="see-more"
-        className="c16"
+        className="c6"
         hidden={false}
         role="region"
       >
@@ -293,7 +312,7 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c16 c17 c18 c19"
+      className="c6 c18 c19 c20"
     >
       <svg
         className=""
@@ -314,7 +333,7 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
       </svg>
     </div>
     <div
-      className="c20 c21"
+      className="c21 c22"
       data-testid="bottom-box-shadow"
     />
   </div>

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -17,21 +17,21 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c9 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8:hover {
+.c9:hover {
   cursor: pointer;
 }
 
-.c13 {
+.c14 {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c15 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -40,7 +40,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c16 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -49,19 +49,19 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c18 {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c20 {
+.c21 {
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c17 {
   object-fit: contain;
 }
 
@@ -93,7 +93,22 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c9 {
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -104,7 +119,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c10 {
+.c11 {
   font: inherit;
   color: inherit;
   border: none;
@@ -116,13 +131,13 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   padding: 0;
 }
 
-.c19 {
+.c20 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -140,12 +155,12 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   position: relative;
 }
 
-.c12:hover {
+.c13:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c12:focus-visible .shadow {
+.c13:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -164,15 +179,15 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c7 .c18 {
+.c7 .c19 {
   visibility: hidden;
 }
 
-.c7 .c11:focus-visible ~ .c18 {
+.c7 .c12:focus-visible ~ .c19 {
   visibility: visible;
 }
 
-.c21 {
+.c22 {
   position: absolute;
   bottom: 0;
   width: 100%;
@@ -191,7 +206,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   bottom: 0.125rem;
 }
 
-.c22 {
+.c23 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
@@ -225,58 +240,62 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   <div
     className="c5 c6 c7"
   >
-    <button
-      aria-expanded={true}
-      className="c8 c9 c10 c11  c12"
-      id="see-more"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="c2 c8"
     >
-      See more
-      <div
-        className="c13"
+      <button
+        aria-expanded={true}
+        className="c9 c10 c11 c12  c13"
+        id="see-more"
+        onClick={[Function]}
+        type="button"
       >
+        See more
         <div
-          className="c14 shadow"
-        />
-        <div
-          className="c15"
-          style={
-            {
-              "transform": "rotate(180deg)",
-              "transition": "all 0.3s ease 0s",
-            }
-          }
+          className="c14"
         >
-          <img
-            alt="An arrow to indicate whether the item is open or closed"
+          <div
+            className="c15 shadow"
+          />
+          <div
             className="c16"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            onError={[Function]}
-            onLoad={[Function]}
-            src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
             style={
               {
-                "bottom": 0,
-                "color": "transparent",
-                "height": "100%",
-                "left": 0,
-                "objectFit": undefined,
-                "objectPosition": undefined,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "width": "100%",
+                "transform": "rotate(180deg)",
+                "transition": "all 0.3s ease 0s",
               }
             }
-          />
+          >
+            <img
+              alt="An arrow to indicate whether the item is open or closed"
+              className="c17"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              onError={[Function]}
+              onLoad={[Function]}
+              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
+              style={
+                {
+                  "bottom": 0,
+                  "color": "transparent",
+                  "height": "100%",
+                  "left": 0,
+                  "objectFit": undefined,
+                  "objectPosition": undefined,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </div>
         </div>
-      </div>
-    </button>
+      </button>
+    </div>
     <div
-      className="c17"
+      className="c18"
       data-testid="scrollable-content"
       onScroll={[Function]}
     >
@@ -290,7 +309,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c2 c3 c18 c19"
+      className="c2 c3 c19 c20"
     >
       <svg
         className=""
@@ -311,12 +330,12 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
       </svg>
     </div>
     <div
-      className="c20 c21"
+      className="c21 c22"
       data-testid="bottom-box-shadow"
     />
   </div>
   <div
-    className="c2 c3 c22"
+    className="c2 c3 c23"
   >
     <svg
       className=""

--- a/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -23,21 +23,21 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c11 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10:hover {
+.c11:hover {
   cursor: pointer;
 }
 
-.c16 {
+.c17 {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c18 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -46,7 +46,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c19 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -55,14 +55,14 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c21 {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c22 {
+.c23 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -70,7 +70,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c20 {
   object-fit: contain;
 }
 
@@ -110,7 +110,22 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c11 {
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -121,7 +136,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c21 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -136,7 +151,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1rem;
 }
 
-.c26 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -155,7 +170,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 0.5rem;
 }
 
-.c15 {
+.c16 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -166,7 +181,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c27 {
+.c28 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -178,7 +193,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
 }
 
-.c24 {
+.c25 {
   background: none;
   color: inherit;
   border: none;
@@ -200,12 +215,12 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c24:disabled {
+.c25:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c28 {
+.c29 {
   background: none;
   color: inherit;
   border: none;
@@ -227,19 +242,19 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c28:disabled {
+.c29:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c25 {
+.c26 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c25:hover {
+.c26:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -247,26 +262,26 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-color: #575757;
 }
 
-.c25:active {
+.c26:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c25:disabled {
+.c26:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c29 {
+.c30 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c29:hover {
+.c30:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -274,44 +289,44 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-color: #222222;
 }
 
-.c29:active {
+.c30:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c29:disabled {
+.c30:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c23 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c24 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c23 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c24 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c23 .yellow-shadow:has(+ .internal-button:hover),
-.c23 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c24 .yellow-shadow:has(+ .internal-button:hover),
+.c24 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c23 .grey-shadow:has(+ * + .internal-button:hover) {
+.c24 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c23 .grey-shadow:has(+ * + .internal-button:active) {
+.c24 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c23 .yellow-shadow:has(+ .internal-button:active) {
+.c24 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c12 {
+.c13 {
   font: inherit;
   color: inherit;
   border: none;
@@ -323,13 +338,13 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   padding: 0;
 }
 
-.c31 {
+.c32 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -347,12 +362,12 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   position: relative;
 }
 
-.c14:hover {
+.c15:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c14:focus-visible .shadow {
+.c15:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -371,11 +386,11 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c9 .c30 {
+.c9 .c31 {
   visibility: hidden;
 }
 
-.c9 .c13:focus-visible ~ .c30 {
+.c9 .c14:focus-visible ~ .c31 {
   visibility: visible;
 }
 
@@ -385,7 +400,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   bottom: 0.125rem;
 }
 
-.c32 {
+.c33 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
@@ -409,7 +424,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c22 {
     -webkit-box-pack: start;
     -webkit-justify-content: start;
     -ms-flex-pack: start;
@@ -418,7 +433,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c22 {
     -webkit-box-pack: end;
     -webkit-justify-content: end;
     -ms-flex-pack: end;
@@ -460,62 +475,66 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
       <div
         className="c7 c8 c9"
       >
-        <button
-          aria-expanded={false}
-          className="c10 c11 c12 c13  c14"
-          id="mobile-unit-filter-accordion"
-          onClick={[Function]}
-          type="button"
+        <div
+          className="c4 c10"
         >
-          <h2
-            className="c15"
+          <button
+            aria-expanded={false}
+            className="c11 c12 c13 c14  c15"
+            id="mobile-unit-filter-accordion"
+            onClick={[Function]}
+            type="button"
           >
-            Categories
-          </h2>
-          <div
-            className="c16"
-          >
-            <div
-              className="c17 shadow"
-            />
-            <div
-              className="c18"
-              style={
-                {
-                  "transform": "none",
-                  "transition": "all 0.3s ease 0s",
-                }
-              }
+            <h2
+              className="c16"
             >
-              <img
-                alt="An arrow to indicate whether the item is open or closed"
+              Categories
+            </h2>
+            <div
+              className="c17"
+            >
+              <div
+                className="c18 shadow"
+              />
+              <div
                 className="c19"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                onError={[Function]}
-                onLoad={[Function]}
-                src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
                 style={
                   {
-                    "bottom": 0,
-                    "color": "transparent",
-                    "height": "100%",
-                    "left": 0,
-                    "objectFit": undefined,
-                    "objectPosition": undefined,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                    "width": "100%",
+                    "transform": "none",
+                    "transition": "all 0.3s ease 0s",
                   }
                 }
-              />
+              >
+                <img
+                  alt="An arrow to indicate whether the item is open or closed"
+                  className="c20"
+                  data-nimg="fill"
+                  decoding="async"
+                  loading="lazy"
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
+                  style={
+                    {
+                      "bottom": 0,
+                      "color": "transparent",
+                      "height": "100%",
+                      "left": 0,
+                      "objectFit": undefined,
+                      "objectPosition": undefined,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
             </div>
-          </div>
-        </button>
+          </button>
+        </div>
         <div
-          className="c20"
+          className="c21"
           data-testid="scrollable-content"
           onScroll={[Function]}
         >
@@ -527,31 +546,31 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           >
             <div
               aria-label="OakPupilJourneyUnitsFilter"
-              className="c4 c21"
+              className="c4 c22"
               role="radiogroup"
             >
               <div
-                className="c22 c23"
+                className="c23 c24"
               >
                 <div
-                  className="c17 grey-shadow"
+                  className="c18 grey-shadow"
                 />
                 <div
-                  className="c17 yellow-shadow"
+                  className="c18 yellow-shadow"
                 />
                 <button
                   aria-checked={true}
-                  className="c24 c25 internal-button"
+                  className="c25 c26 internal-button"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   role="radio"
                 >
                   <div
-                    className="c4 c26"
+                    className="c4 c27"
                   >
                     <span
-                      className="c27"
+                      className="c28"
                     >
                       All
                     </span>
@@ -559,27 +578,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 </button>
               </div>
               <div
-                className="c22 c23"
+                className="c23 c24"
               >
                 <div
-                  className="c17 grey-shadow"
+                  className="c18 grey-shadow"
                 />
                 <div
-                  className="c17 yellow-shadow"
+                  className="c18 yellow-shadow"
                 />
                 <button
                   aria-checked={false}
-                  className="c28 c29 internal-button"
+                  className="c29 c30 internal-button"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   role="radio"
                 >
                   <div
-                    className="c4 c26"
+                    className="c4 c27"
                   >
                     <span
-                      className="c27"
+                      className="c28"
                     >
                       Biology
                     </span>
@@ -587,27 +606,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 </button>
               </div>
               <div
-                className="c22 c23"
+                className="c23 c24"
               >
                 <div
-                  className="c17 grey-shadow"
+                  className="c18 grey-shadow"
                 />
                 <div
-                  className="c17 yellow-shadow"
+                  className="c18 yellow-shadow"
                 />
                 <button
                   aria-checked={false}
-                  className="c28 c29 internal-button"
+                  className="c29 c30 internal-button"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   role="radio"
                 >
                   <div
-                    className="c4 c26"
+                    className="c4 c27"
                   >
                     <span
-                      className="c27"
+                      className="c28"
                     >
                       Chemistry
                     </span>
@@ -615,27 +634,27 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 </button>
               </div>
               <div
-                className="c22 c23"
+                className="c23 c24"
               >
                 <div
-                  className="c17 grey-shadow"
+                  className="c18 grey-shadow"
                 />
                 <div
-                  className="c17 yellow-shadow"
+                  className="c18 yellow-shadow"
                 />
                 <button
                   aria-checked={false}
-                  className="c28 c29 internal-button"
+                  className="c29 c30 internal-button"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   role="radio"
                 >
                   <div
-                    className="c4 c26"
+                    className="c4 c27"
                   >
                     <span
-                      className="c27"
+                      className="c28"
                     >
                       Physics
                     </span>
@@ -646,7 +665,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </div>
         </div>
         <div
-          className="c4 c5 c30 c31"
+          className="c4 c5 c31 c32"
         >
           <svg
             className=""
@@ -668,7 +687,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="c4 c5 c32"
+        className="c4 c5 c33"
       >
         <svg
           className=""

--- a/src/components/organisms/shared/OakMediaClipList/__snapshots__/OakMediaClipList.test.tsx.snap
+++ b/src/components/organisms/shared/OakMediaClipList/__snapshots__/OakMediaClipList.test.tsx.snap
@@ -23,11 +23,15 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6:hover {
+.c8 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c8:hover {
   cursor: pointer;
 }
 
-.c11 {
+.c13 {
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.75rem;
@@ -36,7 +40,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   text-align: left;
 }
 
-.c12 {
+.c14 {
   margin-bottom: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -48,7 +52,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c14 {
+.c16 {
   margin-bottom: 0.25rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -60,7 +64,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c16 {
+.c18 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -71,13 +75,13 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c17 {
+.c19 {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c20 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -86,7 +90,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c21 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -95,18 +99,14 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c23 {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c22 {
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c27 {
+.c28 {
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
@@ -137,24 +137,39 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.c24 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c20 {
+.c22 {
   object-fit: contain;
 }
 
-.c13 {
+.c15 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
@@ -165,7 +180,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c15 {
+.c17 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -176,7 +191,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c23 {
+.c24 {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -187,7 +202,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c10 {
   font: inherit;
   color: inherit;
   border: none;
@@ -199,13 +214,13 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   padding: 0;
 }
 
-.c26 {
+.c27 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -223,12 +238,12 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   position: relative;
 }
 
-.c10:hover {
+.c12:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c10:focus-visible .shadow {
+.c12:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
@@ -252,15 +267,15 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c5 .c25 {
+.c5 .c26 {
   visibility: hidden;
 }
 
-.c5 .c9:focus-visible ~ .c25 {
+.c5 .c11:focus-visible ~ .c26 {
   visibility: visible;
 }
 
-.c28 {
+.c29 {
   position: absolute;
   bottom: 0;
   width: 100%;
@@ -308,97 +323,101 @@ exports[`OakMediaClipList matches snapshot 1`] = `
     <div
       className="c3 c4 c5"
     >
-      <button
-        aria-expanded={true}
-        className="c6 c7 c8 c9  c10"
-        id="media-clip-list"
-        onClick={[Function]}
-        type="button"
+      <div
+        className="c6 c7"
       >
-        <div
-          className="c11 c1"
+        <button
+          aria-expanded={true}
+          className="c8 c9 c10 c11  c12"
+          id="media-clip-list"
+          onClick={[Function]}
+          type="button"
         >
           <div
-            className="c12 c13"
+            className="c13 c1"
           >
-            Lesson
+            <div
+              className="c14 c15"
+            >
+              Lesson
+            </div>
+            <div
+              className="c16 c17"
+            >
+              What is a democratic community?
+            </div>
+            <div
+              className="c18 c15"
+            >
+              3
+              /
+              3
+               clips
+            </div>
           </div>
-          <div
-            className="c14 c15"
-          >
-            What is a democratic community?
-          </div>
-          <div
-            className="c16 c13"
-          >
-            3
-            /
-            3
-             clips
-          </div>
-        </div>
-        <div
-          className="c17"
-        >
-          <div
-            className="c18 shadow"
-          />
           <div
             className="c19"
-            style={
-              {
-                "transform": "rotate(180deg)",
-                "transition": "all 0.3s ease 0s",
-              }
-            }
           >
-            <img
-              alt="An arrow to indicate whether the item is open or closed"
-              className="c20"
-              data-nimg="fill"
-              decoding="async"
-              loading="lazy"
-              onError={[Function]}
-              onLoad={[Function]}
-              src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
+            <div
+              className="c20 shadow"
+            />
+            <div
+              className="c21"
               style={
                 {
-                  "bottom": 0,
-                  "color": "transparent",
-                  "height": "100%",
-                  "left": 0,
-                  "objectFit": undefined,
-                  "objectPosition": undefined,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "width": "100%",
+                  "transform": "rotate(180deg)",
+                  "transition": "all 0.3s ease 0s",
                 }
               }
-            />
+            >
+              <img
+                alt="An arrow to indicate whether the item is open or closed"
+                className="c22"
+                data-nimg="fill"
+                decoding="async"
+                loading="lazy"
+                onError={[Function]}
+                onLoad={[Function]}
+                src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1699953557/icons/botfld6brychmttwtv6u.svg"
+                style={
+                  {
+                    "bottom": 0,
+                    "color": "transparent",
+                    "height": "100%",
+                    "left": 0,
+                    "objectFit": undefined,
+                    "objectPosition": undefined,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
           </div>
-        </div>
-      </button>
+        </button>
+      </div>
       <div
-        className="c21"
+        className="c23"
         data-testid="scrollable-content"
         onScroll={[Function]}
       >
         <div
           aria-labelledby="media-clip-list"
-          className="c22"
+          className="c6"
           hidden={false}
           role="region"
         >
           <ul
-            className="c23"
+            className="c24"
           >
             children
           </ul>
         </div>
       </div>
       <div
-        className="c22 c24 c25 c26"
+        className="c6 c25 c26 c27"
       >
         <svg
           className=""
@@ -419,7 +438,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
         </svg>
       </div>
       <div
-        className="c27 c28"
+        className="c28 c29"
         data-testid="bottom-box-shadow"
       />
     </div>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Arising from accessibility concerns in https://github.com/oaknational/Oak-Web-Application/pull/3686, we need the option to insert elements outside of the interact area on the accordion button.

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

You can find a story with a demo of the new feature [here](https://oak-components-storybook-git-feat-add-slots-outside-butt-5902e5.vercel.thenational.academy/?path=/story/components-molecules-internalchevronaccordion--before-after-slots-accordion), which will show checkboxes that are not nested in the accordion button.

Check InternalChevronAccordion still works as expected, along with other components that use it:

1. OakBasicAccordion
2. OakMediaClipListAccordion
3. OakOutlineAccordion
4. OakPupilJourneyUnitsFilter
5. OakMediaClipList

## ACs
