### PR TITLE
Make `FormDataEntryValue` type safe by checking of type string

### DIFF
--- a/src/components/cookies/OakCookieSettingsModal/OakCookieSettingsModal.tsx
+++ b/src/components/cookies/OakCookieSettingsModal/OakCookieSettingsModal.tsx
@@ -74,10 +74,12 @@ export const OakCookieSettingsModal = ({
     }
 
     for (const policyId of formData.getAll("consent")) {
-      newConsents[policyId.toString()] = {
-        policyId: policyId.toString(),
-        consentState: "granted",
-      };
+      if (typeof policyId === "string") {
+        newConsents[policyId] = {
+          policyId: policyId,
+          consentState: "granted",
+        };
+      }
     }
 
     onConfirm(Object.values(newConsents));


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Make `FormDataEntryValue` type safe by checking of type string

Note that FormDataEntryValue can be either string or File, see <https://bun.com/reference/bun/FormDataEntryValue>

Fixes
 - https://sonarcloud.io/project/issues?open=AZgxmoaQBoQMKbyNldXn&id=oaknational_oak-components
 - https://sonarcloud.io/project/issues?open=AZgxmoaQBoQMKbyNldXo&id=oaknational_oak-components

## Link to the design doc
None

## A link to the component in the deployment preview
https://oak-components-storybook-git-fix-make-formdataentryvalue-504ff4.vercel.thenational.academy/

## Testing instructions

## ACs
