### PR TITLE
Fix: use unordered list on OakTabs to show grouping for screen readers

### DIFF
--- a/src/components/navigation/OakTabs/OakTabs.test.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.test.tsx
@@ -21,6 +21,16 @@ const props: OakTabsProps<string> = {
 };
 
 describe("OakTabs", () => {
+  it("renders tabs inside a semantic list", () => {
+    renderWithTheme(<OakTabs {...props} />);
+
+    const list = screen.getByRole("list");
+    const items = screen.getAllByRole("button");
+
+    expect(list).toBeInTheDocument();
+    expect(items).toHaveLength(3);
+  });
+
   it("renders tabs with correct styling for black variant", () => {
     renderWithTheme(<OakTabs {...props} />);
     const tabOne = screen.getByRole("button", { name: "Tab one" });

--- a/src/components/navigation/OakTabs/OakTabs.test.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.test.tsx
@@ -93,6 +93,7 @@ describe("OakTabs", () => {
       throw new Error("Cannot find first link");
     }
     expect(links[0]).toHaveProperty("href");
+    expect(links[0].ariaCurrent).toBe("page");
     const user = userEvent.setup();
     await user.click(links[0]);
     expect(onClickCallback).toHaveBeenCalledWith("Tab one");

--- a/src/components/navigation/OakTabs/OakTabs.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.tsx
@@ -9,6 +9,7 @@ import { ResponsiveValues } from "@/styles/utils/responsiveStyle";
 import { InternalButton } from "@/components/internal-components/InternalButton";
 import { OakFlex } from "@/components/layout-and-structure";
 import { OakUiRoleToken } from "@/styles";
+import { OakUL } from "@/components/typography";
 
 type Tab<T> = {
   label: T;
@@ -32,7 +33,12 @@ export type OakTabsProps<T extends string> = {
 
 const StyledFocusOutline = styled(OakFlex)``;
 
-const StyledTabButton = styled(InternalButton)<{
+const StyledUnorderedList = styled(OakUL)`
+  display: flex;
+  justify-content: space-around;
+`;
+
+const StyledTabButton = styled(InternalButton) <{
   $hoverColor: OakUiRoleToken;
   $hoverBackground: OakUiRoleToken;
 }>`
@@ -61,7 +67,7 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
   const hoverText = colorVariant === "black" ? "text-inverted" : "text-primary";
 
   return (
-    <OakFlex
+    <StyledUnorderedList
       $height={sizeVariant === "compact" ? "spacing-40" : "spacing-56"}
       $background={backgroundColor}
       $borderRadius={"border-radius-circle"}
@@ -113,6 +119,6 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
           </StyledTabButton>
         );
       })}
-    </OakFlex>
+    </StyledUnorderedList>
   );
 }

--- a/src/components/navigation/OakTabs/OakTabs.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.tsx
@@ -92,7 +92,7 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
             <StyledTabButton
               element={type === "link" ? Link : undefined}
               href={type === "link" ? tab.href : undefined}
-              aria-current={isSelected ? "page" : undefined}
+              aria-current={type === "link" && isSelected ? "page" : undefined}
               $background={isSelected ? "bg-decorative1-main" : backgroundColor}
               $color={isSelected ? "text-primary" : textColor}
               $hoverColor={isSelected ? "text-primary" : hoverText}

--- a/src/components/navigation/OakTabs/OakTabs.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.tsx
@@ -33,7 +33,7 @@ export type OakTabsProps<T extends string> = {
 
 const StyledFocusOutline = styled(OakFlex)``;
 
-const StyledTabButton = styled(InternalButton) <{
+const StyledTabButton = styled(InternalButton)<{
   $hoverColor: OakUiRoleToken;
   $hoverBackground: OakUiRoleToken;
 }>`

--- a/src/components/navigation/OakTabs/OakTabs.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.tsx
@@ -86,6 +86,7 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
             $listStyle={"none"}
             $width={"100%"}
             $height={"100%"}
+            $display={"flex"}
             key={label}
           >
             <StyledTabButton

--- a/src/components/navigation/OakTabs/OakTabs.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.tsx
@@ -38,7 +38,7 @@ const StyledUnorderedList = styled(OakUL)`
   justify-content: space-around;
 `;
 
-const StyledTabButton = styled(InternalButton) <{
+const StyledTabButton = styled(InternalButton)<{
   $hoverColor: OakUiRoleToken;
   $hoverBackground: OakUiRoleToken;
 }>`

--- a/src/components/navigation/OakTabs/OakTabs.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.tsx
@@ -33,16 +33,6 @@ export type OakTabsProps<T extends string> = {
 
 const StyledFocusOutline = styled(OakFlex)``;
 
-const StyledUnorderedList = styled(OakUL)`
-  display: flex;
-  justify-content: space-around;
-`;
-
-const StyledListItem = styled(OakLI)`
-  list-style: none;
-  width: 100%;
-`;
-
 const StyledTabButton = styled(InternalButton)<{
   $hoverColor: OakUiRoleToken;
   $hoverBackground: OakUiRoleToken;
@@ -72,7 +62,9 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
   const hoverText = colorVariant === "black" ? "text-inverted" : "text-primary";
 
   return (
-    <StyledUnorderedList
+    <OakUL
+      $display={"flex"}
+      $justifyContent={"space-around"}
       $height={sizeVariant === "compact" ? "spacing-40" : "spacing-56"}
       $background={backgroundColor}
       $borderRadius={"border-radius-circle"}
@@ -90,7 +82,7 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
         const isSelected = activeTab === label;
 
         return (
-          <StyledListItem key={label} role="presentation">
+          <OakLI $listStyle={"none"} $width={"100%"} key={label}>
             <StyledTabButton
               element={type === "link" ? Link : undefined}
               href={type === "link" ? tab.href : undefined}
@@ -122,9 +114,9 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
                 {label}
               </StyledFocusOutline>
             </StyledTabButton>
-          </StyledListItem>
+          </OakLI>
         );
       })}
-    </StyledUnorderedList>
+    </OakUL>
   );
 }

--- a/src/components/navigation/OakTabs/OakTabs.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.tsx
@@ -91,6 +91,7 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
             <StyledTabButton
               element={type === "link" ? Link : undefined}
               href={type === "link" ? tab.href : undefined}
+              aria-current={isSelected ? "page" : undefined}
               $background={isSelected ? "bg-decorative1-main" : backgroundColor}
               $color={isSelected ? "text-primary" : textColor}
               $hoverColor={isSelected ? "text-primary" : hoverText}

--- a/src/components/navigation/OakTabs/OakTabs.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.tsx
@@ -9,7 +9,7 @@ import { ResponsiveValues } from "@/styles/utils/responsiveStyle";
 import { InternalButton } from "@/components/internal-components/InternalButton";
 import { OakFlex } from "@/components/layout-and-structure";
 import { OakUiRoleToken } from "@/styles";
-import { OakUL } from "@/components/typography";
+import { OakLI, OakUL } from "@/components/typography";
 
 type Tab<T> = {
   label: T;
@@ -36,6 +36,11 @@ const StyledFocusOutline = styled(OakFlex)``;
 const StyledUnorderedList = styled(OakUL)`
   display: flex;
   justify-content: space-around;
+`;
+
+const StyledListItem = styled(OakLI)`
+  list-style: none;
+  width: 100%;
 `;
 
 const StyledTabButton = styled(InternalButton)<{
@@ -85,38 +90,39 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
         const isSelected = activeTab === label;
 
         return (
-          <StyledTabButton
-            element={type === "link" ? Link : undefined}
-            href={type === "link" ? tab.href : undefined}
-            key={label}
-            $background={isSelected ? "bg-decorative1-main" : backgroundColor}
-            $color={isSelected ? "text-primary" : textColor}
-            $hoverColor={isSelected ? "text-primary" : hoverText}
-            $hoverBackground={
-              isSelected ? "bg-decorative1-main" : hoverBackground
-            }
-            $ba="border-solid-s"
-            $borderColor={
-              isSelected ? "border-decorative1-stronger" : backgroundColor
-            }
-            onClick={(event: Event) => {
-              if (onTabClick) {
-                onTabClick(label, event);
+          <StyledListItem key={label} role="presentation">
+            <StyledTabButton
+              element={type === "link" ? Link : undefined}
+              href={type === "link" ? tab.href : undefined}
+              $background={isSelected ? "bg-decorative1-main" : backgroundColor}
+              $color={isSelected ? "text-primary" : textColor}
+              $hoverColor={isSelected ? "text-primary" : hoverText}
+              $hoverBackground={
+                isSelected ? "bg-decorative1-main" : hoverBackground
               }
-            }}
-          >
-            <StyledFocusOutline
-              $width={"100%"}
-              $height={"100%"}
-              $borderRadius={"border-radius-circle"}
-              $pa={"spacing-4"}
-              $alignItems={"center"}
-              $justifyContent={"center"}
-              $whiteSpace={"nowrap"}
+              $ba="border-solid-s"
+              $borderColor={
+                isSelected ? "border-decorative1-stronger" : backgroundColor
+              }
+              onClick={(event: Event) => {
+                if (onTabClick) {
+                  onTabClick(label, event);
+                }
+              }}
             >
-              {label}
-            </StyledFocusOutline>
-          </StyledTabButton>
+              <StyledFocusOutline
+                $width={"100%"}
+                $height={"100%"}
+                $borderRadius={"border-radius-circle"}
+                $pa={"spacing-4"}
+                $alignItems={"center"}
+                $justifyContent={"center"}
+                $whiteSpace={"nowrap"}
+              >
+                {label}
+              </StyledFocusOutline>
+            </StyledTabButton>
+          </StyledListItem>
         );
       })}
     </StyledUnorderedList>

--- a/src/components/navigation/OakTabs/OakTabs.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.tsx
@@ -33,7 +33,7 @@ export type OakTabsProps<T extends string> = {
 
 const StyledFocusOutline = styled(OakFlex)``;
 
-const StyledTabButton = styled(InternalButton)<{
+const StyledTabButton = styled(InternalButton) <{
   $hoverColor: OakUiRoleToken;
   $hoverBackground: OakUiRoleToken;
 }>`
@@ -82,7 +82,12 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
         const isSelected = activeTab === label;
 
         return (
-          <OakLI $listStyle={"none"} $width={"100%"} key={label}>
+          <OakLI
+            $listStyle={"none"}
+            $width={"100%"}
+            $height={"100%"}
+            key={label}
+          >
             <StyledTabButton
               element={type === "link" ? Link : undefined}
               href={type === "link" ? tab.href : undefined}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

- Replaced OakFlex with an unordered list to improve screen reader description of OakTabs.
- Grouped elements in an unordered list result in the following screen reader message, "visited, link, Description, 3 of 3" compared to previous message, "Download, button".
- Added a test that checks for the unordered list and the buttons in the list exist

## Link to the design doc

[Figma](https://www.figma.com/design/ktldjkEqAqv0X8PGzxrZyA/%F0%9F%9A%80-Integrated-journeys-v2?node-id=16876-63490&m=dev) - see "Programme Page v1 - Citizenship Secondary" specifically.

## A link to the component in the deployment preview

[Storybook preview](https://oak-components-storybook-git-fix-lesq-1853a11y-improvements.vercel.thenational.academy/?path=/docs/components-navigation-oaktabs--docs)

## Testing instructions

- Visit storybook preview above
- Navigate to OakTabs
- Turn on screen reader, I used mac voiceover
- See/hear screen reader message

## ACs

- [x]  links on programme page are grouped together with `<ul>` and `<li>` elements