### PR TITLE
feat: add hoverBackground prop to OakCard

### DIFF
--- a/src/components/navigation/OakCard/OakCard.stories.tsx
+++ b/src/components/navigation/OakCard/OakCard.stories.tsx
@@ -39,6 +39,9 @@ const meta: Meta<typeof OakCard> = {
     linkIconName: {
       options: controlIconNames,
     },
+    hoverBackground: {
+      options: oakUiRoleTokens,
+    },
   },
   parameters: {
     controls: {
@@ -56,6 +59,7 @@ const meta: Meta<typeof OakCard> = {
         "tagBackground",
         "linkText",
         "linkIconName",
+        "hoverBackground",
       ],
     },
   },
@@ -81,6 +85,7 @@ export const Default: Story = {
     tagBackground: "bg-decorative5-main",
     linkText: "Link Text",
     linkIconName: "arrow-right",
+    hoverBackground: "bg-btn-secondary-hover",
   },
 };
 
@@ -99,6 +104,7 @@ export const ColumnOrientationWithSquareImage: Story = {
     aspectRatio: "1/1",
     linkText: "Watch the video",
     linkIconName: "chevron-right",
+    hoverBackground: "bg-decorative1-main",
   },
 };
 

--- a/src/components/navigation/OakCard/OakCard.tsx
+++ b/src/components/navigation/OakCard/OakCard.tsx
@@ -71,6 +71,10 @@ export type OakCardProps = {
    * The name of the icon to be displayed next to the link text in the card.
    */
   linkIconName?: OakIconName;
+  /**
+   * The background colour of the card on hover.
+   */
+  hoverBackground?: OakUiRoleToken;
 };
 
 type StyledFlexProps = {
@@ -130,11 +134,12 @@ export const OakCard = ({
   tagBackground = "bg-decorative3-very-subdued",
   linkText,
   linkIconName = "arrow-right",
+  hoverBackground = "bg-btn-secondary-hover",
 }: OakCardProps) => {
   return (
     <OakFocusIndicator
       $background={"bg-primary"}
-      hoverBackground={"bg-btn-secondary-hover"}
+      hoverBackground={hoverBackground}
       $height={"100%"}
       $width={cardWidth}
       $borderRadius={"border-radius-m2"}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Added `hoverBackground` prop to `OakCard`, which accepts Oak colour tokens

## Link to the design doc
https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=18389-1067&m=dev

## A link to the component in the deployment preview
https://oak-components-storybook-git-feat-add-hover-background-t-0e68f5.vercel.thenational.academy/?path=/docs/components-navigation-oakcard--docs

## Testing instructions

## ACs
