### PR TITLE
Fix OakLessonNavItem bad prop spreading

### DIFF
--- a/src/components/owa/pupil/lesson/OakLessonNavItem/OakLessonNavItem.tsx
+++ b/src/components/owa/pupil/lesson/OakLessonNavItem/OakLessonNavItem.tsx
@@ -144,6 +144,8 @@ export const OakLessonNavItem = <C extends ElementType = "a">(
     isLoading,
     href,
     onClick,
+    numQuestions,
+    grade,
     ...rest
   } = props;
   const isDisabled = Boolean(disabled || isLoading);


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
`numQuestions` and `grade` are props on the OakLessonNavItem. They are not being destructured from the rest of the props and so will be included in `...rest`. The rest are then being spread onto the native HTML element. 

This means that it is possible for `numQuestions` and `grade` to be spread onto the underlying native element when they are not valid properties. We should exclude `numQuestions` and `grade` from the `...rest` by destructuring them out.

## Testing instructions
Code review only
