### PR TITLE
Feat/lesq 1919/unit page heading accessibility

### DIFF
--- a/src/components/navigation/OakCard/OakCard.stories.tsx
+++ b/src/components/navigation/OakCard/OakCard.stories.tsx
@@ -21,6 +21,9 @@ const meta: Meta<typeof OakCard> = {
   component: OakCard,
   tags: ["autodocs"],
   argTypes: {
+    headingLevel: {
+      options: ["h1", "h2", "h3", "h4", "h5", "h6"],
+    },
     cardOrientation: {
       options: ["row", "column"],
     },
@@ -41,6 +44,7 @@ const meta: Meta<typeof OakCard> = {
     controls: {
       include: [
         "heading",
+        "headingLevel",
         "href",
         "cardOrientation",
         "cardWidth",
@@ -65,6 +69,7 @@ export const Default: Story = {
   render: (args) => <OakCard {...args} />,
   args: {
     heading: "A Heading",
+    headingLevel: "h2",
     href: "https://example.com",
     cardOrientation: "column",
     cardWidth: "fit-content",
@@ -84,6 +89,7 @@ export const ColumnOrientationWithSquareImage: Story = {
   args: {
     heading:
       "Raising ambition and inspiring a love for language with Oak's English curriculum",
+    headingLevel: "h3",
     href: "https://example.com",
     cardOrientation: "column",
     cardWidth: "spacing-360",
@@ -101,6 +107,7 @@ export const RowOrientationWithRectangularImage: Story = {
   args: {
     heading:
       "Building curious, confident historians: inside Oak's history curriculum",
+    headingLevel: "h3",
     href: "https://example.com",
     cardOrientation: "row",
     cardWidth: "100%",
@@ -120,6 +127,7 @@ export const DownloadCard: Story = {
   render: (args) => <OakCard {...args} />,
   args: {
     heading: "Oak's 2022-2025 strategy: April 2024 update",
+    headingLevel: "h3",
     href: "https://example.com/download.pdf",
     cardOrientation: "column",
     cardWidth: "spacing-240",

--- a/src/components/navigation/OakCard/OakCard.test.tsx
+++ b/src/components/navigation/OakCard/OakCard.test.tsx
@@ -8,6 +8,7 @@ import renderWithTheme from "@/test-helpers/renderWithTheme";
 
 const testData = {
   heading: "Test Heading",
+  headingLevel: "h3" as const,
   href: "https://www.example.com",
   cardOrientation: "row" as const,
   cardWidth: "spacing-360" as const,
@@ -41,6 +42,12 @@ describe("OakCard", () => {
     expect(screen.getByRole("link")).toHaveAttribute("href", testData.href);
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
     expect(screen.queryByRole("paragraph")).not.toBeInTheDocument();
+  });
+
+  it("renders card with the correct heading level when provided", () => {
+    renderWithTheme(<OakCard {...requiredProps} headingLevel="h4" />);
+
+    expect(screen.getByRole("heading")).toHaveProperty("tagName", "H4");
   });
 
   it("renders card with correct orientation when provided", () => {

--- a/src/components/navigation/OakCard/OakCard.tsx
+++ b/src/components/navigation/OakCard/OakCard.tsx
@@ -24,6 +24,10 @@ export type OakCardProps = {
    */
   heading: string;
   /**
+   * The heading level of the card.
+   */
+  headingLevel?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  /**
    * The URL that the card links to.
    */
   href: string;
@@ -114,6 +118,7 @@ const StyledOakImage = styled(OakImage)<StyledImageProps>`
  */
 export const OakCard = ({
   heading,
+  headingLevel = "h3",
   href,
   cardOrientation = "column",
   cardWidth,
@@ -161,7 +166,7 @@ export const OakCard = ({
           $gap="spacing-16"
         >
           <OakFlex $flexDirection="column" $gap="spacing-16">
-            <OakHeading tag="h3" $font={"heading-6"}>
+            <OakHeading tag={headingLevel} $font={"heading-6"}>
               {heading}
             </OakHeading>
             {subCopy && <OakP>{subCopy}</OakP>}

--- a/src/components/navigation/OakCard/OakCard.tsx
+++ b/src/components/navigation/OakCard/OakCard.tsx
@@ -5,7 +5,7 @@ import { parseBorderRadius } from "@/styles/helpers/parseBorderRadius";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
 import { OakFlex } from "@/components/layout-and-structure/OakFlex";
 import { OakFocusIndicator } from "@/components/messaging-and-feedback/OakFocusIndicator";
-import { OakHeading } from "@/components/typography/OakHeading";
+import { OakHeading, OakHeadingTag } from "@/components/typography/OakHeading";
 import { OakImage } from "@/components/images-and-icons/OakImage";
 import { OakP } from "@/components/typography/OakP";
 import { OakIconName, OakIcon } from "@/components/images-and-icons/OakIcon";
@@ -26,7 +26,7 @@ export type OakCardProps = {
   /**
    * The heading level of the card.
    */
-  headingLevel?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  headingLevel?: OakHeadingTag;
   /**
    * The URL that the card links to.
    */


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

- Added ability to change the heading level on the OakCard component for accessibility reasons.

## Link to the design doc

[Figma](https://www.figma.com/design/ktldjkEqAqv0X8PGzxrZyA/%F0%9F%9A%80-Integrated-journeys-v2?node-id=16897-147249&m=dev)

## Testing instructions

- Go to [Storybook](https://oak-components-storybook-git-feat-lesq-1919unit-page-hea-c1ce91.vercel.thenational.academy/?path=/docs/components-navigation-oakcard--docs)
- Navigate to OakCard
- Open Voice Over or another screen reader
- Navigate over the card and see heading has correct level
- Amend heading level with Storybook controls and see change with screen reader

## ACs

- [x] Update the `OakCard` component so that it can be used as a h2