### PR TITLE
Export responsive style utils 

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,2 +1,3 @@
 export * from "./theme";
 export * from "./helpers";
+export * from "./utils";

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1,0 +1,6 @@
+export {
+  getBreakpoint,
+  getMediaQuery,
+  responsiveStyle,
+} from "./responsiveStyle";
+export type { BreakpointName, Device } from "./responsiveStyle";

--- a/src/styles/utils/responsiveStyle.ts
+++ b/src/styles/utils/responsiveStyle.ts
@@ -19,6 +19,7 @@ export const breakpoints = Object.values(breakpointsByName).sort((a, b) =>
 
 export type BreakpointName = keyof typeof breakpointsByName;
 
+/** Get the pixel width for a breakpoint by its name. */
 export const getBreakpoint = (
   breakpointName: keyof typeof breakpointsByName,
 ) => {
@@ -35,6 +36,12 @@ const mediaQueries: Record<Device, string> = {
   desktop: `(min-width: ${getBreakpoint("large")}px)`,
 };
 
+/**
+ * Get a CSS snippet of a media query condition which matches a specific device.
+ *
+ * @example
+ *   `@media ${getMediaQuery("mobile")} { ... }`
+ */
 export const getMediaQuery = (device: Device) => {
   return mediaQueries[device];
 };
@@ -43,6 +50,11 @@ export type ResponsiveValues<Value> = (Value | null) | (Value | null)[];
 
 type Generic = string | number | undefined | null;
 
+/**
+ * Helper for a styled component's styles. Generates CSS to apply a value to a
+ * specific CSS property, including media queries if the value is a responsive
+ * array.
+ */
 export const responsiveStyle =
   <Props, T extends Generic>(
     attr: string,


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

If you end up defining your own styled component, then having access to the same breakpoint values as `oak-components` is important for keeping everything consistent. This PR exports `getBreakpoint` so library consumers can access breakpoints themselves.

This also adds exports two other helpers, `getMediaQuery` and `responsiveStyle`, which would be useful when defining these custom components. Less crucial but likely handy for consumers.

Since these are now exported, they now have short doc comments.

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
