### PR TITLE
Feat/pupil 1335/focusable false aria hidden

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-focus-on": "^3.9.2",
-        "react-test-renderer": "^18.2.0",
         "react-transition-group": "^4.4.5",
         "rollup": "^4.9.4",
         "rollup-plugin-dts": "^6.1.0",
@@ -2024,17 +2023,6 @@
       "peer": true,
       "dependencies": {
         "@cloudinary/transformation-builder-sdk": "^1.10.0"
-      }
-    },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -4628,134 +4616,6 @@
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.4.tgz",
       "integrity": "sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g==",
       "peer": true
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.4.tgz",
-      "integrity": "sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.4.tgz",
-      "integrity": "sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.4.tgz",
-      "integrity": "sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.4.tgz",
-      "integrity": "sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.4.tgz",
-      "integrity": "sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.4.tgz",
-      "integrity": "sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.4.tgz",
-      "integrity": "sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.4.tgz",
-      "integrity": "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -25133,19 +24993,6 @@
         }
       }
     },
-    "node_modules/react-shallow-renderer": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
-      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
@@ -25168,26 +25015,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/react-test-renderer": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
-      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
-      "dev": true,
-      "dependencies": {
-        "react-is": "^18.2.0",
-        "react-shallow-renderer": "^16.15.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
@@ -28195,20 +28022,6 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
-    },
-    "node_modules/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29376,6 +29376,126 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.4.tgz",
+      "integrity": "sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.4.tgz",
+      "integrity": "sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.4.tgz",
+      "integrity": "sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.4.tgz",
+      "integrity": "sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.4.tgz",
+      "integrity": "sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.4.tgz",
+      "integrity": "sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.4.tgz",
+      "integrity": "sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.4.tgz",
+      "integrity": "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/components/molecules/OakHandDrawnHR/OakHandDrawnHR.stories.tsx
+++ b/src/components/molecules/OakHandDrawnHR/OakHandDrawnHR.stories.tsx
@@ -35,6 +35,5 @@ export const Default: Story = {
   render: (args) => <OakHandDrawnHR {...args} />,
   args: {
     $height: "all-spacing-1",
-    focusable: false,
   },
 };

--- a/src/components/molecules/OakHandDrawnHR/OakHandDrawnHR.stories.tsx
+++ b/src/components/molecules/OakHandDrawnHR/OakHandDrawnHR.stories.tsx
@@ -35,5 +35,6 @@ export const Default: Story = {
   render: (args) => <OakHandDrawnHR {...args} />,
   args: {
     $height: "all-spacing-1",
+    focusable: false,
   },
 };

--- a/src/components/molecules/OakHandDrawnHR/OakHandDrawnHR.tsx
+++ b/src/components/molecules/OakHandDrawnHR/OakHandDrawnHR.tsx
@@ -8,10 +8,13 @@ import { InternalStyledSvgProps } from "@/components/atoms/InternalStyledSvg";
 import { SizeStyleProps } from "@/styles/utils/sizeStyle";
 import { SpacingStyleProps } from "@/styles/utils/spacingStyle";
 
-const StyledOakFlex = styled(OakFlex)``;
+const StyledOakFlex = styled(OakFlex)<{ focusable: boolean }>`
+  ${(props) => (!props.focusable ? "focusable: false;" : "focusable: true;")}
+`;
 
 export type OakHandDrawnHRProps = {
   hrColor?: InternalStyledSvgProps["$fill"];
+  focusable?: boolean;
 } & SpacingStyleProps &
   SizeStyleProps;
 
