### PR TITLE
feat: unstyled chevron accordion can be both (un)controlled

### DIFF
--- a/src/components/internal-components/InternalChevronAccordion/InternalChevronAccordion.tsx
+++ b/src/components/internal-components/InternalChevronAccordion/InternalChevronAccordion.tsx
@@ -66,7 +66,8 @@ export const StyledAccordionButton = styled(
   }
   &:focus-visible {
     .shadow {
-      box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
+      box-shadow:
+        ${parseDropShadow("drop-shadow-centered-lemon")},
         ${parseDropShadow("drop-shadow-centered-grey")};
     }
   }

--- a/src/components/internal-components/InternalChevronAccordion/InternalChevronAccordion.tsx
+++ b/src/components/internal-components/InternalChevronAccordion/InternalChevronAccordion.tsx
@@ -66,8 +66,7 @@ export const StyledAccordionButton = styled(
   }
   &:focus-visible {
     .shadow {
-      box-shadow:
-        ${parseDropShadow("drop-shadow-centered-lemon")},
+      box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
         ${parseDropShadow("drop-shadow-centered-grey")};
     }
   }

--- a/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.test.tsx
+++ b/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.test.tsx
@@ -58,6 +58,41 @@ describe(UnstyledChevronAccordion, () => {
     expect(getByRole("region")).toBeInTheDocument();
   });
 
