### PR TITLE
chore: add globe icon to image map

### DIFF
--- a/src/image-map.ts
+++ b/src/image-map.ts
@@ -206,6 +206,7 @@ export const icons = {
   list: "v1774882349/icons/List.svg",
   "media-clips": "v1774884267/icons/media-clips_nw3zpt.svg",
   retake: "v1775141914/icons/retake-icon_xgqxzv.svg",
+  globe: "v1776851811/icons/globe.svg",
 } as const satisfies VersionedSvgMap;
 
 export type IconName = keyof typeof icons;


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Adds globe icon to icon map

## A link to the component in the deployment preview
https://oak-components-storybook-git-chore-add-globe-icon.vercel.thenational.academy/?path=/story/components-images-and-icons-oakicon--pick-icon&args=iconName:globe

<img width="100" alt="Screenshot 2026-04-22 at 11 18 28" src="https://github.com/user-attachments/assets/be6c02ae-e010-4e01-a2ea-0ab6dd872204" />