@@ -23,10 +26,10 @@ export type OakHandDrawnHRProps = {
  * change the sizeProps of the flex container to change the size and dimentions of the HR
  */
 export const OakHandDrawnHR = (props: OakHandDrawnHRProps) => {
-  const { hrColor, ...flexProps } = props;
+  const { hrColor, focusable = true, ...flexProps } = props;
 
   return (
-    <StyledOakFlex {...flexProps}>
+    <StyledOakFlex focusable={focusable} {...flexProps}>
       <HandDrawnHRSvg $fill={hrColor} />
     </StyledOakFlex>
   );

--- a/src/components/molecules/OakHandDrawnHR/OakHandDrawnHR.tsx
+++ b/src/components/molecules/OakHandDrawnHR/OakHandDrawnHR.tsx
@@ -8,13 +8,10 @@ import { InternalStyledSvgProps } from "@/components/atoms/InternalStyledSvg";
 import { SizeStyleProps } from "@/styles/utils/sizeStyle";
 import { SpacingStyleProps } from "@/styles/utils/spacingStyle";
 
-const StyledOakFlex = styled(OakFlex)<{ focusable: boolean }>`
-  ${(props) => (!props.focusable ? "focusable: false;" : "focusable: true;")}
-`;
+const StyledOakFlex = styled(OakFlex)``;
 
 export type OakHandDrawnHRProps = {
   hrColor?: InternalStyledSvgProps["$fill"];
-  focusable?: boolean;
 } & SpacingStyleProps &
   SizeStyleProps;
 
@@ -26,10 +23,10 @@ export type OakHandDrawnHRProps = {
  * change the sizeProps of the flex container to change the size and dimentions of the HR
  */
 export const OakHandDrawnHR = (props: OakHandDrawnHRProps) => {
-  const { hrColor, focusable = true, ...flexProps } = props;
+  const { hrColor, ...flexProps } = props;
 
   return (
-    <StyledOakFlex focusable={focusable} {...flexProps}>
+    <StyledOakFlex focusable={false} {...flexProps}>
       <HandDrawnHRSvg $fill={hrColor} />
     </StyledOakFlex>
   );

--- a/src/components/molecules/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
@@ -12,9 +12,14 @@ exports[`OakHandDrawnHR matches snapshot 1`] = `
   display: flex;
 }
 
+.c2 {
+  focusable: true;
+}
+
 <div>
   <div
-    class="c0 c1"
+    class="c0 c1 c2"
+    focusable="true"
   >
     <svg
       class=""

--- a/src/components/molecules/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
+++ b/src/components/molecules/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
@@ -12,14 +12,10 @@ exports[`OakHandDrawnHR matches snapshot 1`] = `
   display: flex;
 }
 
-.c2 {
-  focusable: true;
-}
-
 <div>
   <div
-    class="c0 c1 c2"
-    focusable="true"
+    class="c0 c1"
+    focusable="false"
   >
     <svg
       class=""

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -10,28 +10,28 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c5 {
+.c6 {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c9 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8:hover {
+.c9:hover {
   cursor: pointer;
 }
 
-.c13 {
+.c14 {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c14 {
+.c15 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -40,7 +40,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c16 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -49,19 +49,19 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c18 {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c20 {
+.c21 {
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c17 {
   object-fit: contain;
 }
 
@@ -82,7 +82,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   display: flex;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -93,7 +93,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -104,7 +104,11 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c10 {
+.c4 {
+  focusable: true;
+}
+
+.c11 {
   font: inherit;
   color: inherit;
   border: none;
@@ -116,13 +120,13 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   padding: 0;
 }
 
-.c19 {
+.c20 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -140,16 +144,16 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   position: relative;
 }
 
-.c12:hover {
+.c13:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c12:focus-visible .shadow {
+.c13:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c7 {
+.c8 {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
@@ -164,15 +168,15 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c7 .c18 {
+.c8 .c19 {
   visibility: hidden;
 }
 
-.c7 .c11:focus-visible ~ .c18 {
+.c8 .c12:focus-visible ~ .c19 {
   visibility: visible;
 }
 
-.c21 {
+.c22 {
   position: absolute;
   bottom: 0;
   width: 100%;
@@ -185,13 +189,13 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   padding: 2px;
 }
 
-.c4 {
+.c5 {
   height: 0.125rem;
   width: 100%;
   bottom: 0.125rem;
 }
 
-.c22 {
+.c23 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
@@ -203,7 +207,8 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
     class="c0 c1"
   >
     <div
-      class="c2 c3 c4"
+      class="c2 c3 c4 c5"
+      focusable="true"
     >
       <svg
         class=""
@@ -224,28 +229,28 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
       </svg>
     </div>
     <div
-      class="c5 c6 c7"
+      class="c6 c7 c8"
     >
       <button
         aria-expanded="true"
-        class="c8 c9 c10 c11  c12"
+        class="c9 c10 c11 c12  c13"
         id="see-more"
         type="button"
       >
         See more
         <div
-          class="c13"
+          class="c14"
         >
           <div
-            class="c14 shadow"
+            class="c15 shadow"
           />
           <div
-            class="c15"
+            class="c16"
             style="transform: rotate(180deg); transition: all 0.3s ease 0s;"
           >
             <img
               alt="An arrow to indicate whether the item is open or closed"
-              class="c16"
+              class="c17"
               data-nimg="fill"
               decoding="async"
               loading="lazy"
@@ -256,7 +261,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
         </div>
       </button>
       <div
-        class="c17"
+        class="c18"
         data-testid="scrollable-content"
       >
         <div
@@ -268,7 +273,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="c2 c3 c18 c19"
+        class="c2 c3 c19 c20"
       >
         <svg
           class=""
@@ -289,12 +294,13 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
         </svg>
       </div>
       <div
-        class="c20 c21"
+        class="c21 c22"
         data-testid="bottom-box-shadow"
       />
     </div>
     <div
-      class="c2 c3 c22"
+      class="c2 c3 c4 c23"
+      focusable="true"
     >
       <svg
         class=""

--- a/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/molecules/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -10,28 +10,28 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c6 {
+.c5 {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c8 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9:hover {
+.c8:hover {
   cursor: pointer;
 }
 
-.c14 {
+.c13 {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c14 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -40,7 +40,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c15 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -49,19 +49,19 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c17 {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c21 {
+.c20 {
   pointer-events: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c16 {
   object-fit: contain;
 }
 
@@ -82,7 +82,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   display: flex;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -93,7 +93,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -104,11 +104,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c4 {
-  focusable: true;
-}
-
-.c11 {
+.c10 {
   font: inherit;
   color: inherit;
   border: none;
@@ -120,13 +116,13 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   padding: 0;
 }
 
-.c20 {
+.c19 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -144,16 +140,16 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   position: relative;
 }
 
-.c13:hover {
+.c12:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c13:focus-visible .shadow {
+.c12:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c8 {
+.c7 {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
@@ -168,15 +164,15 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c8 .c19 {
+.c7 .c18 {
   visibility: hidden;
 }
 
-.c8 .c12:focus-visible ~ .c19 {
+.c7 .c11:focus-visible ~ .c18 {
   visibility: visible;
 }
 
-.c22 {
+.c21 {
   position: absolute;
   bottom: 0;
   width: 100%;
@@ -189,13 +185,13 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   padding: 2px;
 }
 
-.c5 {
+.c4 {
   height: 0.125rem;
   width: 100%;
   bottom: 0.125rem;
 }
 
-.c23 {
+.c22 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
@@ -207,8 +203,8 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
     class="c0 c1"
   >
     <div
-      class="c2 c3 c4 c5"
-      focusable="true"
+      class="c2 c3 c4"
+      focusable="false"
     >
       <svg
         class=""
@@ -229,28 +225,28 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
       </svg>
     </div>
     <div
-      class="c6 c7 c8"
+      class="c5 c6 c7"
     >
       <button
         aria-expanded="true"
-        class="c9 c10 c11 c12  c13"
+        class="c8 c9 c10 c11  c12"
         id="see-more"
         type="button"
       >
         See more
         <div
-          class="c14"
+          class="c13"
         >
           <div
-            class="c15 shadow"
+            class="c14 shadow"
           />
           <div
-            class="c16"
+            class="c15"
             style="transform: rotate(180deg); transition: all 0.3s ease 0s;"
           >
             <img
               alt="An arrow to indicate whether the item is open or closed"
-              class="c17"
+              class="c16"
               data-nimg="fill"
               decoding="async"
               loading="lazy"
@@ -261,7 +257,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
         </div>
       </button>
       <div
-        class="c18"
+        class="c17"
         data-testid="scrollable-content"
       >
         <div
@@ -273,7 +269,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="c2 c3 c19 c20"
+        class="c2 c3 c18 c19"
       >
         <svg
           class=""
@@ -294,13 +290,13 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
         </svg>
       </div>
       <div
-        class="c21 c22"
+        class="c20 c21"
         data-testid="bottom-box-shadow"
       />
     </div>
     <div
-      class="c2 c3 c4 c23"
-      focusable="true"
+      class="c2 c3 c22"
+      focusable="false"
     >
       <svg
         class=""

--- a/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -15,28 +15,28 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c8 {
+.c7 {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c10 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11:hover {
+.c10:hover {
   cursor: pointer;
 }
 
-.c17 {
+.c16 {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c17 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,7 +45,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c18 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -54,14 +54,14 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c21 {
+.c20 {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c23 {
+.c22 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -69,17 +69,17 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c34 {
+.c33 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c37 {
+.c36 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c19 {
   object-fit: contain;
 }
 
@@ -108,7 +108,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   display: flex;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -119,7 +119,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -130,7 +130,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -145,7 +145,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1rem;
 }
 
-.c27 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -164,7 +164,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 0.5rem;
 }
 
-.c35 {
+.c34 {
   display: none;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -176,7 +176,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c38 {
+.c37 {
   display: block;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -184,7 +184,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c16 {
+.c15 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -195,7 +195,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c28 {
+.c27 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -207,7 +207,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
 }
 
-.c25 {
+.c24 {
   background: none;
   color: inherit;
   border: none;
@@ -229,12 +229,12 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c25:disabled {
+.c24:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c29 {
+.c28 {
   background: none;
   color: inherit;
   border: none;
@@ -256,19 +256,19 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c29:disabled {
+.c28:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c26 {
+.c25 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c26:hover {
+.c25:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -276,26 +276,26 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-color: #575757;
 }
 
-.c26:active {
+.c25:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c26:disabled {
+.c25:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c30 {
+.c29 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c30:hover {
+.c29:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -303,48 +303,44 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-color: #222222;
 }
 
-.c30:active {
+.c29:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c30:disabled {
+.c29:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c24 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c23 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c24 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c23 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c24 .yellow-shadow:has(+ .internal-button:hover),
-.c24 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c23 .yellow-shadow:has(+ .internal-button:hover),
+.c23 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c24 .grey-shadow:has(+ * + .internal-button:hover) {
+.c23 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c24 .grey-shadow:has(+ * + .internal-button:active) {
+.c23 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c24 .yellow-shadow:has(+ .internal-button:active) {
+.c23 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c6 {
-  focusable: true;
-}
-
-.c13 {
+.c12 {
   font: inherit;
   color: inherit;
   border: none;
@@ -356,13 +352,13 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   padding: 0;
 }
 
-.c32 {
+.c31 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -380,16 +376,16 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   position: relative;
 }
 
-.c15:hover {
+.c14:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c15:focus-visible .shadow {
+.c14:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c10 {
+.c9 {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
@@ -404,33 +400,33 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c10 .c31 {
+.c9 .c30 {
   visibility: hidden;
 }
 
-.c10 .c14:focus-visible ~ .c31 {
+.c9 .c13:focus-visible ~ .c30 {
   visibility: visible;
 }
 
-.c7 {
+.c6 {
   height: 0.125rem;
   width: 100%;
   bottom: 0.125rem;
 }
 
-.c33 {
+.c32 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
   bottom: 0.125rem;
 }
 
-.c36 > button {
+.c35 > button {
   opacity: 0;
   position: absolute;
 }
 
-.c36 > button:focus-visible {
+.c35 > button:focus-visible {
   opacity: 1;
   position: relative;
 }
@@ -442,7 +438,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c34 {
+  .c33 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -457,7 +453,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c22 {
+  .c21 {
     -webkit-box-pack: start;
     -webkit-justify-content: start;
     -ms-flex-pack: start;
@@ -466,7 +462,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c22 {
+  .c21 {
     -webkit-box-pack: end;
     -webkit-justify-content: end;
     -ms-flex-pack: end;
@@ -475,7 +471,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c35 {
+  .c34 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -491,8 +487,8 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
       class="c2 c3"
     >
       <div
-        class="c4 c5 c6 c7"
-        focusable="true"
+        class="c4 c5 c6"
+        focusable="false"
       >
         <svg
           class=""
@@ -513,32 +509,32 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </svg>
       </div>
       <div
-        class="c8 c9 c10"
+        class="c7 c8 c9"
       >
         <button
           aria-expanded="false"
-          class="c11 c12 c13 c14  c15"
+          class="c10 c11 c12 c13  c14"
           id="mobile-unit-filter-accordion"
           type="button"
         >
           <h2
-            class="c16"
+            class="c15"
           >
             Categories
           </h2>
           <div
-            class="c17"
+            class="c16"
           >
             <div
-              class="c18 shadow"
+              class="c17 shadow"
             />
             <div
-              class="c19"
+              class="c18"
               style="transform: none; transition: all 0.3s ease 0s;"
             >
               <img
                 alt="An arrow to indicate whether the item is open or closed"
-                class="c20"
+                class="c19"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -549,7 +545,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </div>
         </button>
         <div
-          class="c21"
+          class="c20"
           data-testid="scrollable-content"
         >
           <div
@@ -560,28 +556,28 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           >
             <div
               aria-label="OakPupilJourneyUnitsFilter"
-              class="c4 c22"
+              class="c4 c21"
               role="radiogroup"
             >
               <div
-                class="c23 c24"
+                class="c22 c23"
               >
                 <div
-                  class="c18 grey-shadow"
+                  class="c17 grey-shadow"
                 />
                 <div
-                  class="c18 yellow-shadow"
+                  class="c17 yellow-shadow"
                 />
                 <button
                   aria-checked="true"
-                  class="c25 c26 internal-button"
+                  class="c24 c25 internal-button"
                   role="radio"
                 >
                   <div
-                    class="c4 c27"
+                    class="c4 c26"
                   >
                     <span
-                      class="c28"
+                      class="c27"
                     >
                       All
                     </span>
@@ -589,24 +585,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 </button>
               </div>
               <div
-                class="c23 c24"
+                class="c22 c23"
               >
                 <div
-                  class="c18 grey-shadow"
+                  class="c17 grey-shadow"
                 />
                 <div
-                  class="c18 yellow-shadow"
+                  class="c17 yellow-shadow"
                 />
                 <button
                   aria-checked="false"
-                  class="c29 c30 internal-button"
+                  class="c28 c29 internal-button"
                   role="radio"
                 >
                   <div
-                    class="c4 c27"
+                    class="c4 c26"
                   >
                     <span
-                      class="c28"
+                      class="c27"
                     >
                       Biology
                     </span>
@@ -614,24 +610,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 </button>
               </div>
               <div
-                class="c23 c24"
+                class="c22 c23"
               >
                 <div
-                  class="c18 grey-shadow"
+                  class="c17 grey-shadow"
                 />
                 <div
-                  class="c18 yellow-shadow"
+                  class="c17 yellow-shadow"
                 />
                 <button
                   aria-checked="false"
-                  class="c29 c30 internal-button"
+                  class="c28 c29 internal-button"
                   role="radio"
                 >
                   <div
-                    class="c4 c27"
+                    class="c4 c26"
                   >
                     <span
-                      class="c28"
+                      class="c27"
                     >
                       Chemistry
                     </span>
@@ -639,24 +635,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 </button>
               </div>
               <div
-                class="c23 c24"
+                class="c22 c23"
               >
                 <div
-                  class="c18 grey-shadow"
+                  class="c17 grey-shadow"
                 />
                 <div
-                  class="c18 yellow-shadow"
+                  class="c17 yellow-shadow"
                 />
                 <button
                   aria-checked="false"
-                  class="c29 c30 internal-button"
+                  class="c28 c29 internal-button"
                   role="radio"
                 >
                   <div
-                    class="c4 c27"
+                    class="c4 c26"
                   >
                     <span
-                      class="c28"
+                      class="c27"
                     >
                       Physics
                     </span>
@@ -667,7 +663,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </div>
         </div>
         <div
-          class="c4 c5 c31 c32"
+          class="c4 c5 c30 c31"
         >
           <svg
             class=""
@@ -689,8 +685,8 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="c4 c5 c6 c33"
-        focusable="true"
+        class="c4 c5 c32"
+        focusable="false"
       >
         <svg
           class=""
@@ -713,25 +709,25 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
     </div>
   </div>
   <div
-    class="c34 c35"
+    class="c33 c34"
   >
     <div
-      class="c23 c24 c36"
+      class="c22 c23 c35"
     >
       <div
-        class="c18 grey-shadow"
+        class="c17 grey-shadow"
       />
       <div
-        class="c18 yellow-shadow"
+        class="c17 yellow-shadow"
       />
       <button
-        class="c29 c30 internal-button"
+        class="c28 c29 internal-button"
       >
         <div
-          class="c4 c27"
+          class="c4 c26"
         >
           <span
-            class="c28"
+            class="c27"
           >
             Skip to results
           </span>
@@ -739,32 +735,32 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
       </button>
     </div>
     <div
-      class="c37 c38"
+      class="c36 c37"
     >
       <div
         aria-label="OakPupilJourneyUnitsFilter"
-        class="c4 c22"
+        class="c4 c21"
         role="radiogroup"
       >
         <div
-          class="c23 c24"
+          class="c22 c23"
         >
           <div
-            class="c18 grey-shadow"
+            class="c17 grey-shadow"
           />
           <div
-            class="c18 yellow-shadow"
+            class="c17 yellow-shadow"
           />
           <button
             aria-checked="true"
-            class="c25 c26 internal-button"
+            class="c24 c25 internal-button"
             role="radio"
           >
             <div
-              class="c4 c27"
+              class="c4 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 All
               </span>
@@ -772,24 +768,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </button>
         </div>
         <div
-          class="c23 c24"
+          class="c22 c23"
         >
           <div
-            class="c18 grey-shadow"
+            class="c17 grey-shadow"
           />
           <div
-            class="c18 yellow-shadow"
+            class="c17 yellow-shadow"
           />
           <button
             aria-checked="false"
-            class="c29 c30 internal-button"
+            class="c28 c29 internal-button"
             role="radio"
           >
             <div
-              class="c4 c27"
+              class="c4 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Biology
               </span>
@@ -797,24 +793,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </button>
         </div>
         <div
-          class="c23 c24"
+          class="c22 c23"
         >
           <div
-            class="c18 grey-shadow"
+            class="c17 grey-shadow"
           />
           <div
-            class="c18 yellow-shadow"
+            class="c17 yellow-shadow"
           />
           <button
             aria-checked="false"
-            class="c29 c30 internal-button"
+            class="c28 c29 internal-button"
             role="radio"
           >
             <div
-              class="c4 c27"
+              class="c4 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Chemistry
               </span>
@@ -822,24 +818,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </button>
         </div>
         <div
-          class="c23 c24"
+          class="c22 c23"
         >
           <div
-            class="c18 grey-shadow"
+            class="c17 grey-shadow"
           />
           <div
-            class="c18 yellow-shadow"
+            class="c17 yellow-shadow"
           />
           <button
             aria-checked="false"
-            class="c29 c30 internal-button"
+            class="c28 c29 internal-button"
             role="radio"
           >
             <div
-              class="c4 c27"
+              class="c4 c26"
             >
               <span
-                class="c28"
+                class="c27"
               >
                 Physics
               </span>

--- a/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/organisms/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -15,28 +15,28 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c8 {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10 {
+.c11 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c10:hover {
+.c11:hover {
   cursor: pointer;
 }
 
-.c16 {
+.c17 {
   position: relative;
   margin-right: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c17 {
+.c18 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -45,7 +45,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c18 {
+.c19 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -54,14 +54,14 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c20 {
+.c21 {
   position: relative;
   overflow: auto;
   font-family: --var(google-font),Lexend,sans-serif;
   overflow: auto;
 }
 
-.c22 {
+.c23 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -69,17 +69,17 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c33 {
+.c34 {
   display: none;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c36 {
+.c37 {
   display: block;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c20 {
   object-fit: contain;
 }
 
@@ -108,7 +108,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   display: flex;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -119,7 +119,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -130,7 +130,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c21 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -145,7 +145,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1rem;
 }
 
-.c26 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -164,7 +164,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 0.5rem;
 }
 
-.c34 {
+.c35 {
   display: none;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -176,7 +176,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c37 {
+.c38 {
   display: block;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -184,7 +184,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c15 {
+.c16 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
@@ -195,7 +195,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c27 {
+.c28 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -207,7 +207,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
 }
 
-.c24 {
+.c25 {
   background: none;
   color: inherit;
   border: none;
@@ -229,12 +229,12 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c24:disabled {
+.c25:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c28 {
+.c29 {
   background: none;
   color: inherit;
   border: none;
@@ -256,19 +256,19 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
-.c28:disabled {
+.c29:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c25 {
+.c26 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c25:hover {
+.c26:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #ffffff;
@@ -276,26 +276,26 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-color: #575757;
 }
 
-.c25:active {
+.c26:active {
   background: #222222;
   border-color: #222222;
   color: #ffffff;
 }
 
-.c25:disabled {
+.c26:disabled {
   background: #808080;
   border-color: #808080;
   color: #ffffff;
 }
 
-.c29 {
+.c30 {
   position: relative;
   width: 100%;
   height: 100%;
   display: inline-block;
 }
 
-.c29:hover {
+.c30:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
@@ -303,44 +303,48 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   border-color: #222222;
 }
 
-.c29:active {
+.c30:active {
   background: #ffffff;
   border-color: #222222;
   color: #222222;
 }
 
-.c29:disabled {
+.c30:disabled {
   background: #e4e4e4;
   border-color: #808080;
   color: #808080;
 }
 
-.c23 .grey-shadow:has(+ * + .internal-button:focus-visible) {
+.c24 .grey-shadow:has(+ * + .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c23 .yellow-shadow:has(+ .internal-button:focus-visible) {
+.c24 .yellow-shadow:has(+ .internal-button:focus-visible) {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%);
 }
 
-.c23 .yellow-shadow:has(+ .internal-button:hover),
-.c23 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
+.c24 .yellow-shadow:has(+ .internal-button:hover),
+.c24 .yellow-shadow:has(+ .internal-button:hover:not(:focus-visible,:active)) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c23 .grey-shadow:has(+ * + .internal-button:hover) {
+.c24 .grey-shadow:has(+ * + .internal-button:hover) {
   box-shadow: none;
 }
 
-.c23 .grey-shadow:has(+ * + .internal-button:active) {
+.c24 .grey-shadow:has(+ * + .internal-button:active) {
   box-shadow: 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c23 .yellow-shadow:has(+ .internal-button:active) {
+.c24 .yellow-shadow:has(+ .internal-button:active) {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c12 {
+.c6 {
+  focusable: true;
+}
+
+.c13 {
   font: inherit;
   color: inherit;
   border: none;
@@ -352,13 +356,13 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   padding: 0;
 }
 
-.c31 {
+.c32 {
   position: absolute;
   width: 100%;
   bottom: -0.25rem;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -376,16 +380,16 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   position: relative;
 }
 
-.c14:hover {
+.c15:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c14:focus-visible .shadow {
+.c15:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c9 {
+.c10 {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
@@ -400,33 +404,33 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   gap: 1.5rem;
 }
 
-.c9 .c30 {
+.c10 .c31 {
   visibility: hidden;
 }
 
-.c9 .c13:focus-visible ~ .c30 {
+.c10 .c14:focus-visible ~ .c31 {
   visibility: visible;
 }
 
-.c6 {
+.c7 {
   height: 0.125rem;
   width: 100%;
   bottom: 0.125rem;
 }
 
-.c32 {
+.c33 {
   height: 0.125rem;
   position: absolute;
   width: 100%;
   bottom: 0.125rem;
 }
 
-.c35 > button {
+.c36 > button {
   opacity: 0;
   position: absolute;
 }
 
-.c35 > button:focus-visible {
+.c36 > button:focus-visible {
   opacity: 1;
   position: relative;
 }
@@ -438,7 +442,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c33 {
+  .c34 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -453,7 +457,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c21 {
+  .c22 {
     -webkit-box-pack: start;
     -webkit-justify-content: start;
     -ms-flex-pack: start;
@@ -462,7 +466,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:1280px) {
-  .c21 {
+  .c22 {
     -webkit-box-pack: end;
     -webkit-justify-content: end;
     -ms-flex-pack: end;
@@ -471,7 +475,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c34 {
+  .c35 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -487,7 +491,8 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
       class="c2 c3"
     >
       <div
-        class="c4 c5 c6"
+        class="c4 c5 c6 c7"
+        focusable="true"
       >
         <svg
           class=""
@@ -508,32 +513,32 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </svg>
       </div>
       <div
-        class="c7 c8 c9"
+        class="c8 c9 c10"
       >
         <button
           aria-expanded="false"
-          class="c10 c11 c12 c13  c14"
+          class="c11 c12 c13 c14  c15"
           id="mobile-unit-filter-accordion"
           type="button"
         >
           <h2
-            class="c15"
+            class="c16"
           >
             Categories
           </h2>
           <div
-            class="c16"
+            class="c17"
           >
             <div
-              class="c17 shadow"
+              class="c18 shadow"
             />
             <div
-              class="c18"
+              class="c19"
               style="transform: none; transition: all 0.3s ease 0s;"
             >
               <img
                 alt="An arrow to indicate whether the item is open or closed"
-                class="c19"
+                class="c20"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -544,7 +549,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </div>
         </button>
         <div
-          class="c20"
+          class="c21"
           data-testid="scrollable-content"
         >
           <div
@@ -555,28 +560,28 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           >
             <div
               aria-label="OakPupilJourneyUnitsFilter"
-              class="c4 c21"
+              class="c4 c22"
               role="radiogroup"
             >
               <div
-                class="c22 c23"
+                class="c23 c24"
               >
                 <div
-                  class="c17 grey-shadow"
+                  class="c18 grey-shadow"
                 />
                 <div
-                  class="c17 yellow-shadow"
+                  class="c18 yellow-shadow"
                 />
                 <button
                   aria-checked="true"
-                  class="c24 c25 internal-button"
+                  class="c25 c26 internal-button"
                   role="radio"
                 >
                   <div
-                    class="c4 c26"
+                    class="c4 c27"
                   >
                     <span
-                      class="c27"
+                      class="c28"
                     >
                       All
                     </span>
@@ -584,24 +589,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 </button>
               </div>
               <div
-                class="c22 c23"
+                class="c23 c24"
               >
                 <div
-                  class="c17 grey-shadow"
+                  class="c18 grey-shadow"
                 />
                 <div
-                  class="c17 yellow-shadow"
+                  class="c18 yellow-shadow"
                 />
                 <button
                   aria-checked="false"
-                  class="c28 c29 internal-button"
+                  class="c29 c30 internal-button"
                   role="radio"
                 >
                   <div
-                    class="c4 c26"
+                    class="c4 c27"
                   >
                     <span
-                      class="c27"
+                      class="c28"
                     >
                       Biology
                     </span>
@@ -609,24 +614,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 </button>
               </div>
               <div
-                class="c22 c23"
+                class="c23 c24"
               >
                 <div
-                  class="c17 grey-shadow"
+                  class="c18 grey-shadow"
                 />
                 <div
-                  class="c17 yellow-shadow"
+                  class="c18 yellow-shadow"
                 />
                 <button
                   aria-checked="false"
-                  class="c28 c29 internal-button"
+                  class="c29 c30 internal-button"
                   role="radio"
                 >
                   <div
-                    class="c4 c26"
+                    class="c4 c27"
                   >
                     <span
-                      class="c27"
+                      class="c28"
                     >
                       Chemistry
                     </span>
@@ -634,24 +639,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
                 </button>
               </div>
               <div
-                class="c22 c23"
+                class="c23 c24"
               >
                 <div
-                  class="c17 grey-shadow"
+                  class="c18 grey-shadow"
                 />
                 <div
-                  class="c17 yellow-shadow"
+                  class="c18 yellow-shadow"
                 />
                 <button
                   aria-checked="false"
-                  class="c28 c29 internal-button"
+                  class="c29 c30 internal-button"
                   role="radio"
                 >
                   <div
-                    class="c4 c26"
+                    class="c4 c27"
                   >
                     <span
-                      class="c27"
+                      class="c28"
                     >
                       Physics
                     </span>
@@ -662,7 +667,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </div>
         </div>
         <div
-          class="c4 c5 c30 c31"
+          class="c4 c5 c31 c32"
         >
           <svg
             class=""
@@ -684,7 +689,8 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="c4 c5 c32"
+        class="c4 c5 c6 c33"
+        focusable="true"
       >
         <svg
           class=""
@@ -707,25 +713,25 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
     </div>
   </div>
   <div
-    class="c33 c34"
+    class="c34 c35"
   >
     <div
-      class="c22 c23 c35"
+      class="c23 c24 c36"
     >
       <div
-        class="c17 grey-shadow"
+        class="c18 grey-shadow"
       />
       <div
-        class="c17 yellow-shadow"
+        class="c18 yellow-shadow"
       />
       <button
-        class="c28 c29 internal-button"
+        class="c29 c30 internal-button"
       >
         <div
-          class="c4 c26"
+          class="c4 c27"
         >
           <span
-            class="c27"
+            class="c28"
           >
             Skip to results
           </span>
@@ -733,32 +739,32 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
       </button>
     </div>
     <div
-      class="c36 c37"
+      class="c37 c38"
     >
       <div
         aria-label="OakPupilJourneyUnitsFilter"
-        class="c4 c21"
+        class="c4 c22"
         role="radiogroup"
       >
         <div
-          class="c22 c23"
+          class="c23 c24"
         >
           <div
-            class="c17 grey-shadow"
+            class="c18 grey-shadow"
           />
           <div
-            class="c17 yellow-shadow"
+            class="c18 yellow-shadow"
           />
           <button
             aria-checked="true"
-            class="c24 c25 internal-button"
+            class="c25 c26 internal-button"
             role="radio"
           >
             <div
-              class="c4 c26"
+              class="c4 c27"
             >
               <span
-                class="c27"
+                class="c28"
               >
                 All
               </span>
@@ -766,24 +772,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </button>
         </div>
         <div
-          class="c22 c23"
+          class="c23 c24"
         >
           <div
-            class="c17 grey-shadow"
+            class="c18 grey-shadow"
           />
           <div
-            class="c17 yellow-shadow"
+            class="c18 yellow-shadow"
           />
           <button
             aria-checked="false"
-            class="c28 c29 internal-button"
+            class="c29 c30 internal-button"
             role="radio"
           >
             <div
-              class="c4 c26"
+              class="c4 c27"
             >
               <span
-                class="c27"
+                class="c28"
               >
                 Biology
               </span>
@@ -791,24 +797,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </button>
         </div>
         <div
-          class="c22 c23"
+          class="c23 c24"
         >
           <div
-            class="c17 grey-shadow"
+            class="c18 grey-shadow"
           />
           <div
-            class="c17 yellow-shadow"
+            class="c18 yellow-shadow"
           />
           <button
             aria-checked="false"
-            class="c28 c29 internal-button"
+            class="c29 c30 internal-button"
             role="radio"
           >
             <div
-              class="c4 c26"
+              class="c4 c27"
             >
               <span
-                class="c27"
+                class="c28"
               >
                 Chemistry
               </span>
@@ -816,24 +822,24 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
           </button>
         </div>
         <div
-          class="c22 c23"
+          class="c23 c24"
         >
           <div
-            class="c17 grey-shadow"
+            class="c18 grey-shadow"
           />
           <div
-            class="c17 yellow-shadow"
+            class="c18 yellow-shadow"
           />
           <button
             aria-checked="false"
-            class="c28 c29 internal-button"
+            class="c29 c30 internal-button"
             role="radio"
           >
             <div
-              class="c4 c26"
+              class="c4 c27"
             >
               <span
-                class="c27"
+                class="c28"
               >
                 Physics
               </span>

--- a/src/components/organisms/pupil/quiz/OakQuizCounter/OakQuizCounter.tsx
+++ b/src/components/organisms/pupil/quiz/OakQuizCounter/OakQuizCounter.tsx
@@ -43,7 +43,12 @@ export const OakQuizCounter = (props: OakQuizCounterProps) => {
         </OakSpan>
         of {total}
       </OakSpan>
-      <OakFlex $gap={"space-between-ssx"} $flexWrap={"wrap"}>
+      <OakFlex
+        $gap={"space-between-ssx"}
+        $flexWrap={"wrap"}
+        aria-hidden="true"
+        focusable={false}
+      >
         {pills}
       </OakFlex>
     </OakFlex>

--- a/src/components/organisms/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
+++ b/src/components/organisms/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
@@ -80,7 +80,9 @@ exports[`OakQuizCounter matches snapshot 1`] = `
       6
     </span>
     <div
+      aria-hidden="true"
       class="c0 c4"
+      focusable="false"
     >
       <svg
         class="c5"

--- a/src/styles/utils/flexStyle.ts
+++ b/src/styles/utils/flexStyle.ts
@@ -99,6 +99,7 @@ export type FlexStyleProps = DisplayStyleProps & {
   $rowGap?: ResponsiveValues<
     OakAllSpacingToken | OakSpaceBetweenToken | null | undefined
   >;
+  focusable?: boolean;
 };
 
 export const flexStyle = css<FlexStyleProps>`


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
have made counter component permenantly focusable=false and aria-hidden
the hhandrawn line can accept props for aria and focucsable when used on owa


## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions
<img width="974" height="308" alt="Screenshot 2025-09-26 at 12 01 51" src="https://github.com/user-attachments/assets/8416c020-51e2-4296-9a79-f7c89828c78f" />
<img width="945" height="129" alt="Screenshot 2025-09-26 at 12 05 23" src="https://github.com/user-attachments/assets/4d83f904-41a9-47d6-bb9c-082c5ca1186a" />


## ACs
- [ ]  Horizontal dividers in pupil browse journey have `aria-hidden="true"` and `focusable="false"` props (this component has also been used by the teacher downloads experiment to separate the sections and will need to be checked)
- [ ]  Decorative progress indicator ‘pips’ below the `X of Y` text in pupil quizzes  have `aria-hidden="true"` and `focusable="false"` props
- [ ]  test coverage
