### PR TITLE
Adopt-1931: Build new ‘View by’ switcher

### DIFF
--- a/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.stories.tsx
+++ b/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.stories.tsx
@@ -15,16 +15,37 @@ export default meta;
 
 type Story = StoryObj<typeof OakViewBySwitcher>;
 
+const defaultTabs = [
+  { label: "Key stage & year group", type: "button" as const, icon: "class-grouping" as const },
+  { label: "Strand", type: "button" as const, icon: "strand" as const },
+];
+
 export const Default: Story = {
   render: function DefaultStory(args) {
-    const [activeTab, setActiveTab] = useState<
-      "Key stage & year group" | "Strand"
-    >("Key stage & year group");
+    const [activeTab, setActiveTab] = useState("Key stage & year group");
     return (
       <OakFlex $mt={"spacing-24"} $justifyContent={"center"}>
         <OakViewBySwitcher
           {...args}
+          tabs={defaultTabs}
           activeTab={activeTab}
+          onTabClick={(tab) => setActiveTab(tab)}
+        />
+      </OakFlex>
+    );
+  },
+};
+
+export const Compact: Story = {
+  render: function CompactStory(args) {
+    const [activeTab, setActiveTab] = useState("Key stage & year group");
+    return (
+      <OakFlex $mt={"spacing-24"} $justifyContent={"center"}>
+        <OakViewBySwitcher
+          {...args}
+          tabs={defaultTabs}
+          activeTab={activeTab}
+          sizeVariant="compact"
           onTabClick={(tab) => setActiveTab(tab)}
         />
       </OakFlex>

--- a/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.stories.tsx
+++ b/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.stories.tsx
@@ -16,7 +16,11 @@ export default meta;
 type Story = StoryObj<typeof OakViewBySwitcher>;
 
 const defaultTabs = [
-  { label: "Key stage & year group", type: "button" as const, icon: "class-grouping" as const },
+  {
+    label: "Key stage & year group",
+    type: "button" as const,
+    icon: "class-grouping" as const,
+  },
   { label: "Strand", type: "button" as const, icon: "strand" as const },
 ];
 

--- a/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.stories.tsx
+++ b/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.stories.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import { StoryObj, Meta } from "@storybook/nextjs";
+
+import { OakViewBySwitcher } from "./OakViewBySwitcher";
+
+import { OakFlex } from "@/index";
+
+const meta: Meta<typeof OakViewBySwitcher> = {
+  component: OakViewBySwitcher,
+  title: "components/Navigation/OakViewBySwitcher",
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OakViewBySwitcher>;
+
+export const Default: Story = {
+  render: function DefaultStory(args) {
+    const [activeTab, setActiveTab] = useState<
+      "Key stage & year group" | "Strand"
+    >("Key stage & year group");
+    return (
+      <OakFlex $mt={"spacing-24"} $justifyContent={"center"}>
+        <OakViewBySwitcher
+          {...args}
+          activeTab={activeTab}
+          onTabClick={(tab) => setActiveTab(tab)}
+        />
+      </OakFlex>
+    );
+  },
+};

--- a/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.stories.tsx
+++ b/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.stories.tsx
@@ -24,6 +24,21 @@ const defaultTabs = [
   { label: "Strand", type: "button" as const, icon: "strand" as const },
 ];
 
+const linkTabs = [
+  {
+    label: "Key stage & year group",
+    type: "link" as const,
+    href: "#key-stage-year-group",
+    icon: "class-grouping" as const,
+  },
+  {
+    label: "Strand",
+    type: "link" as const,
+    href: "#strand",
+    icon: "strand" as const,
+  },
+];
+
 export const Default: Story = {
   render: function DefaultStory(args) {
     const [activeTab, setActiveTab] = useState("Key stage & year group");
@@ -51,6 +66,20 @@ export const Compact: Story = {
           activeTab={activeTab}
           sizeVariant="compact"
           onTabClick={(tab) => setActiveTab(tab)}
+        />
+      </OakFlex>
+    );
+  },
+};
+
+export const Links: Story = {
+  render: function LinksStory(args) {
+    return (
+      <OakFlex $mt={"spacing-24"} $justifyContent={"center"}>
+        <OakViewBySwitcher
+          {...args}
+          tabs={linkTabs}
+          activeTab="Key stage & year group"
         />
       </OakFlex>
     );

--- a/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.test.tsx
+++ b/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.test.tsx
@@ -9,7 +9,13 @@ import renderWithTheme from "@/test-helpers/renderWithTheme";
 
 const onClickCallback = jest.fn();
 
+const defaultTabs: OakViewBySwitcherProps["tabs"] = [
+  { label: "Key stage & year group", type: "button", icon: "class-grouping" },
+  { label: "Strand", type: "button", icon: "strand" },
+];
+
 const props: OakViewBySwitcherProps = {
+  tabs: defaultTabs,
   activeTab: "Key stage & year group",
   onTabClick: (tab) => onClickCallback(tab),
 };
@@ -64,11 +70,16 @@ describe("OakViewBySwitcher", () => {
   });
 
   describe("when rendered as links", () => {
-    const linkProps = {
-      ...props,
-      keyStageYearGroupHref: "#key-stage",
-      strandHref: "#strand",
-    };
+    const linkTabs: OakViewBySwitcherProps["tabs"] = [
+      {
+        label: "Key stage & year group",
+        type: "link",
+        href: "#key-stage",
+        icon: "class-grouping",
+      },
+      { label: "Strand", type: "link", href: "#strand", icon: "strand" },
+    ];
+    const linkProps = { ...props, tabs: linkTabs };
 
     it("renders both tabs as links with correct hrefs", () => {
       renderWithTheme(<OakViewBySwitcher {...linkProps} />);

--- a/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.test.tsx
+++ b/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { OakViewBySwitcher, OakViewBySwitcherProps } from "./OakViewBySwitcher";
+
+import renderWithTheme from "@/test-helpers/renderWithTheme";
+
+const onClickCallback = jest.fn();
+
+const props: OakViewBySwitcherProps = {
+  activeTab: "Key stage & year group",
+  onTabClick: (tab) => onClickCallback(tab),
+};
+
+describe("OakViewBySwitcher", () => {
+  it("renders inside a nav element labelled by the View by heading", () => {
+    renderWithTheme(<OakViewBySwitcher {...props} />);
+    expect(
+      screen.getByRole("navigation", { name: "View by" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders tabs inside a semantic list", () => {
+    renderWithTheme(<OakViewBySwitcher {...props} />);
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+  });
+
+  it("applies white background to the selected tab", () => {
+    renderWithTheme(<OakViewBySwitcher {...props} />);
+    const selected = screen.getByRole("button", {
+      name: "Key stage & year group",
+    });
+    expect(selected).toHaveStyle({ background: "#ffffff" });
+  });
+
+  it("applies black background to unselected tabs", () => {
+    renderWithTheme(<OakViewBySwitcher {...props} />);
+    const unselected = screen.getByRole("button", { name: "Strand" });
+    expect(unselected).toHaveStyle({ background: "#222222" });
+  });
+
+  it("calls onTabClick with the tab label when a button is clicked", async () => {
+    renderWithTheme(<OakViewBySwitcher {...props} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Strand" }));
+    expect(onClickCallback).toHaveBeenCalledWith("Strand");
+  });
+
+  it("marks the active tab with aria-current='true'", () => {
+    renderWithTheme(<OakViewBySwitcher {...props} />);
+    const active = screen.getByRole("button", {
+      name: "Key stage & year group",
+    });
+    expect(active).toHaveAttribute("aria-current", "true");
+  });
+
+  it("does not mark inactive tabs with aria-current", () => {
+    renderWithTheme(<OakViewBySwitcher {...props} />);
+    const inactive = screen.getByRole("button", { name: "Strand" });
+    expect(inactive).not.toHaveAttribute("aria-current");
+  });
+
+  describe("when rendered as links", () => {
+    const linkProps = {
+      ...props,
+      keyStageYearGroupHref: "#key-stage",
+      strandHref: "#strand",
+    };
+
+    it("renders both tabs as links with correct hrefs", () => {
+      renderWithTheme(<OakViewBySwitcher {...linkProps} />);
+      const links = screen.getAllByRole("link");
+      expect(links).toHaveLength(2);
+      expect(links[0]).toHaveAttribute("href", "#key-stage");
+      expect(links[1]).toHaveAttribute("href", "#strand");
+    });
+
+    it("calls onTabClick when a link tab is clicked", async () => {
+      renderWithTheme(<OakViewBySwitcher {...linkProps} />);
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("link", { name: "Strand" }));
+      expect(onClickCallback).toHaveBeenCalledWith("Strand");
+    });
+
+    it("marks the active link tab with aria-current='true'", () => {
+      renderWithTheme(<OakViewBySwitcher {...linkProps} />);
+      const activeLink = screen.getByRole("link", {
+        name: "Key stage & year group",
+      });
+      expect(activeLink).toHaveAttribute("aria-current", "true");
+    });
+
+    it("does not mark inactive link tabs with aria-current", () => {
+      renderWithTheme(<OakViewBySwitcher {...linkProps} />);
+      const inactiveLink = screen.getByRole("link", { name: "Strand" });
+      expect(inactiveLink).not.toHaveAttribute("aria-current");
+    });
+  });
+});

--- a/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.tsx
+++ b/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.tsx
@@ -66,7 +66,7 @@ export function OakViewBySwitcher(props: Readonly<OakViewBySwitcherProps>) {
   return (
     <OakFlex
       as="nav"
-      aria-labelledby="view-by-switcher"
+      aria-labelledby="view-by-switcher-label"
       $flexDirection={"column"}
       $alignItems={"flex-start"}
       $gap={"spacing-4"}

--- a/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.tsx
+++ b/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.tsx
@@ -12,13 +12,16 @@ import { OakLI, OakUL } from "@/components/typography";
 import { OakIcon, OakIconName } from "@/components/images-and-icons/OakIcon";
 import { OakJauntyAngleLabel } from "@/components/form-elements/OakJauntyAngleLabel";
 
-export type OakViewByTab = "Key stage & year group" | "Strand";
+export type OakViewByTabItem<T extends string = string> = {
+  label: T;
+  icon: OakIconName;
+} & ({ type: "button" } | { type: "link"; href: string });
 
-export type OakViewBySwitcherProps = {
-  activeTab: OakViewByTab;
-  keyStageYearGroupHref?: string;
-  strandHref?: string;
-  onTabClick?: (tab: OakViewByTab, event: Event) => void;
+export type OakViewBySwitcherProps<T extends string = string> = {
+  tabs: Array<OakViewByTabItem<T>>;
+  activeTab: T;
+  sizeVariant?: "default" | "compact";
+  onTabClick?: (tab: T, event: Event) => void;
 };
 
 const StyledFocusOutline = styled(OakFlex)``;
@@ -42,26 +45,12 @@ const StyledTabButton = styled(InternalButton)<{
   }
 `;
 
-const TABS: OakViewByTab[] = ["Key stage & year group", "Strand"];
-
-const iconByTab: Record<OakViewByTab, OakIconName> = {
-  "Key stage & year group": "class-grouping",
-  Strand: "strand",
-};
-
-// "class-grouping" icon is black; "strand" icon is white.
-const iconIsWhiteSource: Record<OakViewByTab, boolean> = {
-  "Key stage & year group": false,
-  Strand: true,
-};
-
-export function OakViewBySwitcher(props: Readonly<OakViewBySwitcherProps>) {
-  const { activeTab, keyStageYearGroupHref, strandHref, onTabClick } = props;
-
-  const hrefByTab: Record<OakViewByTab, string | undefined> = {
-    "Key stage & year group": keyStageYearGroupHref,
-    Strand: strandHref,
-  };
+export function OakViewBySwitcher<T extends string>(
+  props: Readonly<OakViewBySwitcherProps<T>>,
+) {
+  const { tabs, activeTab, sizeVariant = "default", onTabClick } = props;
+  const isCompact = sizeVariant === "compact";
+  const listHeight = isCompact ? "spacing-40" : "spacing-56";
 
   return (
     <OakFlex
@@ -71,7 +60,7 @@ export function OakViewBySwitcher(props: Readonly<OakViewBySwitcherProps>) {
       $alignItems={"flex-start"}
       $gap={"spacing-4"}
       $position={"relative"}
-      $height={"spacing-56"}
+      $height={listHeight}
       $maxWidth={"spacing-360"}
     >
       <OakJauntyAngleLabel
@@ -89,24 +78,20 @@ export function OakViewBySwitcher(props: Readonly<OakViewBySwitcherProps>) {
 
       <OakUL
         $display={"flex"}
-        $height={"spacing-56"}
+        $height={listHeight}
         $background={"bg-inverted"}
         $borderRadius={"border-radius-circle"}
         $gap={"spacing-8"}
         $pa={"spacing-8"}
         $alignItems={"center"}
-        $font={"heading-light-7"}
+        $font={isCompact ? "body-3" : "heading-light-7"}
         $ba={"border-solid-s"}
         $borderColor={"bg-inverted"}
       >
-        {TABS.map((label) => {
+        {tabs.map((tab) => {
+          const { label, type, icon } = tab;
           const isSelected = activeTab === label;
-          const icon = iconByTab[label];
-          const href = hrefByTab[label];
-          const iconColorFilter =
-            iconIsWhiteSource[label] === isSelected
-              ? "icon-inverted"
-              : "icon-primary";
+          const iconColorFilter = isSelected ? "icon-primary" : "icon-inverted";
 
           return (
             <OakLI
@@ -117,8 +102,8 @@ export function OakViewBySwitcher(props: Readonly<OakViewBySwitcherProps>) {
               key={label}
             >
               <StyledTabButton
-                element={href ? Link : undefined}
-                href={href}
+                element={type === "link" ? Link : undefined}
+                href={type === "link" ? tab.href : undefined}
                 aria-current={isSelected ? "true" : undefined}
                 $background={isSelected ? "bg-primary" : "bg-inverted"}
                 $color={isSelected ? "text-primary" : "text-inverted"}
@@ -129,7 +114,7 @@ export function OakViewBySwitcher(props: Readonly<OakViewBySwitcherProps>) {
                 $ba="border-solid-s"
                 $borderColor={isSelected ? "bg-primary" : "bg-inverted"}
                 onClick={(event: Event) => onTabClick?.(label, event)}
-                $font={"heading-light-7"}
+                $font={isCompact ? "body-3" : "heading-light-7"}
               >
                 <StyledFocusOutline
                   $width={"100%"}
@@ -142,10 +127,10 @@ export function OakViewBySwitcher(props: Readonly<OakViewBySwitcherProps>) {
                   $gap={"spacing-4"}
                 >
                   <OakIcon
-                    $display={["none", "block"]}
+                    $display={"block"}
                     iconName={icon}
-                    $width={"spacing-24"}
-                    $height={"spacing-24"}
+                    $width={isCompact ? "spacing-20" : "spacing-24"}
+                    $height={isCompact ? "spacing-20" : "spacing-24"}
                     $colorFilter={iconColorFilter}
                   />
                   {label}

--- a/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.tsx
+++ b/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import styled from "styled-components";
+import Link from "next/link";
+
+import { parseColor } from "@/styles/helpers/parseColor";
+import { parseBorderRadius } from "@/styles/helpers/parseBorderRadius";
+import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
+import { InternalButton } from "@/components/internal-components/InternalButton";
+import { OakFlex } from "@/components/layout-and-structure";
+import { OakUiRoleToken } from "@/styles";
+import { OakLI, OakUL } from "@/components/typography";
+import { OakIcon, OakIconName } from "@/components/images-and-icons/OakIcon";
+import { OakJauntyAngleLabel } from "@/components/form-elements/OakJauntyAngleLabel";
+
+export type OakViewByTab = "Key stage & year group" | "Strand";
+
+export type OakViewBySwitcherProps = {
+  activeTab: OakViewByTab;
+  keyStageYearGroupHref?: string;
+  strandHref?: string;
+  onTabClick?: (tab: OakViewByTab, event: Event) => void;
+};
+
+const StyledFocusOutline = styled(OakFlex)``;
+
+const StyledTabButton = styled(InternalButton)<{
+  $hoverColor: OakUiRoleToken;
+  $hoverBackground: OakUiRoleToken;
+}>`
+  width: 100%;
+  height: 100%;
+  border-radius: ${parseBorderRadius("border-radius-circle")};
+  &:hover {
+    color: ${(props) => parseColor(props.$hoverColor)};
+    background: ${(props) => parseColor(props.$hoverBackground)};
+  }
+  &:focus-visible:not(&:active) {
+    box-shadow: ${parseDropShadow("drop-shadow-centered-grey")};
+    ${StyledFocusOutline} {
+      box-shadow: ${parseDropShadow("drop-shadow-centered-lemon")};
+    }
+  }
+`;
+
+const TABS: OakViewByTab[] = ["Key stage & year group", "Strand"];
+
+const iconByTab: Record<OakViewByTab, OakIconName> = {
+  "Key stage & year group": "class-grouping",
+  Strand: "strand",
+};
+
+// "class-grouping" icon is black; "strand" icon is white.
+const iconIsWhiteSource: Record<OakViewByTab, boolean> = {
+  "Key stage & year group": false,
+  Strand: true,
+};
+
+export function OakViewBySwitcher(props: Readonly<OakViewBySwitcherProps>) {
+  const { activeTab, keyStageYearGroupHref, strandHref, onTabClick } = props;
+
+  const hrefByTab: Record<OakViewByTab, string | undefined> = {
+    "Key stage & year group": keyStageYearGroupHref,
+    Strand: strandHref,
+  };
+
+  return (
+    <OakFlex
+      as="nav"
+      aria-labelledby="view-by-switcher"
+      $flexDirection={"column"}
+      $alignItems={"flex-start"}
+      $gap={"spacing-4"}
+      $position={"relative"}
+      $height={"spacing-56"}
+      $maxWidth={"spacing-360"}
+    >
+      <OakJauntyAngleLabel
+        id="view-by-switcher-label"
+        label={"View by"}
+        $background={"bg-decorative5-main"}
+        $color={"text-primary"}
+        $position={"absolute"}
+        $zIndex={"in-front"}
+        $top={"-18px"}
+        $left={"16.5px"}
+        $font={"heading-7"}
+        $borderRadius={"border-radius-square"}
+      />
+
+      <OakUL
+        $display={"flex"}
+        $height={"spacing-56"}
+        $background={"bg-inverted"}
+        $borderRadius={"border-radius-circle"}
+        $gap={"spacing-8"}
+        $pa={"spacing-8"}
+        $alignItems={"center"}
+        $font={"heading-light-7"}
+        $ba={"border-solid-s"}
+        $borderColor={"bg-inverted"}
+      >
+        {TABS.map((label) => {
+          const isSelected = activeTab === label;
+          const icon = iconByTab[label];
+          const href = hrefByTab[label];
+          const iconColorFilter =
+            iconIsWhiteSource[label] === isSelected
+              ? "icon-inverted"
+              : "icon-primary";
+
+          return (
+            <OakLI
+              $listStyle={"none"}
+              $width={"100%"}
+              $height={"100%"}
+              $display={"flex"}
+              key={label}
+            >
+              <StyledTabButton
+                element={href ? Link : undefined}
+                href={href}
+                aria-current={isSelected ? "true" : undefined}
+                $background={isSelected ? "bg-primary" : "bg-inverted"}
+                $color={isSelected ? "text-primary" : "text-inverted"}
+                $hoverColor={isSelected ? "text-primary" : "text-inverted"}
+                $hoverBackground={
+                  isSelected ? "bg-primary" : "bg-btn-primary-hover"
+                }
+                $ba="border-solid-s"
+                $borderColor={isSelected ? "bg-primary" : "bg-inverted"}
+                onClick={(event: Event) => onTabClick?.(label, event)}
+                $font={"heading-light-7"}
+              >
+                <StyledFocusOutline
+                  $width={"100%"}
+                  $height={"100%"}
+                  $borderRadius={"border-radius-circle"}
+                  $pa={"spacing-8"}
+                  $alignItems={"center"}
+                  $justifyContent={"center"}
+                  $whiteSpace={"nowrap"}
+                  $gap={"spacing-4"}
+                >
+                  <OakIcon
+                    $display={["none", "block"]}
+                    iconName={icon}
+                    $width={"spacing-24"}
+                    $height={"spacing-24"}
+                    $colorFilter={iconColorFilter}
+                  />
+                  {label}
+                </StyledFocusOutline>
+              </StyledTabButton>
+            </OakLI>
+          );
+        })}
+      </OakUL>
+    </OakFlex>
+  );
+}

--- a/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.tsx
+++ b/src/components/navigation/OakViewBySwitcher/OakViewBySwitcher.tsx
@@ -82,7 +82,7 @@ export function OakViewBySwitcher<T extends string>(
         $background={"bg-inverted"}
         $borderRadius={"border-radius-circle"}
         $gap={"spacing-8"}
-        $pa={"spacing-8"}
+        $pa={isCompact ? "spacing-4" : "spacing-8"}
         $alignItems={"center"}
         $font={isCompact ? "body-3" : "heading-light-7"}
         $ba={"border-solid-s"}
@@ -97,7 +97,7 @@ export function OakViewBySwitcher<T extends string>(
             <OakLI
               $listStyle={"none"}
               $width={"100%"}
-              $height={"100%"}
+              $height={isCompact ? "spacing-32" : "100%"}
               $display={"flex"}
               key={label}
             >

--- a/src/components/navigation/OakViewBySwitcher/index.ts
+++ b/src/components/navigation/OakViewBySwitcher/index.ts
@@ -1,0 +1,1 @@
+export * from "./OakViewBySwitcher";

--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -85,6 +85,8 @@ export const icons = {
   data: "v1763393164/icons/data-illustration_ukwdxg.svg",
   chatting: "v1763393163/icons/chatting-illustration_l52zaf.svg",
   "snack-break": "v1763393167/icons/snackbreak_illustration_fguw7l.svg",
+  "class-grouping": "v1776785621/icons/class-grouping.svg",
+  "strand": "v1776785925/icons/strand.svg",
   // subject icons
   "subject-art": "v1706616347/subject-icons/art.svg",
   "subject-biology": "v1706616415/subject-icons/biology.svg",

--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -86,7 +86,7 @@ export const icons = {
   chatting: "v1763393163/icons/chatting-illustration_l52zaf.svg",
   "snack-break": "v1763393167/icons/snackbreak_illustration_fguw7l.svg",
   "class-grouping": "v1776785621/icons/class-grouping.svg",
-  "strand": "v1776785925/icons/strand.svg",
+  strand: "v1776785925/icons/strand.svg",
   // subject icons
   "subject-art": "v1706616347/subject-icons/art.svg",
   "subject-biology": "v1706616415/subject-icons/biology.svg",

--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -86,7 +86,7 @@ export const icons = {
   chatting: "v1763393163/icons/chatting-illustration_l52zaf.svg",
   "snack-break": "v1763393167/icons/snackbreak_illustration_fguw7l.svg",
   "class-grouping": "v1776785621/icons/class-grouping.svg",
-  strand: "v1776785925/icons/strand.svg",
+  strand: "v1776850533/icons/strand.svg",
   // subject icons
   "subject-art": "v1706616347/subject-icons/art.svg",
   "subject-biology": "v1706616415/subject-icons/biology.svg",


### PR DESCRIPTION
## New component: `OakViewBySwitcher`

A fixed two-option navigation switcher for toggling between "Key stage & year group" and "Strand" views. Based on the `OakTabs` component.

### Component
- Renders as a `<nav>` with `aria-labelledby` pointing to the "View by" label
- Tabs implemented as `<ul>` / `<li>` with a `<button>` or `<Link>` per tab, configurable via `keyStageYearGroupHref` / `strandHref` props
- Active tab marked with `aria-current="true"`
- sizeVariant prop ("default" | "compact") controls height and font size, matching the OakTabs
- Black colour scheme — selected tab is white bg / black text, unselected is black bg / white text
- Icons hidden on mobile (`$display={["none", "block"]}`) with per-icon colour filter logic to account for differing SVG source colours (`class-grouping` is black source, `strand` is white source)
- Hover state preserves the selected/unselected appearance

### Image map
- Added `class-grouping` and `strand` icons

### Stories
- Default (interactive)

### Tests
- Nav landmark, list semantics, selected/unselected backgrounds, `aria-current`, `onTabClick` callback
- Link mode covered separately: correct `href` values, `aria-current`, and callback on click

# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

## Link to the design doc
Desktop -  https://www.figma.com/design/kuLMyGstxyX5S1EsQSeVCQ/National-Curriculum?node-id=592-23533&m=dev
Mobile - https://www.figma.com/design/kuLMyGstxyX5S1EsQSeVCQ/National-Curriculum?node-id=1-374&p=f&m=dev

## A link to the component in the deployment preview

https://oak-components-storybook-git-feat-adopt-1931-view-by-switcher.vercel.thenational.academy/?path=/docs/components-navigation-oakviewbyswitcher--docs

## Testing instructions

## ACs
- [ ]  Users can switch between KS + YG view and Strand view
- [ ]  Currently active view is highlighted using inverted colours
- [ ]  Toggle switch has ‘View by’ label.
- [ ]  Accessibility requirements
    - [ ]  Implemented as `<nav>`, `<ul>` and `<li>` elements
    - [ ]  Nav is `aria-labelledby` its `View by` label text.
    - [ ]  Each view is implemented as a link.
    - [ ]  Currently active view has an `aria-current="true"` attribute
