### PR TITLE
Success Toast has autodismiss and close button option

### DIFF
--- a/src/components/messaging-and-feedback/OakToast/OakToast.stories.tsx
+++ b/src/components/messaging-and-feedback/OakToast/OakToast.stories.tsx
@@ -45,6 +45,11 @@ const meta: Meta<typeof OakToast> = {
         "success",
       ],
     },
+    showClose: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
 };
 

--- a/src/components/messaging-and-feedback/OakToast/OakToast.test.tsx
+++ b/src/components/messaging-and-feedback/OakToast/OakToast.test.tsx
@@ -50,6 +50,16 @@ describe("OakToast", () => {
     expect(closeButton).not.toBeInTheDocument();
   });
 
+  it("renders close button when autoDismiss and showClose are true", async () => {
+    renderWithTheme(<OakToast {...defautProps} autoDismiss showClose />);
+    const toast = screen.getByTestId("oak-toast");
+    expect(toast).toBeVisible();
+    const closeButton = screen.getByRole("button");
+    expect(closeButton).toBeVisible();
+    act(() => jest.advanceTimersByTime(5300));
+    await waitFor(() => expect(toast).not.toBeVisible());
+  });
+
   it("extends the autodismiss duration when reopened", async () => {
     const { rerender } = renderWithTheme(
       <OakToast {...defautProps} autoDismiss id={1} />,

--- a/src/components/messaging-and-feedback/OakToast/OakToast.tsx
+++ b/src/components/messaging-and-feedback/OakToast/OakToast.tsx
@@ -17,6 +17,7 @@ export type OakToastProps = {
   showIcon: boolean;
   onClose?: () => void;
   id?: number;
+  showClose?: boolean;
 };
 
 type VariantKey =
@@ -137,6 +138,7 @@ export const OakToast = ({
   showIcon,
   onClose,
   id,
+  showClose = false,
 }: OakToastProps) => {
   const [isVisible, setIsVisible] = useState(true);
 
@@ -182,7 +184,7 @@ export const OakToast = ({
         >
           {showIcon && icon}
           {message}
-          {!autoDismiss && (
+          {(!autoDismiss || showClose) && (
             <InternalShadowIconButton
               aria-label={"Dismiss"}
               defaultIconColor={color}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

- Updated Oak Toast to allow for both autoDismiss and close button
- Retains default behaviour of one or the other, but can specify to add a close button to autoDismiss with the showClose property

## Link to the design doc

[Figma](https://www.figma.com/design/ktldjkEqAqv0X8PGzxrZyA/%F0%9F%9A%80-Integrated-journeys-v2?node-id=17816-53709&p=f&t=vFhk5NBBiiP1fqjQ-0)

## A link to the component in the deployment preview

[Storybook](https://oak-components-storybook-git-feat-lesq-1946success-toast.vercel.thenational.academy/?path=/story/components-messaging-and-feedback-oaktoast--extendible-auto-dismiss&args=showClose:!true)

## Testing instructions

- Visit Storybook
- See OakToast story
- Try setting autoDismiss to true then showClose to true

## ACs

- AutoDismiss OakToast can be manually dismissed