### PR TITLE
Added default color to global style reset

### DIFF
--- a/src/styles/global/oak.styles.ts
+++ b/src/styles/global/oak.styles.ts
@@ -8,6 +8,8 @@
 
 import { css } from "styled-components";
 
+import { parseColor } from "@/styles/helpers";
+
 export const oakGlobalCss = css`
   html,
   body {
@@ -25,6 +27,7 @@ export const oakGlobalCss = css`
     display: flex;
     flex-direction: column;
     flex-grow: 1;
+    color: ${parseColor("text-primary")};
   }
 
   a {


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Added a global default color to `<OakGlobalStyle/>` the color in now defaults to `text-primary`   

Big shout out to @CatMillerCM for coming up with the idea for this

## Link to the design doc
None

## A link to the component in the deployment preview
https://oak-components-storybook-git-feat-adopt-1866-text-primar-460597.vercel.thenational.academy/

## Testing instructions
This looks like a sensible change as I don't **think** we ever want `#000000` (browser default), but we'll still need some testing.

## ACs
No regressions in oak-components or consuming apps.