### PR TITLE
Add hoverBorderColor, selectedBackground and selectedHeadingFont props to OakSideMenuNavLink

### DIFF
--- a/src/components/owa/OakSideMenuNavLink/OakSideMenuNavLink.stories.tsx
+++ b/src/components/owa/OakSideMenuNavLink/OakSideMenuNavLink.stories.tsx
@@ -3,6 +3,9 @@ import { StoryObj, Meta } from "@storybook/nextjs";
 
 import { OakSideMenuNavLink } from "./OakSideMenuNavLink";
 
+import { colorArgTypes } from "@/storybook-helpers/colorStyleHelpers";
+import { typographyArgTypes } from "@/storybook-helpers/typographyStyleHelpers";
+
 const meta: Meta<typeof OakSideMenuNavLink> = {
   component: OakSideMenuNavLink,
   tags: ["autodocs"],
@@ -18,13 +21,24 @@ const meta: Meta<typeof OakSideMenuNavLink> = {
         type: "boolean",
       },
     },
+    hoverBorderColor: colorArgTypes.$color,
+    selectedBackground: colorArgTypes.$background,
+    selectedHeadingFont: typographyArgTypes.$font,
     onClick: {
       action: "clicked",
     },
   },
   parameters: {
     controls: {
-      include: ["item", "isSelected", "onClick", "type"],
+      include: [
+        "item",
+        "isSelected",
+        "hoverBorderColor",
+        "selectedBackground",
+        "selectedHeadingFont",
+        "onClick",
+        "type",
+      ],
     },
   },
 };
@@ -42,6 +56,25 @@ export const Default: Story = {
       href: "#test",
     },
     isSelected: false,
