### PR TITLE
fix: dependabot yaml syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,5 @@ updates:
         update-types:
           - "patch"
           - "minor"
-      # only group version updates, not security updates
-      applies-to: version-updates
+        # only group version updates, not security updates
+        applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,4 @@ updates:
           - "patch"
           - "minor"
       # only group version updates, not security updates
-      applies-to: "version-updates"
+      applies-to: version-updates


### PR DESCRIPTION
# Add your PR description below

- update `dependabot.yaml`, it looks like the `applies-to` field for groups format was incorrect ([see docs with example](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#example-1-three-version-update-groups))