+  it("operates as a controlled component when isOpen and onOpenChange are provided", () => {
+    const onOpenChange = jest.fn();
+    const { getByRole, queryByRole, rerender } = renderWithTheme(
+      <UnstyledChevronAccordion
+        isOpen={false}
+        onOpenChange={onOpenChange}
+        header="See more"
+        content={<div>Here it is</div>}
+        id="see-more"
+      />,
+    );
+
+    expect(queryByRole("region")).toBeNull();
+
+    act(() => {
+      fireEvent.click(getByRole("button"));
+    });
+
+    // Parent owns state - prop hasn't changed, so content stays hidden
+    expect(queryByRole("region")).toBeNull();
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    rerender(
+      <UnstyledChevronAccordion
+        isOpen={true}
+        onOpenChange={onOpenChange}
+        header="See more"
+        content={<div>Here it is</div>}
+        id="see-more"
+      />,
+    );
+
+    expect(getByRole("region")).toBeVisible();
+  });
+
   it("changes aria-label based on open state", () => {
     const { getByRole } = renderWithTheme(
       <UnstyledChevronAccordion

--- a/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.tsx
+++ b/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.tsx
@@ -46,17 +46,19 @@ type UnstyledChevronAccordionCommonProps = {
 type UnstyledChevronAccordionUncontrolledProps = {
   /** Whether the accordion should be open initially. Uncontrolled usage only. */
   isInitiallyOpen?: boolean;
+
   isOpen?: never;
   onOpenChange?: never;
 };
 
 type UnstyledChevronAccordionControlledProps = {
+  isInitiallyOpen?: never;
+
   /** Controlled open state. Must be paired with `onOpenChange`. */
   isOpen: boolean;
 
   /** Called when the user toggles the accordion. Required when `isOpen` is provided. */
   onOpenChange: (open: boolean) => void;
-  isInitiallyOpen?: never;
 };
 
 export type UnstyledChevronAccordionProps =

--- a/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.tsx
+++ b/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.tsx
@@ -13,18 +13,17 @@ import {
   InternalAccordionContent,
 } from "@/components/internal-components/InternalAccordion";
 import useAccordionContext from "@/components/internal-components/InternalAccordion/useAccordionContext";
-import InternalAccordionProvider from "@/components/internal-components/InternalAccordion/InternalAccordionProvider";
+import InternalAccordionProvider, {
+  accordionContext,
+} from "@/components/internal-components/InternalAccordion/InternalAccordionProvider";
 import { flexStyle, FlexStyleProps } from "@/styles/utils/flexStyle";
 import { ColorStyleProps } from "@/styles/utils/colorStyle";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 import { parseColorFilter } from "@/styles/helpers/parseColorFilter";
 
-export type UnstyledChevronAccordionProps = {
+type UnstyledChevronAccordionCommonProps = {
   /** The header of the accordion. */
   header: ReactNode;
-
-  /** Whether the accordion should be open initially. */
-  isInitiallyOpen?: boolean;
 
   /** The content of the accordion. */
   content: ReactNode;
@@ -43,6 +42,29 @@ export type UnstyledChevronAccordionProps = {
 } & FlexStyleProps &
   OakBoxProps &
   ColorStyleProps;
+
+type UnstyledChevronAccordionUncontrolledProps = {
+  /** Whether the accordion should be open initially. Uncontrolled usage only. */
+  isInitiallyOpen?: boolean;
+  isOpen?: never;
+  onOpenChange?: never;
+};
+
+type UnstyledChevronAccordionControlledProps = {
+  /** Controlled open state. Must be paired with `onOpenChange`. */
+  isOpen: boolean;
+
+  /** Called when the user toggles the accordion. Required when `isOpen` is provided. */
+  onOpenChange: (open: boolean) => void;
+  isInitiallyOpen?: never;
+};
+
+export type UnstyledChevronAccordionProps =
+  UnstyledChevronAccordionCommonProps &
+    (
+      | UnstyledChevronAccordionUncontrolledProps
+      | UnstyledChevronAccordionControlledProps
+    );
 
 const StyledAccordionButton = styled(InternalAccordionButton)<FlexStyleProps>`
   ${flexStyle}
@@ -72,7 +94,7 @@ const Accordion = ({
   ariaLabelOpen = "Close accordion",
   ariaLabelClose = "Open accordion",
   ...styleProps
-}: UnstyledChevronAccordionProps) => {
+}: UnstyledChevronAccordionCommonProps) => {
   const { isOpen } = useAccordionContext();
 
   return (
@@ -126,14 +148,28 @@ const Accordion = ({
  * - Unlike InternalChevronAccordion, it has no border effects for hover or focus states.
  * - Only the chevron is interactive so as to allow interactive elements to be placed in the header.
  * - The intention is for these to be added by consuming components as needed.
+ * - Can be used as an uncontrolled component (via `isInitiallyOpen`) or as a
+ *   controlled component (via `isOpen` + `onOpenChange`).
  */
-export const UnstyledChevronAccordion = ({
-  isInitiallyOpen = false,
-  ...props
-}: UnstyledChevronAccordionProps) => {
+export const UnstyledChevronAccordion = (
+  props: UnstyledChevronAccordionProps,
+) => {
+  // Is the accordion being used as a controlled component?
+  if (props.isOpen !== undefined) {
+    const { isOpen, onOpenChange, ...accordionProps } = props;
+    return (
+      <accordionContext.Provider
+        value={{ isOpen, setOpen: onOpenChange }}
+      >
+        <Accordion {...accordionProps} />
+      </accordionContext.Provider>
+    );
+  }
+
+  const { isInitiallyOpen = false, ...accordionProps } = props;
   return (
     <InternalAccordionProvider isInitialOpen={isInitiallyOpen}>
-      <Accordion {...props} />
+      <Accordion {...accordionProps} />
     </InternalAccordionProvider>
   );
 };

--- a/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.tsx
+++ b/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.tsx
@@ -78,8 +78,7 @@ const StyledAccordionButton = styled(InternalAccordionButton)<FlexStyleProps>`
   }
   &:focus-visible {
     .focus-outline {
-      box-shadow:
-        ${parseDropShadow("drop-shadow-centered-lemon")},
+      box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
         ${parseDropShadow("drop-shadow-centered-grey")};
     }
   }
@@ -160,9 +159,7 @@ export const UnstyledChevronAccordion = (
   if (props.isOpen !== undefined) {
     const { isOpen, onOpenChange, ...accordionProps } = props;
     return (
-      <accordionContext.Provider
-        value={{ isOpen, setOpen: onOpenChange }}
-      >
+      <accordionContext.Provider value={{ isOpen, setOpen: onOpenChange }}>
         <Accordion {...accordionProps} />
       </accordionContext.Provider>
     );

--- a/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.tsx
+++ b/src/components/unstyled/UnstyledChevronAccordion/UnstyledChevronAccordion.tsx
@@ -78,7 +78,8 @@ const StyledAccordionButton = styled(InternalAccordionButton)<FlexStyleProps>`
   }
   &:focus-visible {
     .focus-outline {
-      box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")},
+      box-shadow:
+        ${parseDropShadow("drop-shadow-centered-lemon")},
         ${parseDropShadow("drop-shadow-centered-grey")};
     }
   }


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Enable the `UnstyledChevronAccordion` component to be both controlled/uncontrolled depending on incoming param usage.

## ACs

- [x] Accordion can be used both controlled/uncontrolled.