### PR TITLE
Add missing padding/gap tokens from design kit

### DIFF
--- a/src/styles/theme/spacing.ts
+++ b/src/styles/theme/spacing.ts
@@ -32,6 +32,7 @@ export type OakAllSpacingToken = keyof typeof oakAllSpacingTokens;
 
 export const oakInnerPaddingTokens = {
   "spacing-0": "spacing-0",
+  "spacing-2": "spacing-2",
   "spacing-4": "spacing-4",
   "spacing-8": "spacing-8",
   "spacing-12": "spacing-12",
@@ -51,14 +52,18 @@ export type OakInnerPaddingToken = keyof typeof oakInnerPaddingTokens;
 
 export const oakSpaceBetweenTokens = {
   "spacing-0": "spacing-0",
+  "spacing-2": "spacing-2",
   "spacing-4": "spacing-4",
   "spacing-8": "spacing-8",
   "spacing-12": "spacing-12",
   "spacing-16": "spacing-16",
+  "spacing-20": "spacing-20",
   "spacing-24": "spacing-24",
   "spacing-32": "spacing-32",
+  "spacing-40": "spacing-40",
   "spacing-48": "spacing-48",
   "spacing-56": "spacing-56",
+  "spacing-64": "spacing-64",
   "spacing-72": "spacing-72",
   "spacing-80": "spacing-80",
 };


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

The Figma design kit has spacing variables defined for gaps and paddings. (Screenshots below.)

The `oakInnerPaddingTokens` and `oakSpaceBetweenTokens` collections are presumably intended to match what's available in Figma, but there were a few tokens missing from these collections compared to Figma. This PR adds them.

## Screenshots

### Padding

<img width="422" height="675" alt="2026-04-29_14-20-44" src="https://github.com/user-attachments/assets/024ac5a6-0cbf-4170-a661-b9bf9356d758" />

### Gap

<img width="422" height="675" alt="2026-04-29_14-20-33" src="https://github.com/user-attachments/assets/fc3bea78-162f-4760-9cd3-b163ef8e0736" />

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
