### PR TITLE
Allow Arial as a fallback via setting `--base-font`

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -19,6 +19,15 @@ const globalDecorator: Decorator = (Story, context) => {
         href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;700&display=swap"
         rel="stylesheet"
       />
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+        :root {
+          --base-font: Arial, Helvetica, sans-serif;
+        }
+      `,
+        }}
+      />
       <OakGlobalStyle />
       <Story {...context} />
     </ThemeProvider>

--- a/src/components/CopyPasteThisComponent/__snapshots__/CopyPasteThisComponent.test.tsx.snap
+++ b/src/components/CopyPasteThisComponent/__snapshots__/CopyPasteThisComponent.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CopyPasteThisComponent matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/buttons/OakButtonWithDropdown/__snapshots__/OakButtonWithDropdown.test.tsx.snap
+++ b/src/components/buttons/OakButtonWithDropdown/__snapshots__/OakButtonWithDropdown.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`OakButtonWithDropdown matches snapshot 1`] = `
 .c0 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -16,7 +16,7 @@ exports[`OakButtonWithDropdown matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -25,7 +25,7 @@ exports[`OakButtonWithDropdown matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -35,7 +35,7 @@ exports[`OakButtonWithDropdown matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -88,7 +88,7 @@ exports[`OakButtonWithDropdown matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -109,7 +109,7 @@ exports[`OakButtonWithDropdown matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/buttons/OakCloseButton/__snapshots__/OakCloseButton.test.tsx.snap
+++ b/src/components/buttons/OakCloseButton/__snapshots__/OakCloseButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakCloseButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -21,7 +21,7 @@ exports[`OakCloseButton matches snapshot 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -30,7 +30,7 @@ exports[`OakCloseButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -40,7 +40,7 @@ exports[`OakCloseButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -85,7 +85,7 @@ exports[`OakCloseButton matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -105,7 +105,7 @@ exports[`OakCloseButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: transparent;
 }
 

--- a/src/components/buttons/OakLeftAlignedButton/__snapshots__/OalLeftAlignedButton.test.tsx.snap
+++ b/src/components/buttons/OakLeftAlignedButton/__snapshots__/OalLeftAlignedButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakLeftAlignedButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakLeftAlignedButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakLeftAlignedButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -53,7 +53,7 @@ exports[`OakLeftAlignedButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -74,7 +74,7 @@ exports[`OakLeftAlignedButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 0.5rem;

--- a/src/components/buttons/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
+++ b/src/components/buttons/OakPrimaryButton/__snapshots__/OakPrimaryButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -53,7 +53,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -74,7 +74,7 @@ exports[`OakPrimaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/buttons/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/buttons/OakPrimaryInvertedButton/__snapshots__/OakPrimaryInvertedButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -53,7 +53,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -74,7 +74,7 @@ exports[`OakPrimaryInvertedButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/buttons/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
+++ b/src/components/buttons/OakSecondaryButton/__snapshots__/OakSecondaryButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -53,7 +53,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -74,7 +74,7 @@ exports[`OakSecondaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/buttons/OakSecondaryButtonWithDropdown/__snapshots__/OakSecondaryButtonWithDropdown.test.tsx.snap
+++ b/src/components/buttons/OakSecondaryButtonWithDropdown/__snapshots__/OakSecondaryButtonWithDropdown.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`OakSecondaryButtonWithDropdown matches snapshot 1`] = `
 .c0 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -16,7 +16,7 @@ exports[`OakSecondaryButtonWithDropdown matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -25,7 +25,7 @@ exports[`OakSecondaryButtonWithDropdown matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -35,7 +35,7 @@ exports[`OakSecondaryButtonWithDropdown matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -88,7 +88,7 @@ exports[`OakSecondaryButtonWithDropdown matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -109,7 +109,7 @@ exports[`OakSecondaryButtonWithDropdown matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/buttons/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
+++ b/src/components/buttons/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -53,7 +53,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -74,7 +74,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 0.5rem;

--- a/src/components/buttons/OakSmallPrimaryInvertedButton/__snapshots__/OakSmallPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/buttons/OakSmallPrimaryInvertedButton/__snapshots__/OakSmallPrimaryInvertedButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -53,7 +53,7 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -74,7 +74,7 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 0.5rem;

--- a/src/components/buttons/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
+++ b/src/components/buttons/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -53,7 +53,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -74,7 +74,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 0.5rem;

--- a/src/components/buttons/OakSmallSecondaryButtonWithDropdown/__snapshots__/OakSmallSecondaryButtonWithDropdown.test.tsx.snap
+++ b/src/components/buttons/OakSmallSecondaryButtonWithDropdown/__snapshots__/OakSmallSecondaryButtonWithDropdown.test.tsx.snap
@@ -3,16 +3,16 @@
 exports[`OakSmallSecondaryButtonWithDropdown matches snapshot 1`] = `
 .c0 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -21,7 +21,7 @@ exports[`OakSmallSecondaryButtonWithDropdown matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakSmallSecondaryButtonWithDropdown matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -40,7 +40,7 @@ exports[`OakSmallSecondaryButtonWithDropdown matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -93,7 +93,7 @@ exports[`OakSmallSecondaryButtonWithDropdown matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -114,7 +114,7 @@ exports[`OakSmallSecondaryButtonWithDropdown matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 0.5rem;

--- a/src/components/buttons/OakSmallSecondaryToggleButton/__snapshots__/OakSmallSecondaryToggleButton.test.tsx.snap
+++ b/src/components/buttons/OakSmallSecondaryToggleButton/__snapshots__/OakSmallSecondaryToggleButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakSmallSecondaryToggleButton component matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakSmallSecondaryToggleButton component matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -43,7 +43,7 @@ exports[`OakSmallSecondaryToggleButton component matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -64,7 +64,7 @@ exports[`OakSmallSecondaryToggleButton component matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 0.5rem;

--- a/src/components/buttons/OakSmallTertiaryInvertedButton/__snapshots__/OakSmallTertiaryInvertedButton.test.tsx.snap
+++ b/src/components/buttons/OakSmallTertiaryInvertedButton/__snapshots__/OakSmallTertiaryInvertedButton.test.tsx.snap
@@ -6,25 +6,25 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   padding-left: 0rem;
   padding-right: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
   position: relative;
   color: #222222;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -36,7 +36,7 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -48,7 +48,7 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -58,7 +58,7 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -103,7 +103,7 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
 }
 
 .c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -123,7 +123,7 @@ exports[`OakSmallTertiaryInvertedButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   border-radius: 0.25rem;
 }

--- a/src/components/buttons/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
+++ b/src/components/buttons/OakTertiaryButton/__snapshots__/OakTertiaryButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -40,7 +40,7 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -60,7 +60,7 @@ exports[`OakTertiaryButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/buttons/OakTertiaryInvertedButton/__snapshots__/OakTertiaryInvertedButton.test.tsx.snap
+++ b/src/components/buttons/OakTertiaryInvertedButton/__snapshots__/OakTertiaryInvertedButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakTertiaryInvertedButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -40,7 +40,7 @@ exports[`OakTertiaryInvertedButton matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -60,7 +60,7 @@ exports[`OakTertiaryInvertedButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/cookies/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
+++ b/src/components/cookies/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   background: #f2f2f2;
   border-top: 0.063rem solid;
   border-color: #808080;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
   margin-left: auto;
   margin-right: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -20,11 +20,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   padding-bottom: 1.5rem;
   margin-left: 1rem;
   margin-right: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -35,11 +35,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -56,7 +56,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -65,7 +65,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -136,7 +136,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -147,11 +147,11 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -172,7 +172,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -200,7 +200,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/cookies/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
+++ b/src/components/cookies/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   background: #f2f2f2;
   border-top: 0.063rem solid;
   border-color: #808080;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
   margin-left: auto;
   margin-right: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -20,11 +20,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   padding-bottom: 1.5rem;
   margin-left: 1rem;
   margin-right: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -35,11 +35,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -56,7 +56,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -65,7 +65,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -136,7 +136,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -147,11 +147,11 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -172,7 +172,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -200,7 +200,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/form-elements/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
+++ b/src/components/form-elements/OakButtonAsRadioGroup/__snapshots__/OakButtonAsRadioGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -11,7 +11,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -20,7 +20,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -51,7 +51,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -72,7 +72,7 @@ exports[`OakButtonAsRadioGroup matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/form-elements/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
+++ b/src/components/form-elements/OakCheckBox/__snapshots__/OakCheckbox.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
 }
 
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 
@@ -55,7 +55,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -65,7 +65,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -75,7 +75,7 @@ exports[`OakCheckBox matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {

--- a/src/components/form-elements/OakFieldset/__snapshots__/OakFieldset.test.tsx.snap
+++ b/src/components/form-elements/OakFieldset/__snapshots__/OakFieldset.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakFieldset matches snapshot 1`] = `
   border: 0;
   margin: 0;
   padding: 0;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/form-elements/OakForm/__snapshots__/OakForm.test.tsx.snap
+++ b/src/components/form-elements/OakForm/__snapshots__/OakForm.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/form-elements/OakFormInput/__snapshots__/OakFormInput.test.tsx.snap
+++ b/src/components/form-elements/OakFormInput/__snapshots__/OakFormInput.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`OakFormInput should match snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #cacaca;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/form-elements/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
+++ b/src/components/form-elements/OakJauntyAngleLabel/__snapshots__/OakJauntyAngleLabel.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`OakjauntyAngleLabel matches snapshot 1`] = `
   -webkit-transform: rotate(-1.5deg);
   -ms-transform: rotate(-1.5deg);
   transform: rotate(-1.5deg);
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/form-elements/OakLabel/__snapshots__/OakLabel.test.tsx.snap
+++ b/src/components/form-elements/OakLabel/__snapshots__/OakLabel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakLabel matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/form-elements/OakMultilineText/__snapshots__/OakMultilineText.test.tsx.snap
+++ b/src/components/form-elements/OakMultilineText/__snapshots__/OakMultilineText.test.tsx.snap
@@ -3,18 +3,18 @@
 exports[`OakMultilineText matches snapshot 1`] = `
 .c0 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
   position: relative;
   min-width: 3.5rem;
   padding-bottom: 1.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -43,7 +43,7 @@ exports[`OakMultilineText matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #cacaca;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   white-space: wrap;
   overflow-y: auto;
   color: #222222;

--- a/src/components/form-elements/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
+++ b/src/components/form-elements/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
@@ -5,19 +5,19 @@ exports[`RadioGroup matches snapshot 1`] = `
   padding: 0rem;
   margin: 0rem;
   border-style: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -29,7 +29,7 @@ exports[`RadioGroup matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -84,7 +84,7 @@ exports[`RadioGroup matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/form-elements/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
+++ b/src/components/form-elements/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
@@ -5,19 +5,19 @@ exports[`RadioGroup matches snapshot 1`] = `
   padding: 0rem;
   margin: 0rem;
   border-style: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -29,7 +29,7 @@ exports[`RadioGroup matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -84,7 +84,7 @@ exports[`RadioGroup matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/form-elements/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
+++ b/src/components/form-elements/OakSearchFilterCheckBox/__snapshots__/OaKSearchFilterCheckBox.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
 .c0 {
   position: relative;
   min-height: 2.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,7 +16,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
   border: 0.063rem solid;
   border-color: #cacaca;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2:hover {
@@ -30,7 +30,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -53,7 +53,7 @@ exports[`OakSearchFilterCheckBox matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/form-elements/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
+++ b/src/components/form-elements/OakSecondaryButtonAsRadio/__snapshots__/OakSecondaryButtonAsRadio.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -43,7 +43,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -64,7 +64,7 @@ exports[`OakSecondaryButtonAsRadio matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/form-elements/OakSelect/__snapshots__/OakSelect.test.tsx.snap
+++ b/src/components/form-elements/OakSelect/__snapshots__/OakSelect.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`OakSelect disabled select 1`] = `
 .c0 {
   position: relative;
   display: inline-block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -80,7 +80,7 @@ exports[`OakSelect disabled select 1`] = `
   right: 0.75rem;
   bottom: 0rem;
   pointer-events: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -90,7 +90,7 @@ exports[`OakSelect disabled select 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -314,7 +314,7 @@ exports[`OakSelect highlighted select 1`] = `
 .c0 {
   position: relative;
   display: inline-block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -323,7 +323,7 @@ exports[`OakSelect highlighted select 1`] = `
   right: 0.75rem;
   bottom: 0rem;
   pointer-events: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -333,7 +333,7 @@ exports[`OakSelect highlighted select 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -556,7 +556,7 @@ exports[`OakSelect invalid select 1`] = `
 .c0 {
   position: relative;
   display: inline-block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -565,7 +565,7 @@ exports[`OakSelect invalid select 1`] = `
   right: 0.75rem;
   bottom: 0rem;
   pointer-events: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -575,7 +575,7 @@ exports[`OakSelect invalid select 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -798,7 +798,7 @@ exports[`OakSelect optgroup select 1`] = `
 .c0 {
   position: relative;
   display: inline-block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -807,7 +807,7 @@ exports[`OakSelect optgroup select 1`] = `
   right: 0.75rem;
   bottom: 0rem;
   pointer-events: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -817,7 +817,7 @@ exports[`OakSelect optgroup select 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -1089,7 +1089,7 @@ exports[`OakSelect plain select 1`] = `
 .c0 {
   position: relative;
   display: inline-block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -1098,7 +1098,7 @@ exports[`OakSelect plain select 1`] = `
   right: 0.75rem;
   bottom: 0rem;
   pointer-events: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -1108,7 +1108,7 @@ exports[`OakSelect plain select 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/form-elements/OakTextArea/__snapshots__/OakTextArea.test.tsx.snap
+++ b/src/components/form-elements/OakTextArea/__snapshots__/OakTextArea.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakTextArea matches snapshot 1`] = `
 .c0 {
   resize: none;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/form-elements/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
+++ b/src/components/form-elements/OakTextInput/__snapshots__/OakTextInput.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`OakTextInput matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0:hover {
@@ -68,7 +68,7 @@ exports[`OakTextInput matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/house-cat/OakCaptionCard/__snapshots__/OakCaptionCard.test.tsx.snap
+++ b/src/components/house-cat/OakCaptionCard/__snapshots__/OakCaptionCard.test.tsx.snap
@@ -8,12 +8,12 @@ exports[`CaptionCard matches snapshot 1`] = `
   padding: 1rem;
   background: #ffffff;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -27,7 +27,7 @@ exports[`CaptionCard matches snapshot 1`] = `
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -37,7 +37,7 @@ exports[`CaptionCard matches snapshot 1`] = `
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -47,11 +47,11 @@ exports[`CaptionCard matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -62,7 +62,7 @@ exports[`CaptionCard matches snapshot 1`] = `
 }
 
 .c21 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c25 {
@@ -72,12 +72,12 @@ exports[`CaptionCard matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c27 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -198,7 +198,7 @@ exports[`CaptionCard matches snapshot 1`] = `
 }
 
 .c19 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -209,11 +209,11 @@ exports[`CaptionCard matches snapshot 1`] = `
 }
 
 .c20 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/house-cat/OakCaptionSearch/__snapshots__/OakCaptionSearch.test.tsx.snap
+++ b/src/components/house-cat/OakCaptionSearch/__snapshots__/OakCaptionSearch.test.tsx.snap
@@ -6,16 +6,16 @@ exports[`OakCaptionSearch should match snapshot 1`] = `
   color: #222222;
   background: #ffffff;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -29,7 +29,7 @@ exports[`OakCaptionSearch should match snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #cacaca;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakCaptionSearch should match snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -58,7 +58,7 @@ exports[`OakCaptionSearch should match snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -68,7 +68,7 @@ exports[`OakCaptionSearch should match snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -134,7 +134,7 @@ exports[`OakCaptionSearch should match snapshot 1`] = `
 }
 
 .c18 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -155,7 +155,7 @@ exports[`OakCaptionSearch should match snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;
@@ -300,7 +300,7 @@ exports[`OakCaptionSearch should match snapshot 1`] = `
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -311,7 +311,7 @@ exports[`OakCaptionSearch should match snapshot 1`] = `
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/images-and-icons/OakIcon/__snapshots__/OakIcon.test.tsx.snap
+++ b/src/components/images-and-icons/OakIcon/__snapshots__/OakIcon.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OakIcon matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/images-and-icons/OakImage/__snapshots__/OakImage.test.tsx.snap
+++ b/src/components/images-and-icons/OakImage/__snapshots__/OakImage.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakImage matches snapshot 1`] = `
   position: relative;
   width: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/images-and-icons/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
+++ b/src/components/images-and-icons/OakRoundIcon/__snapshots__/OakRoundIcon.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakRoundIcon matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -17,7 +17,7 @@ exports[`OakRoundIcon matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/images-and-icons/OakSvg/__snapshots__/OakSvg.test.tsx.snap
+++ b/src/components/images-and-icons/OakSvg/__snapshots__/OakSvg.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakSvg matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
 }

--- a/src/components/internal-components/InternalAccordion/__snapshots__/InternalAccordion.test.tsx.snap
+++ b/src/components/internal-components/InternalAccordion/__snapshots__/InternalAccordion.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`InternalAccordion matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2:hover {

--- a/src/components/internal-components/InternalButton/__snapshots__/InternalButton.test.tsx.snap
+++ b/src/components/internal-components/InternalButton/__snapshots__/InternalButton.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`InternalButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0:disabled {

--- a/src/components/internal-components/InternalCard/__snapshots__/InternalCard.test.tsx.snap
+++ b/src/components/internal-components/InternalCard/__snapshots__/InternalCard.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
   position: relative;
   padding: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/internal-components/InternalCardWithBackgroundElement/__snapshots__/InternalCardWithBackgroundElement.test.tsx.snap
+++ b/src/components/internal-components/InternalCardWithBackgroundElement/__snapshots__/InternalCardWithBackgroundElement.test.tsx.snap
@@ -4,18 +4,18 @@ exports[`InternalStyledSvg matches snapshot 1`] = `
 .c0 {
   position: relative;
   padding: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/internal-components/InternalCheckBoxLabel/__snapshots__/InternalCheckBoxLabel.test.tsx.snap
+++ b/src/components/internal-components/InternalCheckBoxLabel/__snapshots__/InternalCheckBoxLabel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InternalCheckBoxLabel matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/internal-components/InternalCheckBoxWrapper/__snapshots__/InternalCheckBoxWrapper.test.tsx.snap
+++ b/src/components/internal-components/InternalCheckBoxWrapper/__snapshots__/InternalCheckBoxWrapper.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`InternalCheckBoxWrapper matches snapshot 1`] = `
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,7 +15,7 @@ exports[`InternalCheckBoxWrapper matches snapshot 1`] = `
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {

--- a/src/components/internal-components/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
+++ b/src/components/internal-components/InternalChevronAccordion/__snapshots__/InternalChevronAccordion.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3:hover {
@@ -19,7 +19,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
 .c8 {
   position: relative;
   margin-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -28,7 +28,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -38,23 +38,23 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
   position: relative;
   overflow: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
 .c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
   pointer-events: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -122,7 +122,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   position: relative;
 }
 
@@ -139,7 +139,7 @@ exports[`InternalChevronAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/components/internal-components/InternalLink/__snapshots__/InternalLink.test.tsx.snap
+++ b/src/components/internal-components/InternalLink/__snapshots__/InternalLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InternalLink matches snapshot 1`] = `
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0 {

--- a/src/components/internal-components/InternalRadioWrapper/__snapshots__/InternalRadioWrapper.test.tsx.snap
+++ b/src/components/internal-components/InternalRadioWrapper/__snapshots__/InternalRadioWrapper.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`InternalRadioWrapper matches snapshot 1`] = `
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -17,7 +17,7 @@ exports[`InternalRadioWrapper matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/internal-components/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
+++ b/src/components/internal-components/InternalReviewAccordion/__snapshots__/InternalReviewAccordion.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`InternalReviewAccordion matches snapshot 1`] = `
 .c0 {
   padding-top: 1.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -11,11 +11,11 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -26,7 +26,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   color: #222222;
   background: #222222;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -35,7 +35,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -45,7 +45,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -57,7 +57,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   margin-top: 1.5rem;
   background: #ffffff;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -120,7 +120,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -140,7 +140,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 
@@ -207,7 +207,7 @@ exports[`InternalReviewAccordion matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5:hover {

--- a/src/components/internal-components/InternalShadowIconButton/__snapshots__/InternalShadowIconButton.test.tsx.snap
+++ b/src/components/internal-components/InternalShadowIconButton/__snapshots__/InternalShadowIconButton.test.tsx.snap
@@ -6,25 +6,25 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   padding-left: 0rem;
   padding-right: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
   position: relative;
   color: #575757;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -36,7 +36,7 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -48,7 +48,7 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -58,7 +58,7 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -103,7 +103,7 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
 }
 
 .c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -123,7 +123,7 @@ exports[`InternalShadowIconButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #575757;
   border-radius: 0.25rem;
 }

--- a/src/components/internal-components/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
+++ b/src/components/internal-components/InternalShadowRectButton/__snapshots__/InternalShadowRectButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -53,7 +53,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -74,7 +74,7 @@ exports[`InternalShadowRectButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #bef2bd;
   padding-left: 1rem;

--- a/src/components/internal-components/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
+++ b/src/components/internal-components/InternalShadowRoundButton/__snapshots__/InternalShadowRoundButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -21,7 +21,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   color: #575757;
   background: #bef2bd;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -30,7 +30,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -40,7 +40,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -85,7 +85,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -105,7 +105,7 @@ exports[`InternalShadowRoundButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #575757;
 }
 

--- a/src/components/internal-components/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
+++ b/src/components/internal-components/InternalTooltip/__snapshots__/InternalTooltip.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`InternalTooltip matches snapshot 1`] = `
   max-width: 22.5rem;
   color: #ffffff;
   background: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/internal-components/InternalUnstyledChevronAccordion/__snapshots__/InternalUnstyledChevronAccordion.test.tsx.snap
+++ b/src/components/internal-components/InternalUnstyledChevronAccordion/__snapshots__/InternalUnstyledChevronAccordion.test.tsx.snap
@@ -4,15 +4,15 @@ exports[`InternalUnstyledChevronAccordion matches snapshot 1`] = `
 .c0 {
   padding-top: 2.5rem;
   padding-bottom: 2.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4:hover {
@@ -22,7 +22,7 @@ exports[`InternalUnstyledChevronAccordion matches snapshot 1`] = `
 .c8 {
   margin-right: 0.75rem;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -32,13 +32,13 @@ exports[`InternalUnstyledChevronAccordion matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
   position: relative;
   overflow: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
@@ -99,7 +99,7 @@ exports[`InternalUnstyledChevronAccordion matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7:hover .chevron-icon {

--- a/src/components/layout-and-structure/OakAccordion/__snapshots__/OakAccordion.test.tsx.snap
+++ b/src/components/layout-and-structure/OakAccordion/__snapshots__/OakAccordion.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakAccordion matches snapshot 1`] = `
   background: #f2f2f2;
   border: 0.063rem solid;
   border-color: #cacaca;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -23,7 +23,7 @@ exports[`OakAccordion matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3:hover {
@@ -38,19 +38,19 @@ exports[`OakAccordion matches snapshot 1`] = `
   min-height: 1.5rem;
   margin-right: 1rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
   margin-left: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
   padding-left: 1rem;
   margin-left: 1.5rem;
   margin-top: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/layout-and-structure/OakBasicAccordion/__snapshots__/OakBasicAccordion.test.tsx.snap
+++ b/src/components/layout-and-structure/OakBasicAccordion/__snapshots__/OakBasicAccordion.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3:hover {
@@ -19,7 +19,7 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
 .c9 {
   position: relative;
   margin-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -28,7 +28,7 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -38,18 +38,18 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
   position: relative;
   overflow: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
 .c14 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -117,7 +117,7 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   position: relative;
 }
 
@@ -134,7 +134,7 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -154,11 +154,11 @@ exports[`OakBasicAccordion matches snapshot 1`] = `
 }
 
 .c15 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/layout-and-structure/OakBox/__snapshots__/OakBox.test.tsx.snap
+++ b/src/components/layout-and-structure/OakBox/__snapshots__/OakBox.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/layout-and-structure/OakCollapsibleContent/__snapshots__/OakCollapsibleContent.test.tsx.snap
+++ b/src/components/layout-and-structure/OakCollapsibleContent/__snapshots__/OakCollapsibleContent.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakCollapsibleContent matches snapshot 1`] = `
 .c0 {
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -13,7 +13,7 @@ exports[`OakCollapsibleContent matches snapshot 1`] = `
   padding-bottom: 1.5rem;
   background: #e4e4e4;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -21,7 +21,7 @@ exports[`OakCollapsibleContent matches snapshot 1`] = `
   width: 100%;
   max-height: 100%;
   padding-right: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 

--- a/src/components/layout-and-structure/OakFlex/__snapshots__/OakFlex.test.tsx.snap
+++ b/src/components/layout-and-structure/OakFlex/__snapshots__/OakFlex.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakBox matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/layout-and-structure/OakGrid/__snapshots__/OakGrid.test.tsx.snap
+++ b/src/components/layout-and-structure/OakGrid/__snapshots__/OakGrid.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakGrid matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/layout-and-structure/OakGridArea/__snapshots__/OakGridArea.test.tsx.snap
+++ b/src/components/layout-and-structure/OakGridArea/__snapshots__/OakGridArea.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakGrid matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/layout-and-structure/OakMaxWidth/__snapshots__/OakMaxWidth.test.tsx.snap
+++ b/src/components/layout-and-structure/OakMaxWidth/__snapshots__/OakMaxWidth.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OakMaxWidth matches snapshot 1`] = `
   padding-right: 0rem;
   margin-left: auto;
   margin-right: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/messaging-and-feedback/OakFocusIndicator/__snapshots__/OakFocusIndicator.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakFocusIndicator/__snapshots__/OakFocusIndicator.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakFocusIndicator default render 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -37,7 +37,7 @@ exports[`OakFocusIndicator default render 1`] = `
 
 exports[`OakFocusIndicator renders correctly with props set 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/messaging-and-feedback/OakHandDrawnFocusUnderline/__snapshots__/OakHandDrawnFocusUnderline.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakHandDrawnFocusUnderline/__snapshots__/OakHandDrawnFocusUnderline.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakHandDrawnFocusUnderline matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/messaging-and-feedback/OakInformativeModal/__snapshots__/OakInformativeModal.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakInformativeModal/__snapshots__/OakInformativeModal.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakInformativeModal matches snapshot when mounted 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -16,19 +16,19 @@ exports[`OakInformativeModal matches snapshot when mounted 1`] = `
   background: #ffffff;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: 300;
 }
 
 .c5 {
   height: 100%;
   background: #ffffff;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
   padding: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -36,11 +36,11 @@ exports[`OakInformativeModal matches snapshot when mounted 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -51,7 +51,7 @@ exports[`OakInformativeModal matches snapshot when mounted 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -60,7 +60,7 @@ exports[`OakInformativeModal matches snapshot when mounted 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
@@ -70,14 +70,14 @@ exports[`OakInformativeModal matches snapshot when mounted 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c21 {
   overflow: auto;
   border-top: 0.063rem solid;
   border-color: transparent;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
@@ -162,7 +162,7 @@ exports[`OakInformativeModal matches snapshot when mounted 1`] = `
 }
 
 .c20 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -182,7 +182,7 @@ exports[`OakInformativeModal matches snapshot when mounted 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: transparent;
 }
 

--- a/src/components/messaging-and-feedback/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -12,17 +12,17 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: relative;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -32,7 +32,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -40,7 +40,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -51,7 +51,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -60,7 +60,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -70,16 +70,16 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -91,7 +91,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
 
 .c23 {
   margin-top: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -201,7 +201,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
 }
 
 .c18 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -212,7 +212,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
 }
 
 .c25 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -225,7 +225,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: transparent;
 }
 
@@ -293,7 +293,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
 }
 
 .c21 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -479,17 +479,17 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: relative;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -499,14 +499,14 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   height: 2.5rem;
   min-height: 2.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
   position: absolute;
   top: 0rem;
   right: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -514,7 +514,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -525,7 +525,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -534,7 +534,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
@@ -544,16 +544,16 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c20 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c23 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -565,7 +565,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
 
 .c24 {
   margin-top: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -675,7 +675,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
 }
 
 .c19 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -686,7 +686,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
 }
 
 .c26 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -699,7 +699,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: transparent;
 }
 
@@ -767,7 +767,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
 }
 
 .c22 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -953,17 +953,17 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: relative;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -973,7 +973,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -981,7 +981,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -992,7 +992,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -1001,7 +1001,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -1011,16 +1011,16 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c21 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -1137,7 +1137,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
 }
 
 .c18 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -1148,7 +1148,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
 }
 
 .c23 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -1161,7 +1161,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: transparent;
 }
 

--- a/src/components/messaging-and-feedback/OakKbd/__snapshots__/OakKbd.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakKbd/__snapshots__/OakKbd.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`OakKbd matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/messaging-and-feedback/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakModalCenter/__snapshots__/OakModalCenter.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
 .c0 {
   position: fixed;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -12,7 +12,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   position: fixed;
   inset: 0rem;
   background: #22222240;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: -1;
 }
 
@@ -20,7 +20,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   width: 100%;
   max-width: 60rem;
   padding: 1.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,20 +28,20 @@ exports[`OakModalCenter matches snapshot 1`] = `
   width: 100%;
   background: #ffffff;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
   position: relative;
   min-height: 3.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -49,11 +49,11 @@ exports[`OakModalCenter matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
@@ -64,7 +64,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -73,7 +73,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c20 {
@@ -83,7 +83,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c23 {
@@ -93,7 +93,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   border-top: 0rem solid;
   border-bottom: 0rem solid;
   border-color: #cacaca;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
@@ -149,7 +149,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
 }
 
 .c22 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -169,7 +169,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: transparent;
 }
 
@@ -234,7 +234,7 @@ exports[`OakModalCenter matches snapshot 1`] = `
 
 .c6 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {

--- a/src/components/messaging-and-feedback/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakModalCenter/__snapshots__/OakModalCenterBody.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
 .c0 {
   width: 100%;
   padding-bottom: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,7 +15,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
   min-height: 6.25rem;
   margin-bottom: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -41,7 +41,7 @@ exports[`OakModalCenterBody matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;

--- a/src/components/messaging-and-feedback/OakTagFunctional/__snapshots__/OakTagFunctional.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakTagFunctional/__snapshots__/OakTagFunctional.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakTagFunctional matches snapshot 1`] = `
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -26,7 +26,7 @@ exports[`OakTagFunctional matches snapshot 1`] = `
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/messaging-and-feedback/OakToast/__snapshots__/OakToast.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakToast/__snapshots__/OakToast.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`OakToast matches snapshot 1`] = `
   background: #bef2bd;
   border-radius: 0.5rem;
   box-shadow: 0 0.5rem 0.5rem rgba(92,92,92,20%);
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -24,7 +24,7 @@ exports[`OakToast matches snapshot 1`] = `
 
 .c3 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -33,7 +33,7 @@ exports[`OakToast matches snapshot 1`] = `
   height: 1.25rem;
   background: #ffffff;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -43,7 +43,7 @@ exports[`OakToast matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -51,20 +51,20 @@ exports[`OakToast matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
   padding-left: 0rem;
   padding-right: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
   position: relative;
   color: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -76,7 +76,7 @@ exports[`OakToast matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -88,7 +88,7 @@ exports[`OakToast matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c21 {
@@ -98,7 +98,7 @@ exports[`OakToast matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -155,7 +155,7 @@ exports[`OakToast matches snapshot 1`] = `
 }
 
 .c23 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -175,7 +175,7 @@ exports[`OakToast matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: transparent;
   border-radius: 0.25rem;
 }

--- a/src/components/messaging-and-feedback/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakTooltip/__snapshots__/OakTooltip.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakTooltip matches snapshot 1`] = `
 .c0 {
   position: fixed;
   pointer-events: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -21,7 +21,7 @@ exports[`OakTooltip matches snapshot 1`] = `
   -webkit-transform: translateY(calc(100% + 1rem));
   -ms-transform: translateY(calc(100% + 1rem));
   transform: translateY(calc(100% + 1rem));
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -35,7 +35,7 @@ exports[`OakTooltip matches snapshot 1`] = `
   background: #ffe555;
   border-radius: 0.375rem;
   border-top-left-radius: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/navigation/OakBreadcrumbs/__snapshots__/OakBreadcrumbs.test.tsx.snap
+++ b/src/components/navigation/OakBreadcrumbs/__snapshots__/OakBreadcrumbs.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`OakBreadcrumbs matches snapshot 1`] = `
 .c0 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   overflow: hidden;
   min-width: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -22,7 +22,7 @@ exports[`OakBreadcrumbs matches snapshot 1`] = `
   height: 1.25rem;
   min-height: 1.25rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakBreadcrumbs matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {

--- a/src/components/navigation/OakCard/__snapshots__/OakCard.test.tsx.snap
+++ b/src/components/navigation/OakCard/__snapshots__/OakCard.test.tsx.snap
@@ -6,32 +6,32 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
   height: 100%;
   background: #ffffff;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   height: 100%;
   padding: 1rem;
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
   width: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
   height: auto;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -41,7 +41,7 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
   padding-bottom: 0.25rem;
   background: #ffe555;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -58,7 +58,7 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -156,7 +156,7 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
 }
 
 .c12 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -180,15 +180,15 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
 }
 
 .c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {

--- a/src/components/navigation/OakHoverLink/__snapshots__/OakHoverLink.test.tsx.snap
+++ b/src/components/navigation/OakHoverLink/__snapshots__/OakHoverLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakHoverLink matches snapshot 1`] = `
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0 {

--- a/src/components/navigation/OakLink/__snapshots__/OakLink.test.tsx.snap
+++ b/src/components/navigation/OakLink/__snapshots__/OakLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakLink matches snapshot 1`] = `
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0 {

--- a/src/components/navigation/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/navigation/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakPagination Component matches snapshot 1`] = `
 .c0 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -13,7 +13,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -40,8 +40,8 @@ exports[`OakPagination Component matches snapshot 1`] = `
   margin-left: 0.25rem;
   margin-right: 0.25rem;
   display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: revert;
   display: revert;
 }
@@ -55,7 +55,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -63,7 +63,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -137,7 +137,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   justify-content: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -178,7 +178,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
   justify-content: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/navigation/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
+++ b/src/components/navigation/OakPrimaryNav/__snapshots__/OakPrimaryNav.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   margin-right: 0rem;
   margin-top: 0rem;
   margin-bottom: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -17,7 +17,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -26,11 +26,11 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -65,15 +65,15 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
 
 .c2 {
   display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   list-style: none;
   display: revert;
   display: revert;
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -94,7 +94,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -122,7 +122,7 @@ exports[`OakPrimaryNav matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;

--- a/src/components/navigation/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
+++ b/src/components/navigation/OakPrimaryNavItem/__snapshots__/OakPrimaryNavItem.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -43,7 +43,7 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -64,7 +64,7 @@ exports[`OakPrimaryNavItem matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;

--- a/src/components/navigation/OakSecondaryLink/__snapshots__/OakSecondaryLink.test.tsx.snap
+++ b/src/components/navigation/OakSecondaryLink/__snapshots__/OakSecondaryLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakSecondaryLink matches snapshot 1`] = `
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0 {

--- a/src/components/owa/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
+++ b/src/components/owa/OakBackLink/__snapshots__/OakBackLink.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`OakBackLink matches snapshot 1`] = `
   height: 2.5rem;
   min-height: 2.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/owa/OakBulletList/__snapshots__/OakBulletList.test.tsx.snap
+++ b/src/components/owa/OakBulletList/__snapshots__/OakBulletList.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakBulletList matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/owa/OakCardWithHandDrawnBorder/__snapshots__/OakCardWithHandDrawnBorder.test.tsx.snap
+++ b/src/components/owa/OakCardWithHandDrawnBorder/__snapshots__/OakCardWithHandDrawnBorder.test.tsx.snap
@@ -7,18 +7,18 @@ exports[`OakCardWithHandDrawnBorder matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/OakCloudinaryImage/__snapshots__/OakCloudinaryImage.test.tsx.snap
+++ b/src/components/owa/OakCloudinaryImage/__snapshots__/OakCloudinaryImage.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakCloudinaryImage matches snapshot 1`] = `
   position: relative;
   width: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
+++ b/src/components/owa/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`OakCodeRenderer matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
   padding-right: 0.75rem;
   border-right: 0.063rem solid;
   border-color: #808080;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -17,12 +17,12 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   margin-top: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c20 {
@@ -30,7 +30,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c27 {
@@ -41,7 +41,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c29 {
@@ -50,7 +50,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c30 {
@@ -60,7 +60,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -140,7 +140,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -151,7 +151,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   padding-top: 0rem;
   padding-bottom: 0rem;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.5rem;
@@ -170,7 +170,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.5rem;
@@ -183,26 +183,26 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
 
 .c8 {
   padding-left: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
   color: #9EE8FF;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
   color: #EECCFF;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
   color: #94F9AF;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -213,7 +213,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
 }
 
 .c19 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -224,7 +224,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
 }
 
 .c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -233,13 +233,13 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   margin: 0;
   display: block;
   padding-left: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
   display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: revert;
   display: revert;
 }
@@ -254,7 +254,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/owa/OakCopyLinkButton/__snapshots__/OakCopyLinkButton.test.tsx.snap
+++ b/src/components/owa/OakCopyLinkButton/__snapshots__/OakCopyLinkButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakCopyLinkButton matches snapshot 1`] = `
 .c0 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -12,7 +12,7 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -21,11 +21,11 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -35,12 +35,12 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -63,7 +63,7 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -84,7 +84,7 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 0.5rem;

--- a/src/components/owa/OakDownloadCard/__snapshots__/OakDownloadCard.test.tsx.snap
+++ b/src/components/owa/OakDownloadCard/__snapshots__/OakDownloadCard.test.tsx.snap
@@ -7,18 +7,18 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
   padding: 0.75rem;
   background: #ffe555;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -28,7 +28,7 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   height: 3rem;
   min-height: 3rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -36,11 +36,11 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   padding-right: 1rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -51,7 +51,7 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
 }
 
 .c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -63,14 +63,14 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
 
 .c14 {
   padding-right: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
@@ -80,7 +80,7 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c24 {
@@ -90,7 +90,7 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -345,18 +345,18 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
   padding: 0.75rem;
   background: #ffe555;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -366,7 +366,7 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   height: 3rem;
   min-height: 3rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -374,11 +374,11 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   padding-right: 1rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -389,7 +389,7 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
 }
 
 .c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -401,14 +401,14 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
 
 .c14 {
   padding-right: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
@@ -418,7 +418,7 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c24 {
@@ -428,7 +428,7 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/owa/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -17,13 +17,13 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
   position: relative;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -33,16 +33,16 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -56,11 +56,11 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   padding: 0rem;
   margin: 0rem;
   border-style: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -74,7 +74,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
@@ -86,7 +86,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c25 {
@@ -95,7 +95,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c27 {
@@ -104,7 +104,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c32 {
@@ -114,7 +114,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -254,7 +254,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c31 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -275,7 +275,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;
@@ -373,7 +373,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 }
 
 .c15 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/owa/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
+++ b/src/components/owa/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakDragAndDropInstructions matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -12,11 +12,11 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -58,7 +58,7 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/owa/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
+++ b/src/components/owa/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
@@ -10,11 +10,11 @@ exports[`OakDraggable matches snapshot 1`] = `
   color: #222222;
   background: #ffffff;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -24,11 +24,11 @@ exports[`OakDraggable matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/owa/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
+++ b/src/components/owa/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
@@ -12,11 +12,11 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
   border: 0.25rem solid;
   border-color: #287c34;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -26,11 +26,11 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/owa/OakDroppable/__snapshots__/OakDroppable.test.tsx.snap
+++ b/src/components/owa/OakDroppable/__snapshots__/OakDroppable.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakDroppable matches snapshot 1`] = `
   padding: 1rem;
   background: #d7f1ef;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,12 +13,12 @@ exports[`OakDroppable matches snapshot 1`] = `
   padding: 0.25rem;
   background: #f2f2f2;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
+++ b/src/components/owa/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -16,13 +16,13 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   background: #ffffff;
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: 300;
 }
 
 .c5 {
   margin: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -30,11 +30,11 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -45,7 +45,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -54,7 +54,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c20 {
@@ -64,21 +64,21 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c23 {
   overflow: auto;
   border-top: 0.063rem solid;
   border-color: transparent;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
 .c25 {
   margin-left: 1.5rem;
   margin-right: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c26 {
@@ -86,7 +86,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   padding: 0.75rem;
   border-top: 0.063rem solid;
   border-color: #cacaca;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -181,11 +181,11 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -205,7 +205,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: transparent;
 }
 
@@ -269,7 +269,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;

--- a/src/components/owa/OakFormInputWithLabels/__snapshots__/OakFormInputWithLabels.test.tsx.snap
+++ b/src/components/owa/OakFormInputWithLabels/__snapshots__/OakFormInputWithLabels.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`OakFormInputWithLabels should match snapshot 1`] = `
 .c0 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -21,7 +21,7 @@ exports[`OakFormInputWithLabels should match snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #cacaca;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -125,7 +125,7 @@ exports[`OakFormInputWithLabels should match snapshot 1`] = `
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/owa/OakHandDrawnCard/__snapshots__/OakHandDrawnCard.test.tsx.snap
+++ b/src/components/owa/OakHandDrawnCard/__snapshots__/OakHandDrawnCard.test.tsx.snap
@@ -7,18 +7,18 @@ exports[`OakHandDrawnCard matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
+++ b/src/components/owa/OakHandDrawnCardWithIcon/__snapshots__/OakHandDrawnCardWithIcon.test.tsx.snap
@@ -6,18 +6,18 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
   width: 5rem;
   height: 5rem;
   padding: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: absolute;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -27,7 +27,7 @@ exports[`OakHandDrawnCardWithIcon matches snapshot 1`] = `
   height: 4rem;
   min-height: 4rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
+++ b/src/components/owa/OakHandDrawnHR/__snapshots__/OakHandDrawnHR.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakHandDrawnHR matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
+++ b/src/components/owa/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   overflow-x: hidden;
   width: 100%;
   background: #a0b6f2;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -15,57 +15,57 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   padding-right: 0rem;
   margin-left: auto;
   margin-right: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
   min-width: 100%;
   min-height: 22.5rem;
   background: #a0b6f2;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: 0;
 }
 
 .c5 {
   height: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
   max-width: 40rem;
   min-height: 0rem;
   margin-bottom: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
   margin-bottom: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
   position: relative;
   width: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
   position: relative;
   min-height: 11.25rem;
   margin-bottom: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c24 {
@@ -77,7 +77,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   -webkit-transform: rotate(-2.025deg);
   -ms-transform: rotate(-2.025deg);
   transform: rotate(-2.025deg);
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: 1;
 }
 
@@ -86,7 +86,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   top: 0rem;
   bottom: 0rem;
   width: 22.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c27 {
@@ -96,14 +96,14 @@ exports[`OakHeaderHero matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c29 {
   padding-top: 1.5rem;
   margin-left: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -209,7 +209,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c19 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -220,7 +220,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c20 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -231,7 +231,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c21 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -243,7 +243,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -279,7 +279,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {

--- a/src/components/owa/OakHomepageTabButton/__snapshots__/OakHomepageTabButton.test.tsx.snap
+++ b/src/components/owa/OakHomepageTabButton/__snapshots__/OakHomepageTabButton.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0:disabled {
@@ -21,7 +21,7 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
 
 .c2 {
   height: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -31,13 +31,13 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
   height: 3rem;
   min-height: 3rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
   position: relative;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -45,7 +45,7 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
   bottom: 0rem;
   width: 100%;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -91,7 +91,7 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
 
 .c8 {
   color: #575757;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/owa/OakInfo/__snapshots__/OakInfo.test.tsx.snap
+++ b/src/components/owa/OakInfo/__snapshots__/OakInfo.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakInfo matches snapshot 1`] = `
 .c0 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -11,11 +11,11 @@ exports[`OakInfo matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -26,7 +26,7 @@ exports[`OakInfo matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -35,7 +35,7 @@ exports[`OakInfo matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -45,7 +45,7 @@ exports[`OakInfo matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -90,7 +90,7 @@ exports[`OakInfo matches snapshot 1`] = `
 }
 
 .c14 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -110,7 +110,7 @@ exports[`OakInfo matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/owa/OakInfoButton/__snapshots__/OakInfoButton.test.tsx.snap
+++ b/src/components/owa/OakInfoButton/__snapshots__/OakInfoButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakInfoButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -21,7 +21,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -30,7 +30,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -40,7 +40,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -85,7 +85,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -105,7 +105,7 @@ exports[`OakInfoButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/owa/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
+++ b/src/components/owa/OakLessonInfoCard/__snapshots__/OakLessonInfoCard.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -19,7 +19,7 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -46,7 +46,7 @@ exports[`OakLessonInfoCard component test matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;

--- a/src/components/owa/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
+++ b/src/components/owa/OakLinkCard/__snapshots__/OakLinkCard.test.tsx.snap
@@ -7,21 +7,21 @@ exports[`OakLinkCard matches snapshot 1`] = `
   background: #ffffff;
   border-radius: 0.5rem;
   box-shadow: 0 0 0.5rem rgba(92,92,92,20%);
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -29,13 +29,13 @@ exports[`OakLinkCard matches snapshot 1`] = `
   width: 5rem;
   height: 5rem;
   padding: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
   position: absolute;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -45,7 +45,7 @@ exports[`OakLinkCard matches snapshot 1`] = `
   height: 4rem;
   min-height: 4rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -129,7 +129,7 @@ exports[`OakLinkCard matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -140,7 +140,7 @@ exports[`OakLinkCard matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 @media (min-width:750px) {

--- a/src/components/owa/OakListItem/__snapshots__/OakListItem.test.tsx.snap
+++ b/src/components/owa/OakListItem/__snapshots__/OakListItem.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakListItem matches snapshot 1`] = `
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -13,14 +13,14 @@ exports[`OakListItem matches snapshot 1`] = `
   border-bottom-left-radius: 0.375rem;
   border-bottom-right-radius: 0.375rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
   width: 100%;
   height: 100%;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -28,26 +28,26 @@ exports[`OakListItem matches snapshot 1`] = `
   background: #deb7d5;
   border-top-left-radius: 0.375rem;
   border-bottom-left-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
   padding-right: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
   min-width: 5rem;
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
   min-width: 10rem;
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -68,12 +68,12 @@ exports[`OakListItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c25 {
@@ -82,12 +82,12 @@ exports[`OakListItem matches snapshot 1`] = `
   height: 2.5rem;
   background: #deb7d5;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c28 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -228,7 +228,7 @@ exports[`OakListItem matches snapshot 1`] = `
 }
 
 .c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -240,7 +240,7 @@ exports[`OakListItem matches snapshot 1`] = `
 }
 
 .c27 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -257,8 +257,8 @@ exports[`OakListItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   list-style: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -275,7 +275,7 @@ exports[`OakListItem matches snapshot 1`] = `
 
 .c13 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;

--- a/src/components/owa/OakMediaClip/__snapshots__/OakMediaClip.test.tsx.snap
+++ b/src/components/owa/OakMediaClip/__snapshots__/OakMediaClip.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakMediaClip matches snapshot 1`] = `
 .c1 {
   position: relative;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -13,12 +13,12 @@ exports[`OakMediaClip matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -27,14 +27,14 @@ exports[`OakMediaClip matches snapshot 1`] = `
   height: 3.5rem;
   margin-right: 1rem;
   border-radius: 0.125rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
   position: relative;
   width: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -44,7 +44,7 @@ exports[`OakMediaClip matches snapshot 1`] = `
   color: #ffffff;
   background: #222222;
   border-radius: 0.125rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
   line-height: 1rem;
@@ -99,7 +99,7 @@ exports[`OakMediaClip matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #ffffff;
   padding: 0.5rem;
@@ -142,7 +142,7 @@ exports[`OakMediaClip matches snapshot 1`] = `
 }
 
 .c19 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -155,7 +155,7 @@ exports[`OakMediaClip matches snapshot 1`] = `
 }
 
 .c20 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -172,14 +172,14 @@ exports[`OakMediaClip matches snapshot 1`] = `
 .c0 {
   margin-bottom: 0.5rem;
   display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: revert;
   display: revert;
 }
 
 .c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {

--- a/src/components/owa/OakMediaClipList/__snapshots__/OakMediaClipList.test.tsx.snap
+++ b/src/components/owa/OakMediaClipList/__snapshots__/OakMediaClipList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakMediaClipList matches snapshot 1`] = `
 .c0 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -15,11 +15,11 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   border-left: 0.125rem solid;
   border-color: #222222;
   border-style: solid;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6:hover {
@@ -31,13 +31,13 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   padding-right: 1rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   text-align: left;
 }
 
 .c12 {
   margin-bottom: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -49,7 +49,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
 
 .c14 {
   margin-bottom: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -60,7 +60,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
 }
 
 .c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -73,7 +73,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
 .c17 {
   position: relative;
   margin-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
@@ -82,7 +82,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -92,23 +92,23 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c21 {
   position: relative;
   overflow: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
 .c22 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c27 {
   pointer-events: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -151,7 +151,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -162,7 +162,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
 }
 
 .c15 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -180,7 +180,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c20 {
@@ -219,7 +219,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   position: relative;
 }
 
@@ -241,7 +241,7 @@ exports[`OakMediaClipList matches snapshot 1`] = `
   border-left: 0.125rem solid;
   border-color: #222222;
   border-style: solid;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/components/owa/OakMediaClipListAccordion/__snapshots__/OakMediaClipListAccordion.test.tsx.snap
+++ b/src/components/owa/OakMediaClipListAccordion/__snapshots__/OakMediaClipListAccordion.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakMediaClipListAccordion matches snapshot 1`] = `
 .c0 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -14,11 +14,11 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   border-left: 0.125rem solid;
   border-color: #222222;
   border-style: solid;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6:hover {
@@ -28,7 +28,7 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
 .c11 {
   position: relative;
   margin-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -37,7 +37,7 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -47,23 +47,23 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
   position: relative;
   overflow: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
 .c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c20 {
   pointer-events: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -141,7 +141,7 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   position: relative;
 }
 
@@ -162,7 +162,7 @@ exports[`OakMediaClipListAccordion matches snapshot 1`] = `
   border-left: 0.125rem solid;
   border-color: #222222;
   border-style: solid;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/components/owa/OakMediaClipStackListItem/__snapshots__/OakMediaClipStackListItem.test.tsx.snap
+++ b/src/components/owa/OakMediaClipStackListItem/__snapshots__/OakMediaClipStackListItem.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -22,14 +22,14 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
   height: 4rem;
   margin-bottom: 0rem;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
   position: relative;
   width: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -39,17 +39,17 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
   margin-bottom: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
   color: #575757;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -88,7 +88,7 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
 }
 
 .c14 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -99,7 +99,7 @@ exports[`OakMediaClipStackListItem matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/owa/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
+++ b/src/components/owa/OakOutlineAccordion/__snapshots__/OakOutlineAccordion.test.tsx.snap
@@ -3,22 +3,22 @@
 exports[`OakOutlineAccordion matches snapshot 1`] = `
 .c0 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8:hover {
@@ -28,7 +28,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
 .c13 {
   position: relative;
   margin-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -37,7 +37,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -47,19 +47,19 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
   position: relative;
   overflow: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
 .c20 {
   pointer-events: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -137,7 +137,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   position: relative;
 }
 
@@ -154,7 +154,7 @@ exports[`OakOutlineAccordion matches snapshot 1`] = `
   position: relative;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/components/owa/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
+++ b/src/components/owa/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
@@ -8,13 +8,13 @@ exports[`OakPromoTag matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
   position: absolute;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -35,7 +35,7 @@ exports[`OakPromoTag matches snapshot 1`] = `
 .c5 {
   color: #ffe555;
   background: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/owa/OakRadioTile/__snapshots__/OakRadioTile.test.tsx.snap
+++ b/src/components/owa/OakRadioTile/__snapshots__/OakRadioTile.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`OakRadioTile matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #808080;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -19,7 +19,7 @@ exports[`OakRadioTile matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #808080;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -45,7 +45,7 @@ exports[`OakRadioTile matches snapshot 1`] = `
 }
 
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/owa/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
+++ b/src/components/owa/OakSaveCount/__snapshots__/OakSaveCount.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
   border: 0.063rem solid;
   border-color: #bef2bd;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -28,12 +28,12 @@ exports[`OakSaveCount should match snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -57,7 +57,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0 {
@@ -70,7 +70,7 @@ exports[`OakSaveCount should match snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0:disabled {

--- a/src/components/owa/OakScaleImageButton/__snapshots__/OakScaleImageButton.test.tsx.snap
+++ b/src/components/owa/OakScaleImageButton/__snapshots__/OakScaleImageButton.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakScaleImageButton matches snapshot 1`] = `
   position: relative;
   width: 100%;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -14,11 +14,11 @@ exports[`OakScaleImageButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,7 +28,7 @@ exports[`OakScaleImageButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -51,7 +51,7 @@ exports[`OakScaleImageButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -72,7 +72,7 @@ exports[`OakScaleImageButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #f2f2f2;
   padding-left: 0rem;

--- a/src/components/owa/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
+++ b/src/components/owa/OakSideMenuNav/__snapshots__/OakSideMenuNav.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 .c2 {
   padding: 3rem;
   background: #dff9de;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -19,7 +19,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   min-height: 2rem;
   padding-left: 0.75rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -54,7 +54,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 
 .c11 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -66,7 +66,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 
 .c12 {
   color: #575757;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -121,7 +121,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -134,8 +134,8 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
 
 .c6 {
   display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: revert;
   display: revert;
 }
@@ -149,7 +149,7 @@ exports[`OakSideMenuNav matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/components/owa/OakSideMenuNavLink/__snapshots__/OakSideMenuNavLink.test.tsx.snap
+++ b/src/components/owa/OakSideMenuNavLink/__snapshots__/OakSideMenuNavLink.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakSideMenuNavLink matches snapshot 1`] = `
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -13,7 +13,7 @@ exports[`OakSideMenuNavLink matches snapshot 1`] = `
   min-height: 2rem;
   padding-left: 0.75rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -37,7 +37,7 @@ exports[`OakSideMenuNavLink matches snapshot 1`] = `
 
 .c4 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -49,7 +49,7 @@ exports[`OakSideMenuNavLink matches snapshot 1`] = `
 
 .c5 {
   color: #575757;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/owa/OakSignLanguageButton/__snapshots__/OakSignLanguageButton.test.tsx.snap
+++ b/src/components/owa/OakSignLanguageButton/__snapshots__/OakSignLanguageButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakSignLanguageButton matches snapshot 1`] = `
 .c0 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -12,7 +12,7 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -21,11 +21,11 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -35,12 +35,12 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -63,7 +63,7 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -84,7 +84,7 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 0.5rem;

--- a/src/components/owa/OakSubjectIconButton/__snapshots__/OakSubjectIconButton.test.tsx.snap
+++ b/src/components/owa/OakSubjectIconButton/__snapshots__/OakSubjectIconButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`OakSubjectIconButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -15,12 +15,12 @@ exports[`OakSubjectIconButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   width: 7.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakSubjectIconButton matches snapshot 1`] = `
   height: 2rem;
   min-height: 4.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -53,7 +53,7 @@ exports[`OakSubjectIconButton matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -74,7 +74,7 @@ exports[`OakSubjectIconButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #f5e9f2;
   padding-left: 0.75rem;

--- a/src/components/owa/OakTimer/__snapshots__/OakTimer.test.tsx.snap
+++ b/src/components/owa/OakTimer/__snapshots__/OakTimer.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakTimer matches snapshot 1`] = `
   color: #ffffff;
   background: #222222;
   border-radius: 0.125rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.75rem;
   line-height: 1rem;
@@ -16,7 +16,7 @@ exports[`OakTimer matches snapshot 1`] = `
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
+++ b/src/components/owa/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`OakVideoTranscript matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -16,7 +16,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -25,7 +25,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -35,17 +35,17 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -59,7 +59,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   color: #222222;
   background: #e4e4e4;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -74,7 +74,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   width: 100%;
   max-height: 100%;
   padding-right: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
@@ -135,7 +135,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -156,7 +156,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 0.5rem;

--- a/src/components/owa/pupil/browse/OakPupilJourneyHeader/__snapshots__/OakPupilJourneyHeader.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyHeader/__snapshots__/OakPupilJourneyHeader.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`OakPupilJourneyHeader matches snapshot 1`] = `
 .c12 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -14,18 +14,18 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
   width: 4rem;
   height: 4rem;
   padding: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
   position: absolute;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -35,7 +35,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
   height: 3rem;
   min-height: 3rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -98,7 +98,7 @@ exports[`OakPupilJourneyHeader matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;

--- a/src/components/owa/pupil/browse/OakPupilJourneyLayout/__snapshots__/OakPupilJourneyLayout.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyLayout/__snapshots__/OakPupilJourneyLayout.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakPupilJourneyLayout matches snapshot 1`] = `
 .c0 {
   padding-left: 0.75rem;
   padding-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/pupil/browse/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyList/__snapshots__/OakPupilJourneyList.test.tsx.snap
@@ -4,19 +4,19 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
 .c0 {
   width: 100%;
   background: #f5e9f2;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   padding-top: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
   padding: 1rem;
   background: #efdbea;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/pupil/browse/OakPupilJourneyListCounter/__snapshots__/OakPupilJourneyListCount.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyListCounter/__snapshots__/OakPupilJourneyListCount.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakPupilJourneyListCount matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -13,7 +13,7 @@ exports[`OakPupilJourneyListCount matches snapshot 1`] = `
 }
 
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.25rem;
   line-height: 1.5rem;

--- a/src/components/owa/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyListItem/__snapshots__/OakPupilJourneyListItem.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -12,12 +12,12 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   border: 0rem solid;
   border-color: transparent;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -31,7 +31,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
 
 .c8 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -47,7 +47,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -57,7 +57,7 @@ exports[`OakPupilJourneyListItem matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {

--- a/src/components/owa/pupil/browse/OakPupilJourneyListItemSubheading/__snapshots__/OakPupilJourneyListItemSubheading.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyListItemSubheading/__snapshots__/OakPupilJourneyListItemSubheading.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -21,15 +21,15 @@ exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
   border: 0.063rem solid;
   border-color: #ffe555;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -55,7 +55,7 @@ exports[`OakPupilJourneyListItemSubheading matches snapshot 1`] = `
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;

--- a/src/components/owa/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyOptionalityButton/__snapshots__/OakPupilJourneyOptionalityButton.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
 .c0 {
   color: #222222;
   background: #ffffff;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -13,27 +13,27 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: absolute;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -45,7 +45,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
 
 .c13 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -61,7 +61,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   padding: 0.25rem;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -71,7 +71,7 @@ exports[`OakPupilJourneyOptionalityButton matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyOptionalityItem/__snapshots__/OakPupilJourneyOptionalityItem.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   padding: 1.5rem;
   background: #ffffff;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -28,7 +28,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 
 .c6 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -41,7 +41,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 .c8 {
   color: #222222;
   background: #ffffff;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -50,23 +50,23 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   padding: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
   position: absolute;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -78,7 +78,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
 
 .c20 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -94,7 +94,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   padding: 0.25rem;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
@@ -104,7 +104,7 @@ exports[`OakPupilJourneyOptionalityItem component test matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/pupil/browse/OakPupilJourneyProgrammeOptions/__snapshots__/OakPupilJourneyProgrammeOptions.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyProgrammeOptions/__snapshots__/OakPupilJourneyProgrammeOptions.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
 .c0 {
   width: 100%;
   background: #f5e9f2;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,17 +13,17 @@ exports[`OakPupilJourneyList matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #efdbea;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyUnitsFilter/__snapshots__/OakPupilJourneyUnitsFilter.test.tsx.snap
@@ -3,27 +3,27 @@
 exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 .c0 {
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10:hover {
@@ -33,7 +33,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 .c16 {
   position: relative;
   margin-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
@@ -42,7 +42,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
@@ -52,13 +52,13 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c20 {
   position: relative;
   overflow: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
@@ -68,17 +68,17 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c33 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c36 {
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -183,7 +183,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 .c27 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -204,7 +204,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;
@@ -232,7 +232,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 1rem;
@@ -387,7 +387,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   position: relative;
 }
 
@@ -404,7 +404,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
   position: relative;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -437,7 +437,7 @@ exports[`PupilJourneyUnitsFilter matches snapshot 1`] = `
 }
 
 .c15 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;

--- a/src/components/owa/pupil/browse/OakPupilJourneyYearButton/__snapshots__/OakPupilJourneyYearButton.test.tsx.snap
+++ b/src/components/owa/pupil/browse/OakPupilJourneyYearButton/__snapshots__/OakPupilJourneyYearButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -16,11 +16,11 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -43,7 +43,7 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -64,7 +64,7 @@ exports[`OakPupilJourneyYearButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #f5e9f2;
   padding-left: 1.5rem;

--- a/src/components/owa/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -4,16 +4,16 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 .c0 {
   min-height: 3rem;
   padding: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -21,7 +21,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -32,7 +32,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -41,7 +41,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -51,7 +51,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -59,7 +59,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
@@ -68,7 +68,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   padding: 0rem;
   background: #287c34;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c23 {
@@ -78,7 +78,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c27 {
@@ -87,7 +87,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   padding: 0rem;
   background: #dd0035;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -180,7 +180,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 .c18 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -192,7 +192,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c25 {
   color: #287c34;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -204,7 +204,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c26 {
   margin-top: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -216,7 +216,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c28 {
   color: #dd0035;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -228,7 +228,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 
 .c29 {
   margin-top: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -248,7 +248,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/owa/pupil/lesson/OakLessonLayout/__snapshots__/OakLessonLayout.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonLayout/__snapshots__/OakLessonLayout.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`OakLessonLayout matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -21,18 +21,18 @@ exports[`OakLessonLayout matches snapshot 1`] = `
   margin-left: auto;
   margin-right: auto;
   background: #ffffff;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   min-height: 100%;
   padding-top: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: 1;
 }
 
@@ -43,11 +43,11 @@ exports[`OakLessonLayout matches snapshot 1`] = `
   padding-right: 1rem;
   margin-right: 0rem;
   background: #ffffff;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -56,7 +56,7 @@ exports[`OakLessonLayout matches snapshot 1`] = `
   background: #ffffff;
   border-top: 0.25rem solid;
   border-color: #a0b6f2;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {

--- a/src/components/owa/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonNavItem/__snapshots__/OakLessonNavItem.test.tsx.snap
@@ -11,12 +11,12 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #7cd8d0;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
   width: 5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -26,16 +26,16 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   height: 3.5rem;
   min-height: 3.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -47,7 +47,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
 
 .c11 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -63,7 +63,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -73,7 +73,7 @@ exports[`OakLessonNavItem matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonReviewIntroVideo/__snapshots__/OakPupilLessonReviewIntroVideo.test.tsx.snap
@@ -10,11 +10,11 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #b0e2de;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -23,7 +23,7 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   padding: 0.25rem;
   background: #b0e2de;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -33,12 +33,12 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakLessonReviewIntroVideo matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/owa/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonReviewItem/__snapshots__/OakPupilLessonReviewItem.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #b0e2de;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -19,7 +19,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   padding: 0.25rem;
   background: #b0e2de;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -29,16 +29,16 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakLessonReviewItem matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/owa/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonReviewQuiz/__snapshots__/OakPupilLessonReviewQuiz.test.tsx.snap
@@ -10,11 +10,11 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   border: 0.188rem solid;
   border-color: #ffe555;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
@@ -23,7 +23,7 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   padding: 0.25rem;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -33,12 +33,12 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -49,7 +49,7 @@ exports[`OakLessonReviewQuiz matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/owa/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonTopNav/__snapshots__/OakLessonTopNav.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`OakLessonTopNav matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   padding-left: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -17,7 +17,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   height: 2.5rem;
   min-height: 2.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -26,7 +26,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   padding: 0.25rem;
   background: #7cd8d0;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -36,12 +36,12 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -83,7 +83,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 }
 
 .c10 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -94,7 +94,7 @@ exports[`OakLessonTopNav matches snapshot 1`] = `
 }
 
 .c11 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/owa/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonVideoTranscript/__snapshots__/OakLessonVideoTranscript.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakLessonVideoTranscript matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -10,7 +10,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -21,7 +21,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   color: #222222;
   background: #222222;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -30,7 +30,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -40,12 +40,12 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -57,7 +57,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   color: #222222;
   background: #e4e4e4;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -72,7 +72,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   width: 100%;
   max-height: 100%;
   padding-right: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
@@ -148,7 +148,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
 }
 
 .c8 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -168,7 +168,7 @@ exports[`OakLessonVideoTranscript matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   margin-bottom: 1.5rem;
 }

--- a/src/components/owa/pupil/quiz/InternalDroppableHoldingPen/__snapshots__/InternalDroppableHoldingPen.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/InternalDroppableHoldingPen/__snapshots__/InternalDroppableHoldingPen.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`InternalDroppableHoldingPen matches snapshot 1`] = `
 .c0 {
   margin-bottom: 2rem;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   min-height: 5rem;
   padding: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {

--- a/src/components/owa/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakHintButton/__snapshots__/OakHintButton.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`OakHintButton matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
@@ -21,7 +21,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -30,7 +30,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -40,7 +40,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -85,7 +85,7 @@ exports[`OakHintButton matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -105,7 +105,7 @@ exports[`OakHintButton matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/owa/pupil/quiz/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizCheckBox/__snapshots__/OakQuizCheckBox.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
 .c0 {
   position: relative;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -12,7 +12,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   background: #ffffff;
   border-color: #222222;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2:hover {
@@ -23,7 +23,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   position: relative;
   width: 2rem;
   height: 2rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -33,14 +33,14 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   width: 2rem;
   height: 2rem;
   padding: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
   width: 100%;
   height: 100%;
   background: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -48,7 +48,7 @@ exports[`OakQuizCheckBox matches snapshot 1`] = `
   height: 100%;
   border: 0.125rem solid;
   border-color: #ffffff;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -79,7 +79,7 @@ input:checked + .c12 {
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/owa/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizCounter/__snapshots__/OakQuizCounter.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakQuizCounter matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -33,7 +33,7 @@ exports[`OakQuizCounter matches snapshot 1`] = `
 
 .c2 {
   color: #575757;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -45,7 +45,7 @@ exports[`OakQuizCounter matches snapshot 1`] = `
 
 .c3 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;

--- a/src/components/owa/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakQuizFeedback matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -11,7 +11,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   padding: 0rem;
   background: #287c34;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -21,7 +21,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -30,7 +30,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
   padding: 0rem;
   background: #dd0035;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -43,7 +43,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c5 {
   color: #287c34;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -55,7 +55,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c6 {
   margin-top: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -67,7 +67,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c8 {
   color: #dd0035;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -79,7 +79,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 
 .c9 {
   margin-top: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/owa/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakQuizHint matches snapshot 1`] = `
 .c0 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -11,11 +11,11 @@ exports[`OakQuizHint matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -26,7 +26,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   color: #222222;
   background: #ffe555;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -35,7 +35,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -45,7 +45,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -90,7 +90,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
 }
 
 .c14 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -110,7 +110,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 

--- a/src/components/owa/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`OakQuizMatch matches snapshot 1`] = `
 .c0 {
   margin-bottom: 2rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -17,11 +17,11 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -34,13 +34,13 @@ exports[`OakQuizMatch matches snapshot 1`] = `
 .c9 {
   margin-bottom: 2rem;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
   min-height: 5rem;
   padding: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -52,11 +52,11 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   color: #ffffff;
   background: #222222;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c17 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -70,7 +70,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   padding: 1rem;
   background: #d7f1ef;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
@@ -78,12 +78,12 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   padding: 0.25rem;
   background: #d7f1ef;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c25 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c26 {
@@ -95,7 +95,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   padding-bottom: 0.25rem;
   background: #e7f6f5;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -230,7 +230,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/owa/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`OakQuizOrder matches snapshot 1`] = `
 .c0 {
   margin-bottom: 2rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -17,11 +17,11 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -35,7 +35,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   padding: 1rem;
   background: #d7f1ef;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -43,12 +43,12 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   padding: 0.25rem;
   background: #f2f2f2;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -60,11 +60,11 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   color: #222222;
   background: #ffffff;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c20 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -157,7 +157,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #7c9aec;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/src/components/owa/pupil/quiz/OakQuizPrintableHeader/__snapshots__/OakQuizPrintableHeader.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizPrintableHeader/__snapshots__/OakQuizPrintableHeader.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`OakQuizPrintableHeader matches snapshot 1`] = `
 .c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -14,18 +14,18 @@ exports[`OakQuizPrintableHeader matches snapshot 1`] = `
   width: 3.5rem;
   height: 3.5rem;
   padding: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   position: absolute;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
   position: relative;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
@@ -35,7 +35,7 @@ exports[`OakQuizPrintableHeader matches snapshot 1`] = `
   height: 3.5rem;
   min-height: 3.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
@@ -48,7 +48,7 @@ exports[`OakQuizPrintableHeader matches snapshot 1`] = `
   -webkit-transform: rotate(-1.5deg);
   -ms-transform: rotate(-1.5deg);
   transform: rotate(-1.5deg);
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -148,7 +148,7 @@ exports[`OakQuizPrintableHeader matches snapshot 1`] = `
 }
 
 .c12 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/owa/pupil/quiz/OakQuizPrintableSubHeader/__snapshots__/OakQuizPrintableSubHeader.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizPrintableSubHeader/__snapshots__/OakQuizPrintableSubHeader.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakQuizPrintableSubHeader matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c3 {
@@ -12,7 +12,7 @@ exports[`OakQuizPrintableSubHeader matches snapshot 1`] = `
   padding-bottom: 0.25rem;
   background: #f2f2f2;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -61,7 +61,7 @@ exports[`OakQuizPrintableSubHeader matches snapshot 1`] = `
 }
 
 .c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -72,7 +72,7 @@ exports[`OakQuizPrintableSubHeader matches snapshot 1`] = `
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 2rem;
   line-height: 2.5rem;
@@ -83,7 +83,7 @@ exports[`OakQuizPrintableSubHeader matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;

--- a/src/components/owa/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizRadioButton/__snapshots__/OakQuizRadioButton.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
   padding: 0rem;
   margin: 0rem;
   border-style: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -13,7 +13,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
   padding: 1.25rem;
   background: #ffffff;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2:hover {
@@ -21,14 +21,14 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
 }
 
 .c5 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
   position: relative;
   width: 2rem;
   height: 2rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
@@ -40,7 +40,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -109,7 +109,7 @@ exports[`OakQuizRadioButton matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1.125rem;
   line-height: 1.75rem;

--- a/src/components/owa/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizResultItem/__snapshots__/OakQuizResultItem.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakQuizResultItem matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -11,12 +11,12 @@ exports[`OakQuizResultItem matches snapshot 1`] = `
   width: fit-content;
   padding: 0.5rem;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
   min-height: 2rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -59,7 +59,7 @@ exports[`OakQuizResultItem matches snapshot 1`] = `
 
 .c6 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/owa/pupil/quiz/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizTextInput/__snapshots__/OakQuizTextInput.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0:hover {
@@ -68,7 +68,7 @@ exports[`OakQuizTextInput matches snapshot 1`] = `
 }
 
 .c3 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {

--- a/src/components/owa/teacher/OakDownloadsAccordion/__snapshots__/OakDownloadsAccordion.test.tsx.snap
+++ b/src/components/owa/teacher/OakDownloadsAccordion/__snapshots__/OakDownloadsAccordion.test.tsx.snap
@@ -8,17 +8,17 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
   border-top: 0.063rem solid;
   border-bottom: 0.063rem solid;
   border-color: #cacaca;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   padding: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5:hover {
@@ -29,7 +29,7 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
   position: relative;
   width: 1.5rem;
   height: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -39,7 +39,7 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
@@ -49,11 +49,11 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
   height: 100%;
   min-height: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18:hover {
@@ -61,18 +61,18 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
 }
 
 .c22 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c26 {
   padding-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c28 {
   padding: 0.5rem;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c29 {
@@ -82,19 +82,19 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c31 {
   position: relative;
   overflow: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
 .c32 {
   padding-top: 1.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c34 {
@@ -103,14 +103,14 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
   background: #ffffff;
   border: 0.125rem solid;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: hidden;
 }
 
 .c39 {
   padding: 0.75rem;
   background: #ffe555;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c41 {
@@ -120,7 +120,7 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
   height: 3rem;
   min-height: 3rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c42 {
@@ -128,11 +128,11 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
   padding-right: 1rem;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c44 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -143,7 +143,7 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
 }
 
 .c45 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -155,7 +155,7 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
 
 .c46 {
   padding-right: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -309,7 +309,7 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
 }
 
 .c25 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -323,7 +323,7 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
 }
 
 .c27 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   text-align: left;
 }
 
@@ -369,7 +369,7 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
 }
 
@@ -416,7 +416,7 @@ input:checked + .c13 {
   -ms-flex-positive: 1;
   flex-grow: 1;
   margin-right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   min-width: 0;
 }
 

--- a/src/components/owa/teacher/OakInlineRegistrationBanner/__snapshots__/OakInlineRegistrationBanner.test.tsx.snap
+++ b/src/components/owa/teacher/OakInlineRegistrationBanner/__snapshots__/OakInlineRegistrationBanner.test.tsx.snap
@@ -6,29 +6,29 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   margin-bottom: 1.5rem;
   background: #bef2bd;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c5 {
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
   position: relative;
   width: 100%;
   margin-top: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
   position: relative;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -48,7 +48,7 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   -webkit-transform: rotate(-1.5deg);
   -ms-transform: rotate(-1.5deg);
   transform: rotate(-1.5deg);
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -72,7 +72,7 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12:hover {
@@ -85,7 +85,7 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -94,19 +94,19 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c25 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
@@ -187,11 +187,11 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
 }
 
 .c7 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c24 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -212,7 +212,7 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 1rem;
@@ -354,7 +354,7 @@ exports[`OakInlineRegistrationBanner matches snapshot 1`] = `
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 @media (min-width:750px) {

--- a/src/components/owa/teacher/OakTeacherNotesInline/__snapshots__/OakTeacherNotesInline.test.tsx.snap
+++ b/src/components/owa/teacher/OakTeacherNotesInline/__snapshots__/OakTeacherNotesInline.test.tsx.snap
@@ -8,14 +8,14 @@ exports[`OakTeacherNotesInline matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #b0e2de;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
   overflow: scroll;
   height: 4.5rem;
   padding-left: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: scroll;
 }
 

--- a/src/components/owa/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
+++ b/src/components/owa/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 .c0 {
   position: fixed;
   inset: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: 300;
 }
 
@@ -12,7 +12,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   position: fixed;
   inset: 0rem;
   background: #22222240;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   z-index: -1;
 }
 
@@ -20,7 +20,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   width: 100%;
   max-width: 60rem;
   padding: 1.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -28,20 +28,20 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   width: 100%;
   background: #ffffff;
   border-radius: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c9 {
   position: relative;
   min-height: 3.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c11 {
@@ -49,11 +49,11 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
@@ -64,7 +64,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   color: transparent;
   background: transparent;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c19 {
@@ -73,7 +73,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c20 {
@@ -83,7 +83,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c23 {
@@ -93,20 +93,20 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   border-top: 0rem solid;
   border-bottom: 0rem solid;
   border-color: #cacaca;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   overflow: auto;
 }
 
 .c24 {
   padding-bottom: 1.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c27 {
   padding: 0.75rem;
   background: #f2f2f2;
   border-radius: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c29 {
@@ -118,7 +118,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #222222;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c36 {
@@ -127,7 +127,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   width: -moz-max-content;
   width: max-content;
   height: auto;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c38 {
@@ -136,17 +136,17 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c43 {
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c47 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c51 {
@@ -156,7 +156,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   height: 1.5rem;
   min-height: 1.5rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c53 {
@@ -164,7 +164,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c55 {
@@ -178,17 +178,17 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c57 {
   position: relative;
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c60 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -416,7 +416,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 }
 
 .c22 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -427,7 +427,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 }
 
 .c42 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -439,7 +439,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 }
 
 .c64 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c14 {
@@ -452,7 +452,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: transparent;
 }
 
@@ -471,7 +471,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #222222;
   background: #ffffff;
   padding-left: 0.5rem;
@@ -499,7 +499,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
   text-align: left;
   font-family: unset;
   outline: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   color: #ffffff;
   background: #222222;
   padding-left: 0.5rem;
@@ -578,7 +578,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 }
 
 .c26 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -630,7 +630,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 
 .c6 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -788,7 +788,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 }
 
 .c33 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -799,7 +799,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 }
 
 .c61 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -810,7 +810,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 }
 
 .c62 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/owa/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
+++ b/src/components/owa/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -37,7 +37,7 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
 
 .c2 {
   display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -45,7 +45,7 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;
   letter-spacing: 0.0115rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/owa/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
+++ b/src/components/owa/teacher/OakUnitListItem/__snapshots__/OakUnitListItem.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   background: #ffffff;
   border-radius: 0.375rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -15,31 +15,31 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   height: 100%;
   padding-right: 0rem;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
   min-width: 4rem;
   background: #a0b6f2;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
   padding-right: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
   min-width: 5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
   min-width: 10rem;
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -56,7 +56,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
@@ -68,16 +68,16 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c24 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c26 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c28 {
@@ -86,7 +86,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
   height: 2.5rem;
   background: #a0b6f2;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -210,7 +210,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 .c14 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -222,7 +222,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 .c17 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -235,12 +235,12 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 .c19 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   white-space: nowrap;
 }
 
 .c32 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -252,7 +252,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 }
 
 .c30 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -266,8 +266,8 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 .c0 {
   width: 100%;
   display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   list-style: none;
   display: revert;
   display: revert;
@@ -275,7 +275,7 @@ exports[`OakUnitListItem matches snapshot 1`] = `
 
 .c11 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;

--- a/src/components/owa/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
+++ b/src/components/owa/teacher/OakUnitListOptionalityItem/__snapshots__/OakUnitListOptionalityItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 .c6 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1.5rem;
   line-height: 2rem;
@@ -15,7 +15,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 
 .c21 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -29,7 +29,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   width: 100%;
   background: #ffffff;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -40,7 +40,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
@@ -52,13 +52,13 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   border-top-right-radius: 0.25rem;
   border-bottom-left-radius: 0.25rem;
   border-bottom-right-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c7 {
   max-width: 30rem;
   margin-right: 0rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c10 {
@@ -69,28 +69,28 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   border-top-left-radius: 0.25rem;
   border-bottom-left-radius: 0.25rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
   width: 100%;
   padding: 1rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c13 {
   margin-bottom: 1rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c15 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c18 {
   width: 100%;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c22 {
@@ -103,7 +103,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   border: 0.063rem solid;
   border-color: #deb7d5;
   border-radius: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c24 {
@@ -113,13 +113,13 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c26 {
   margin-bottom: 1rem;
   display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -243,7 +243,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 .c9 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -255,7 +255,7 @@ exports[`OakUnitListOptionalityItem matches snapshot 1`] = `
 }
 
 .c23 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/owa/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
+++ b/src/components/owa/teacher/OakUnitListOptionalityItemCard/__snapshots__/OakUnitListOptionalityItemCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
 .c11 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -18,7 +18,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
@@ -30,17 +30,17 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   border: 0.125rem solid;
   border-color: #a0b6f2;
   border-radius: 0.375rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c8 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c12 {
@@ -50,7 +50,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
   height: 2rem;
   min-height: 2rem;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -109,7 +109,7 @@ exports[`OakUnitListOptionalityItemCard matches snapshot 1`] = `
 }
 
 .c6 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;

--- a/src/components/presentational/OakQuote/__snapshots__/OakQuote.test.tsx.snap
+++ b/src/components/presentational/OakQuote/__snapshots__/OakQuote.test.tsx.snap
@@ -4,23 +4,23 @@ exports[`OakQuote component matches snapshot 1`] = `
 .c0 {
   width: 100%;
   max-width: 40rem;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c2 {
   width: 0.5rem;
   margin-right: 1.5rem;
   background: #bef2bd;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c6 {
   color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.25rem;
@@ -34,7 +34,7 @@ exports[`OakQuote component matches snapshot 1`] = `
   position: relative;
   width: 100%;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
@@ -88,7 +88,7 @@ exports[`OakQuote component matches snapshot 1`] = `
 }
 
 .c13 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.5rem;
@@ -100,7 +100,7 @@ exports[`OakQuote component matches snapshot 1`] = `
 }
 
 .c14 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   font-weight: 300;
   font-size: 1rem;
   line-height: 1.5rem;

--- a/src/components/typography/OakHeading/OakHeading.test.tsx
+++ b/src/components/typography/OakHeading/OakHeading.test.tsx
@@ -47,7 +47,7 @@ describe("Heading", () => {
       );
 
       expect(getByTestId("test")).toHaveStyle(
-        "font-family:--var(google-font),Lexend,sans-serif",
+        "font-family:var(--base-font),Lexend,sans-serif",
       );
       expect(getByTestId("test")).toHaveStyle(
         `font-size: ${parseFontSize(font as OakFontToken)}`,

--- a/src/components/typography/OakHeading/__snapshots__/OakHeading.test.tsx.snap
+++ b/src/components/typography/OakHeading/__snapshots__/OakHeading.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Heading matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/typography/OakLI/__snapshots__/OakLI.test.tsx.snap
+++ b/src/components/typography/OakLI/__snapshots__/OakLI.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`Component OakLI matches snapshot 1`] = `
 .c0 {
   display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
   display: revert;
   display: revert;
 }

--- a/src/components/typography/OakOL/__snapshots__/OakOL.test.tsx.snap
+++ b/src/components/typography/OakOL/__snapshots__/OakOL.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Component OakOL matches snapshot 1`] = `
 .c0 {
   counter-reset: item;
   padding: 0;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c0 li {

--- a/src/components/typography/OakP/OakP.test.tsx
+++ b/src/components/typography/OakP/OakP.test.tsx
@@ -11,7 +11,7 @@ describe("P", () => {
       <OakP data-testid="paragraph">Here is some paragraph text</OakP>,
     );
     expect(getByTestId("paragraph")).toHaveStyle(
-      "font-family:--var(google-font),Lexend,sans-serif",
+      "font-family:var(--base-font),Lexend,sans-serif",
     );
   });
 

--- a/src/components/typography/OakP/__snapshots__/OakP.test.tsx.snap
+++ b/src/components/typography/OakP/__snapshots__/OakP.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`P matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/typography/OakSpan/__snapshots__/OakSpan.test.tsx.snap
+++ b/src/components/typography/OakSpan/__snapshots__/OakSpan.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OakSpan matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/typography/OakTypography/__snapshots__/OakTypography.test.tsx.snap
+++ b/src/components/typography/OakTypography/__snapshots__/OakTypography.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`OakTypography matches snapshot 1`] = `
 .c0 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 .c1 {
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/components/typography/OakUL/__snapshots__/OakUL.test.tsx.snap
+++ b/src/components/typography/OakUL/__snapshots__/OakUL.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Component OakUL matches snapshot 1`] = `
 .c0 {
   margin: 0;
   display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
+  font-family: var(--base-font),Lexend,sans-serif;
 }
 
 <div>

--- a/src/styles/utils/typographyStyle.test.tsx
+++ b/src/styles/utils/typographyStyle.test.tsx
@@ -15,7 +15,7 @@ describe("typographyStyle", () => {
     );
     expect(getByTestId("test")).toHaveStyle("font-weight: 600");
     expect(getByTestId("test")).toHaveStyle(
-      "font-family: --var(google-font),Lexend,sans-serif",
+      "font-family: var(--base-font),Lexend,sans-serif",
     );
     expect(getByTestId("test")).toHaveStyle("line-height: 4rem");
     expect(getByTestId("test")).toHaveStyle("letter-spacing:0.0115rem");

--- a/src/styles/utils/typographyStyle.ts
+++ b/src/styles/utils/typographyStyle.ts
@@ -74,7 +74,7 @@ export type TypographyStyleProps = {
 };
 
 export const typographyStyle = css<TypographyStyleProps>`
-  font-family: --var(google-font), Lexend, sans-serif; //  FIXME: this should be a css variable ?
+  font-family: var(--base-font), Lexend, sans-serif;
   ${responsiveStyle("font-weight", (props) => props.$font, parseFontWeight)}
   ${responsiveStyle("font-size", (props) => props.$font, parseFontSize)}
   ${responsiveStyle("line-height", (props) => props.$font, parseLineHeight)}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Changes fixed css setting on base font

With Lexend
<img width="1025" height="204" alt="Screenshot 2026-03-24 at 09 23 43" src="https://github.com/user-attachments/assets/e87386a9-0b53-426c-a80b-e76a7b107b49" />

With Arial
<img width="1025" height="204" alt="Screenshot 2026-03-24 at 09 23 40" src="https://github.com/user-attachments/assets/1f2ef8f1-0501-4029-b6d5-29689b2227e0" />

Note this PR currently forces Arial which will need to be removed prior to merge

https://github.com/oaknational/oak-components/blob/e15f16b63342d2c675b28943aae1531501e3d026/.storybook/preview.tsx#L22-L30

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
