### PR TITLE
Fix: Too much padding on bottom of UnstyledChevronAccordion when collapsed

### DIFF
--- a/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.stories.tsx
+++ b/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.stories.tsx
@@ -6,6 +6,7 @@ import { UnstyledChevronAccordion } from "./UnstyledChevronAccordion";
 import { OakSmallSecondaryButtonWithDropdown } from "@/components/buttons/OakSmallSecondaryButtonWithDropdown";
 import { OakBox } from "@/components/layout-and-structure/OakBox";
 import { OakP } from "@/components/typography/OakP";
+import { flexArgTypes } from "@/storybook-helpers/flexStyleHelpers";
 
 const meta: Meta<typeof UnstyledChevronAccordion> = {
   component: UnstyledChevronAccordion,
@@ -13,10 +14,11 @@ const meta: Meta<typeof UnstyledChevronAccordion> = {
   title: "components/Unstyled/UnstyledChevronAccordion",
   parameters: {
     controls: {
-      include: ["header", "subheader", "content", "initialOpen"],
+      include: ["header", "subheader", "content", "initialOpen", "$gap"],
     },
   },
   argTypes: {
+    ...flexArgTypes,
     content: {
       control: {
         type: "text",
@@ -59,6 +61,7 @@ const meta: Meta<typeof UnstyledChevronAccordion> = {
         Subheader goes here
       </OakBox>
     ),
+    $gap: "spacing-0",
   },
   render: (args) => <UnstyledChevronAccordion {...args} />,
 };

--- a/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.tsx
+++ b/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.tsx
@@ -109,11 +109,13 @@ const Accordion = ({
         </OakBox>
       </OakFlex>
       {subheader}
-      <OakBox $position={"relative"} $overflow={"auto"}>
-        <InternalAccordionContent aria-labelledby={id}>
-          {content}
-        </InternalAccordionContent>
-      </OakBox>
+      <InternalAccordionContent
+        $position={"relative"}
+        $overflow={"auto"}
+        aria-labelledby={id}
+      >
+        {content}
+      </InternalAccordionContent>
     </OakFlex>
   );
 };

--- a/src/components/unstyled/UnstyledChevronAccordion/__snapshots__/UnstyledChevronAccordion.test.tsx.snap
+++ b/src/components/unstyled/UnstyledChevronAccordion/__snapshots__/UnstyledChevronAccordion.test.tsx.snap
@@ -151,16 +151,12 @@ exports[`UnstyledChevronAccordion matches snapshot 1`] = `
       </div>
     </div>
     <div
+      aria-labelledby="see-more"
       class="c11"
+      role="region"
     >
-      <div
-        aria-labelledby="see-more"
-        class="c2"
-        role="region"
-      >
-        <div>
-          Here it is
-        </div>
+      <div>
+        Here it is
       </div>
     </div>
   </div>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Previously, if an `UnstyledChevronAccordion` was closed, the box where its content would go was still rendered. If the accordion has a `$gap`, this means the gap doubles up on the bottom - once between the subheader and empty content box, then again between the empty content box and the bottom of the accordion.

I added `$gap` to the stories for this component. Before the fix, after setting a large `$gap`,  it looked like this: (Note the thick bottom border for the empty content box)

<img width="1017" height="400" alt="image" src="https://github.com/user-attachments/assets/5a737d75-60e8-4cc8-9dde-eed176488f69" />

I've merged the `OakBox` into its child `InternalAccordionContent`, so now the entire content is hidden when the box is collapsed:

<img width="1017" height="340" alt="image" src="https://github.com/user-attachments/assets/dda6d96c-92bc-4977-a8f3-a292cb2617e3" />

The expanded accordion looks identical to before.

We use this component in one place in Studio, and the only visual change is that there's no longer too much padding on the bottom when collapsed. [It doesn't look like there are any other users of this component.](https://github.com/search?q=org:oaknational+UnstyledChevronAccordion&type=code)

## Link to the design doc

Shows equal padding on top and bottom when collapsed: https://www.figma.com/design/wlBE8v42CZj4N0NwT2fwY5/CreateSqDS-QuizB?node-id=1637-19019&t=61bnPOu3SZVfyxoy-4

## A link to the component in the deployment preview

https://oak-components-storybook-k7bkvamt5.vercel.thenational.academy/?path=/docs/components-unstyled-unstyledchevronaccordion--docs

## Testing instructions

1. Turn on outlines
2. Give the accordion a large `$gap`
3. Play with expanding/collapsing it and watch the outlines

## ACs

- [x] Accordion has equal padding on top and bottom