+    hoverBorderColor: "bg-decorative1-main",
+    onClick: () => {
+      // Do nothing
+    },
+  },
+};
+
+export const SelectedCustomState: Story = {
+  render: (args) => <OakSideMenuNavLink {...args} />,
+  args: {
+    item: {
+      heading: "Selected Item",
+      subheading: "Custom selected styling",
+      href: "#selected",
+    },
+    isSelected: true,
+    hoverBorderColor: "bg-decorative1-main",
+    selectedBackground: "bg-decorative2-main",
+    selectedHeadingFont: "heading-7",
     onClick: () => {
       // Do nothing
     },

--- a/src/components/owa/OakSideMenuNavLink/OakSideMenuNavLink.test.tsx
+++ b/src/components/owa/OakSideMenuNavLink/OakSideMenuNavLink.test.tsx
@@ -4,6 +4,7 @@ import "@testing-library/jest-dom";
 import { OakSideMenuNavLink } from "./OakSideMenuNavLink";
 
 import renderWithTheme from "@/test-helpers/renderWithTheme";
+import { getBreakpoint } from "@/styles/utils/responsiveStyle";
 
 describe("OakSideMenuNavLink", () => {
   it("renders", () => {
@@ -38,5 +39,32 @@ describe("OakSideMenuNavLink", () => {
       />,
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it("supports custom selected and hover styling props", () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <OakSideMenuNavLink
+        data-testid="test"
+        isSelected={true}
+        item={{
+          heading: "Test",
+          subheading: "Test Subheading",
+          href: "/test",
+        }}
+        hoverBorderColor="border-neutral"
+        selectedBackground="bg-neutral"
+        selectedHeadingFont="heading-7"
+        onClick={() => {
+          // Do nothing
+        }}
+      />,
+    );
+
+    expect(getByTestId("test")).toHaveStyleRule("background-color", "#f2f2f2");
+    expect(getByTestId("test")).toHaveStyleRule("border-color", "#808080", {
+      media: `(min-width: ${getBreakpoint("small")}px)`,
+      modifier: ":hover",
+    });
+    expect(getByText("Test")).toHaveStyleRule("font-weight", "600");
   });
 });

--- a/src/components/owa/OakSideMenuNavLink/OakSideMenuNavLink.test.tsx
+++ b/src/components/owa/OakSideMenuNavLink/OakSideMenuNavLink.test.tsx
@@ -61,10 +61,33 @@ describe("OakSideMenuNavLink", () => {
     );
 
     expect(getByTestId("test")).toHaveStyleRule("background-color", "#f2f2f2");
-    expect(getByTestId("test")).toHaveStyleRule("border-color", "#808080", {
+    expect(getByTestId("test")).toHaveStyleRule("border-color", "#575757", {
       media: `(min-width: ${getBreakpoint("small")}px)`,
       modifier: ":hover",
     });
     expect(getByText("Test")).toHaveStyleRule("font-weight", "600");
+  });
+
+  it("uses the custom hover border color when not selected", () => {
+    const { getByTestId } = renderWithTheme(
+      <OakSideMenuNavLink
+        data-testid="test"
+        isSelected={false}
+        item={{
+          heading: "Test",
+          subheading: "Test Subheading",
+          href: "/test",
+        }}
+        hoverBorderColor="border-neutral"
+        onClick={() => {
+          // Do nothing
+        }}
+      />,
+    );
+
+    expect(getByTestId("test")).toHaveStyleRule("border-color", "#808080", {
+      media: `(min-width: ${getBreakpoint("small")}px)`,
+      modifier: ":hover",
+    });
   });
 });

--- a/src/components/owa/OakSideMenuNavLink/OakSideMenuNavLink.tsx
+++ b/src/components/owa/OakSideMenuNavLink/OakSideMenuNavLink.tsx
@@ -37,7 +37,10 @@ const StyledLink = styled("a")<
       props.isSelected ? "4px solid #222222" : "4px solid transparent"};
     :hover {
       text-decoration: underline;
-      border-color: ${(props) => parseColor(props.hoverBorderColor)};
+      border-color: ${(props) =>
+        props.isSelected
+          ? parseColor("bg-btn-primary-hover")
+          : parseColor(props.hoverBorderColor)};
     }
   }
 

--- a/src/components/owa/OakSideMenuNavLink/OakSideMenuNavLink.tsx
+++ b/src/components/owa/OakSideMenuNavLink/OakSideMenuNavLink.tsx
@@ -9,6 +9,8 @@ import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 import { OakIcon } from "@/components/images-and-icons/OakIcon";
 import { OakSpan } from "@/components/typography/OakSpan";
+import { OakUiRoleToken } from "@/styles/theme/color";
+import { OakFontToken } from "@/styles/theme/typography";
 
 export type MenuItemProps = {
   heading: string;
@@ -17,21 +19,25 @@ export type MenuItemProps = {
 };
 
 const StyledLink = styled("a")<
-  FlexStyleProps & PaddingStyleProps & { isSelected: boolean }
+  FlexStyleProps &
+    PaddingStyleProps & {
+      isSelected: boolean;
+      hoverBorderColor: OakUiRoleToken;
+      selectedBackground?: OakUiRoleToken;
+    }
 >`
   text-decoration: none;
   display: flex;
   outline: none;
+  background-color: ${(props) =>
+    props.isSelected ? parseColor(props.selectedBackground) : undefined};
 
   @media (min-width: ${getBreakpoint("small")}px) {
     border-left: ${(props) =>
       props.isSelected ? "4px solid #222222" : "4px solid transparent"};
     :hover {
       text-decoration: underline;
-      border-color: ${(props) =>
-        props.isSelected
-          ? parseColor("bg-btn-primary-hover")
-          : parseColor("bg-decorative1-main")};
+      border-color: ${(props) => parseColor(props.hoverBorderColor)};
     }
   }
 
@@ -51,6 +57,9 @@ export type OakSideMenuNavLinkProps = FlexStyleProps &
     item: MenuItemProps;
     isSelected: boolean;
     onClick: () => void;
+    hoverBorderColor?: OakUiRoleToken;
+    selectedBackground?: OakUiRoleToken;
+    selectedHeadingFont?: OakFontToken;
   };
 
 const OakSideMenuNavLinkCss = css<OakSideMenuNavLinkProps>`
@@ -59,7 +68,15 @@ const OakSideMenuNavLinkCss = css<OakSideMenuNavLinkProps>`
 `;
 
 const UnstyledComponent = (props: OakSideMenuNavLinkProps) => {
-  const { item, isSelected, onClick, ...rest } = props;
+  const {
+    item,
+    isSelected,
+    onClick,
+    hoverBorderColor = "bg-decorative1-main",
+    selectedBackground,
+    selectedHeadingFont = "heading-light-7",
+    ...rest
+  } = props;
   return (
     <StyledLink
       $alignItems={["center", "flex-start"]}
@@ -67,6 +84,8 @@ const UnstyledComponent = (props: OakSideMenuNavLinkProps) => {
       href={item.href}
       $ph={["spacing-0", "spacing-12"]}
       isSelected={isSelected}
+      hoverBorderColor={hoverBorderColor}
+      selectedBackground={selectedBackground}
       $flexDirection={["row", "column"]}
       onClick={onClick}
       aria-current={isSelected ? "true" : undefined}
@@ -77,7 +96,10 @@ const UnstyledComponent = (props: OakSideMenuNavLinkProps) => {
         $columnGap={["spacing-16", "spacing-4"]}
         $flexWrap="wrap"
       >
-        <OakSpan $font="heading-light-7" $color="text-primary">
+        <OakSpan
+          $font={isSelected ? selectedHeadingFont : "heading-light-7"}
+          $color="text-primary"
+        >
           {item.heading}
         </OakSpan>
         {item.subheading && (


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Fixes ADOPT-1971

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
