### PR TITLE
Feat/adopt 2001/update oak link

### DIFF
--- a/src/components/cookies/OakCookieBanner/OakCookieBanner.tsx
+++ b/src/components/cookies/OakCookieBanner/OakCookieBanner.tsx
@@ -5,9 +5,9 @@ import { OakFlex } from "@/components/layout-and-structure/OakFlex";
 import { OakSpan } from "@/components/typography";
 import { OakPrimaryButton } from "@/components/buttons/OakPrimaryButton";
 import { OakSecondaryButton } from "@/components/buttons/OakSecondaryButton";
-import { OakSecondaryLink } from "@/components/navigation/OakSecondaryLink";
 import { OakAllSpacingToken } from "@/styles";
 import { ResponsiveValues } from "@/styles/utils/responsiveStyle";
+import { OakLink } from "@/components/navigation/OakLink";
 
 export type OakCookieBannerProps = {
   /**
@@ -115,12 +115,13 @@ export const OakCookieBanner = ({
                         {state}
                       </OakSpan>{" "}
                       additional cookies. You can{" "}
-                      <OakSecondaryLink
+                      <OakLink
+                        variant="secondary"
                         element="button"
                         onClick={onOpenSettings}
                       >
                         change your cookie settings
-                      </OakSecondaryLink>{" "}
+                      </OakLink>{" "}
                       at any time.
                     </OakBox>
                     <OakFlex $justifyContent="flex-end" $flexGrow={1}>
@@ -152,19 +153,16 @@ export const OakCookieBanner = ({
                       $flexWrap={["wrap", "wrap", "nowrap"]}
                       $flexGrow={1}
                     >
-                      <OakFlex
-                        $font="heading-7"
-                        $whiteSpace="nowrap"
-                        $alignItems="center"
-                      >
-                        <OakSecondaryLink
+                      <OakFlex $whiteSpace="nowrap" $alignItems="center">
+                        <OakLink
+                          variant="secondary-strong"
                           element="button"
                           type="button"
                           onClick={onReject}
                           data-testid="cookie-banner-reject"
                         >
                           Reject non-essential cookies
-                        </OakSecondaryLink>
+                        </OakLink>
                       </OakFlex>
                       <OakSecondaryButton onClick={onOpenSettings}>
                         Cookie settings

--- a/src/components/cookies/OakCookieBanner/OakCookieBanner.tsx
+++ b/src/components/cookies/OakCookieBanner/OakCookieBanner.tsx
@@ -155,7 +155,8 @@ export const OakCookieBanner = ({
                     >
                       <OakFlex $whiteSpace="nowrap" $alignItems="center">
                         <OakLink
-                          variant="secondary-strong"
+                          variant="secondary"
+                          $font={"heading-7"}
                           element="button"
                           type="button"
                           onClick={onReject}

--- a/src/components/cookies/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
+++ b/src/components/cookies/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
@@ -353,6 +353,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 
 .c10:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c10[disabled] {
@@ -520,6 +521,8 @@ exports[`OakCookieBanner matches snapshot 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/cookies/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
+++ b/src/components/cookies/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
@@ -40,13 +40,6 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 
 .c8 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
   white-space: nowrap;
 }
 
@@ -333,7 +326,16 @@ exports[`OakCookieBanner matches snapshot 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  font: inherit;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   background: none;
   border: none;
   -webkit-text-decoration: none;
@@ -555,7 +557,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
             class="c8 c9"
           >
             <button
-              class="c10 "
+              class="c10"
               data-testid="cookie-banner-reject"
               type="button"
             >

--- a/src/components/cookies/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
+++ b/src/components/cookies/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
@@ -40,13 +40,6 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 
 .c8 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
   white-space: nowrap;
 }
 
@@ -232,7 +225,16 @@ exports[`OakCookieConsent matches snapshot 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  font: inherit;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   background: none;
   border: none;
   -webkit-text-decoration: none;
@@ -555,7 +557,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
             class="c8 c9"
           >
             <button
-              class="c10 "
+              class="c10"
               data-testid="cookie-banner-reject"
               type="button"
             >

--- a/src/components/cookies/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
+++ b/src/components/cookies/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
@@ -252,6 +252,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 
 .c10:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c10[disabled] {
@@ -520,6 +521,8 @@ exports[`OakCookieConsent matches snapshot 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/cookies/OakCookieSettingsModal/OakCookieSettingsModal.tsx
+++ b/src/components/cookies/OakCookieSettingsModal/OakCookieSettingsModal.tsx
@@ -14,7 +14,6 @@ import {
 import { OakLink } from "@/components/navigation/OakLink";
 import { OakPrimaryButton } from "@/components/buttons/OakPrimaryButton";
 import { OakSecondaryButton } from "@/components/buttons/OakSecondaryButton";
-import { OakSecondaryLink } from "@/components/navigation/OakSecondaryLink";
 import { OakBox } from "@/components/layout-and-structure/OakBox";
 import { OakHeading } from "@/components/typography/OakHeading";
 import { OakP } from "@/components/typography/OakP";
@@ -169,13 +168,14 @@ export const OakCookieSettingsModal = ({
                         <OakUL $reset>
                           {policy.policyParties.map((party, index, all) => (
                             <OakBox as="li" key={index} $display="inline">
-                              <OakSecondaryLink
+                              <OakLink
+                                variant="secondary"
                                 href={party.url}
                                 target="_blank"
                                 rel="external nofollow"
                               >
                                 {party.name}
-                              </OakSecondaryLink>
+                              </OakLink>
                               {index < all.length - 1 && ", "}
                             </OakBox>
                           ))}

--- a/src/components/house-cat/OakCaptionCard/OakCaptionCard.tsx
+++ b/src/components/house-cat/OakCaptionCard/OakCaptionCard.tsx
@@ -10,8 +10,7 @@ import { InternalCheckBoxLabelHoverDecor } from "@/components/internal-component
 import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 import { OakCheckBox } from "@/components/form-elements/OakCheckBox";
-import { OakSecondaryLink } from "@/components/navigation/OakSecondaryLink";
-import { OakLink } from "@/components/navigation";
+import { OakLink } from "@/components/navigation/OakLink";
 
 interface StyledFlexBoxWrapperProps {
   $minHeight: string;
@@ -178,7 +177,8 @@ export const OakCaptionCard = (props: OakCaptionCardProps) => {
         $gap={"spacing-32"}
         $font={"body-2"}
       >
-        <OakSecondaryLink
+        <OakLink
+          variant="secondary"
           href={lessonHref}
           aria-label={`view lesson ${lessonUid} in a new tab`}
           data-testid="lesson_uid"
@@ -190,7 +190,7 @@ export const OakCaptionCard = (props: OakCaptionCardProps) => {
           }}
         >
           {lessonUid}
-        </OakSecondaryLink>
+        </OakLink>
 
         <OakFlex $alignItems={"center"} $gap={"spacing-4"}>
           {" "}

--- a/src/components/house-cat/OakCaptionCard/OakCaptionCard.tsx
+++ b/src/components/house-cat/OakCaptionCard/OakCaptionCard.tsx
@@ -10,8 +10,8 @@ import { InternalCheckBoxLabelHoverDecor } from "@/components/internal-component
 import { parseColor } from "@/styles/helpers/parseColor";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 import { OakCheckBox } from "@/components/form-elements/OakCheckBox";
-import { OakHoverLink } from "@/components/navigation/OakHoverLink";
 import { OakSecondaryLink } from "@/components/navigation/OakSecondaryLink";
+import { OakLink } from "@/components/navigation";
 
 interface StyledFlexBoxWrapperProps {
   $minHeight: string;
@@ -156,7 +156,8 @@ export const OakCaptionCard = (props: OakCaptionCardProps) => {
         </OakFlex>
 
         <OakFlex $flexGrow={10} $justifyContent={"flex-end"}>
-          <OakHoverLink
+          <OakLink
+            variant="secondary"
             href={editHref}
             iconName="external"
             isTrailingIcon
@@ -167,7 +168,7 @@ export const OakCaptionCard = (props: OakCaptionCardProps) => {
             }}
           >
             Edit
-          </OakHoverLink>
+          </OakLink>
         </OakFlex>
       </OakFlex>
       <OakFlex

--- a/src/components/house-cat/OakCaptionCard/__snapshots__/OakCaptionCard.test.tsx.snap
+++ b/src/components/house-cat/OakCaptionCard/__snapshots__/OakCaptionCard.test.tsx.snap
@@ -305,6 +305,7 @@ input:checked + .c12 {
 
 .c23:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c23[disabled] {
@@ -346,6 +347,7 @@ input:checked + .c12 {
 
 .c29:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c29[disabled] {
@@ -400,6 +402,8 @@ input:checked + .c12 {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 
@@ -409,6 +413,8 @@ input:checked + .c12 {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/house-cat/OakCaptionCard/__snapshots__/OakCaptionCard.test.tsx.snap
+++ b/src/components/house-cat/OakCaptionCard/__snapshots__/OakCaptionCard.test.tsx.snap
@@ -454,7 +454,7 @@ input:checked + .c12 {
     >
       <a
         aria-label="view lesson LESS-TEST-01234 in a new tab"
-        class="c23 "
+        class="c23"
         data-testid="lesson_uid"
         href="#"
         target="_blank"

--- a/src/components/house-cat/OakCaptionCard/__snapshots__/OakCaptionCard.test.tsx.snap
+++ b/src/components/house-cat/OakCaptionCard/__snapshots__/OakCaptionCard.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`CaptionCard matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c25 {
+.c24 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -75,7 +75,7 @@ exports[`CaptionCard matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c27 {
+.c26 {
   width: 100%;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -144,7 +144,7 @@ exports[`CaptionCard matches snapshot 1`] = `
   flex-grow: 10;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -160,7 +160,7 @@ exports[`CaptionCard matches snapshot 1`] = `
   gap: 2rem;
 }
 
-.c30 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -172,7 +172,7 @@ exports[`CaptionCard matches snapshot 1`] = `
   gap: 0.25rem;
 }
 
-.c32 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -189,11 +189,11 @@ exports[`CaptionCard matches snapshot 1`] = `
   object-fit: contain;
 }
 
-.c26 {
+.c25 {
   object-fit: contain;
 }
 
-.c31 {
+.c29 {
   object-fit: contain;
 }
 
@@ -310,60 +310,7 @@ input:checked + .c12 {
 
 .c23[disabled] {
   cursor: not-allowed;
-  color: #222222;
-}
-
-.c29 {
-  display: inline;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.25rem;
-  outline: none;
-  border-radius: 0.375rem;
-  padding: 0.25rem;
-  margin: -0.25rem;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  font: inherit;
-  background: none;
-  border: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  cursor: pointer;
-  color: #222222;
-  overflow-wrap: break-word;
-}
-
-.c29:focus-visible {
-  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
-}
-
-.c29:visited {
-  color: #222222;
-}
-
-.c29:active {
-  color: #222222;
-  outline: 1px solid #222222;
-}
-
-.c29[disabled] {
-  cursor: not-allowed;
   color: #808080;
-}
-
-.c24 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c2:has(input:focus-visible) {
@@ -399,17 +346,6 @@ input:checked + .c12 {
 @media (hover:hover) {
   .c23:hover,
   .c23:visited:hover {
-    color: #222222;
-    -webkit-text-decoration: underline;
-    text-decoration: underline;
-    -webkit-text-decoration-thickness: 18%;
-    text-decoration-thickness: 18%;
-  }
-}
-
-@media (hover:hover) {
-  .c29:hover,
-  .c29:visited:hover {
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
@@ -488,7 +424,7 @@ input:checked + .c12 {
       >
         <a
           aria-label="edit caption CAP-TEST-01234 in a new tab in rev"
-          class="c23 c24"
+          class="c23"
           href="#}"
           target="_blank"
         >
@@ -498,11 +434,11 @@ input:checked + .c12 {
             Edit
           </span>
           <span
-            class="c25 "
+            class="c24 "
           >
             <img
               alt=""
-              class="c26"
+              class="c25"
               data-nimg="fill"
               decoding="async"
               loading="lazy"
@@ -514,11 +450,11 @@ input:checked + .c12 {
       </div>
     </div>
     <div
-      class="c27 c28"
+      class="c26 c27"
     >
       <a
         aria-label="view lesson LESS-TEST-01234 in a new tab"
-        class="c29 "
+        class="c23 "
         data-testid="lesson_uid"
         href="#"
         target="_blank"
@@ -529,11 +465,11 @@ input:checked + .c12 {
           LESS-TEST-01234
         </span>
         <span
-          class="c25 "
+          class="c24 "
         >
           <img
             alt=""
-            class="c26"
+            class="c25"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -543,15 +479,15 @@ input:checked + .c12 {
         </span>
       </a>
       <div
-        class="c21 c30"
+        class="c21 c28"
       >
          
         <span
-          class="c25"
+          class="c24"
         >
           <img
             alt=""
-            class="c31"
+            class="c29"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -562,14 +498,14 @@ input:checked + .c12 {
         Lesson video
       </div>
       <div
-        class="c21 c32"
+        class="c21 c30"
       >
         <span
-          class="c25"
+          class="c24"
         >
           <img
             alt=""
-            class="c31"
+            class="c29"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -581,14 +517,14 @@ input:checked + .c12 {
         1 days ago
       </div>
       <div
-        class="c21 c32"
+        class="c21 c30"
       >
         <span
-          class="c25"
+          class="c24"
         >
           <img
             alt=""
-            class="c31"
+            class="c29"
             data-nimg="fill"
             decoding="async"
             loading="lazy"

--- a/src/components/internal-components/InternalLink/InternalLink.tsx
+++ b/src/components/internal-components/InternalLink/InternalLink.tsx
@@ -15,7 +15,8 @@ import { OakIcon, OakIconProps } from "@/components/images-and-icons/OakIcon";
 import { OakSpan } from "@/components/typography/OakSpan";
 import { parseColorFilter } from "@/styles/helpers/parseColorFilter";
 import { OakAllSpacingToken, OakUiRoleToken } from "@/styles";
-import { OakTextDecoration } from "@/styles/theme/typography";
+import { OakFontToken, OakTextDecoration } from "@/styles/theme/typography";
+import { typographyStyle } from "@/styles/utils/typographyStyle";
 
 const StyledOakIcon = styled(OakIcon)``;
 
@@ -26,6 +27,7 @@ const StyledLink = styled.a<{
   $activeColor: OakUiRoleToken;
   $disabledColor: OakUiRoleToken;
   $textDecoration: OakTextDecoration;
+  $font?: OakFontToken;
 }>`
   display: inline;
   align-items: center;
@@ -35,7 +37,7 @@ const StyledLink = styled.a<{
   padding: ${parseSpacing("spacing-4")};
   margin: -${parseSpacing("spacing-4")};
   appearance: none;
-  font: inherit;
+  ${(props) => (props.$font ? typographyStyle : "font: inherit;")}
   background: none;
   border: none;
   text-decoration: ${(props) => props.$textDecoration};
@@ -144,6 +146,7 @@ export const InternalLink: InternalLinkComponent = forwardRef(
       iconWidth = "spacing-24",
       iconHeight = "spacing-24",
       textDecoration = "underline",
+      font,
       ...rest
     } = props;
 
@@ -193,6 +196,7 @@ export const InternalLink: InternalLinkComponent = forwardRef(
         $hoverColor={hoverColor}
         $activeColor={activeColor}
         $textDecoration={textDecoration}
+        $font={font}
         {...rest}
       >
         {!isTrailingIcon && icon}

--- a/src/components/internal-components/InternalLink/InternalLink.tsx
+++ b/src/components/internal-components/InternalLink/InternalLink.tsx
@@ -196,7 +196,6 @@ export const InternalLink: InternalLinkComponent = forwardRef(
         $hoverColor={hoverColor}
         $activeColor={activeColor}
         $textDecoration={textDecoration}
-        $font={font}
         {...rest}
       >
         {!isTrailingIcon && icon}

--- a/src/components/internal-components/InternalLink/InternalLink.tsx
+++ b/src/components/internal-components/InternalLink/InternalLink.tsx
@@ -71,11 +71,13 @@ const StyledLink = styled.a<{
         filter: ${(props) => parseColorFilter(props.$hoverColor)};
       }
       text-decoration: underline;
+      text-decoration-thickness: 18%;
     }
   }
 
   &:active {
     color: ${(props) => parseColor(props.$activeColor)};
+    outline: 1px solid ${(props) => parseColor(props.$activeColor)};
     ${StyledOakIcon} {
       filter: ${(props) => parseColorFilter(props.$activeColor)};
     }

--- a/src/components/internal-components/InternalLink/__snapshots__/InternalLink.test.tsx.snap
+++ b/src/components/internal-components/InternalLink/__snapshots__/InternalLink.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`InternalLink matches snapshot 1`] = `
 
 .c0:active {
   color: #081676;
+  outline: 1px solid #081676;
 }
 
 .c0[disabled] {
@@ -52,6 +53,8 @@ exports[`InternalLink matches snapshot 1`] = `
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.stories.tsx
+++ b/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.stories.tsx
@@ -7,9 +7,9 @@ import {
   bannerTypes,
   bannerVariants,
 } from "@/components/messaging-and-feedback/OakInlineBanner";
-import { OakSecondaryLink } from "@/components/navigation/OakSecondaryLink";
 import { oakIconNames } from "@/components/images-and-icons/OakIcon";
 import { OakPrimaryButton } from "@/components/buttons/OakPrimaryButton";
+import { OakLink } from "@/components/navigation/OakLink";
 
 const meta: Meta<typeof OakInlineBanner> = {
   component: OakInlineBanner,
@@ -67,13 +67,14 @@ const meta: Meta<typeof OakInlineBanner> = {
     title: "Information",
     message: `Provide users with non-disruptive feedback`,
     cta: (
-      <OakSecondaryLink
+      <OakLink
+        variant="secondary"
         iconName="chevron-right"
         isTrailingIcon
         href={`#${Math.random()}`}
       >
         Link
-      </OakSecondaryLink>
+      </OakLink>
     ),
     canDismiss: true,
     onDismiss: () => console.log("dismissed"),

--- a/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.test.tsx
+++ b/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom";
 
 import renderWithTheme from "@/test-helpers/renderWithTheme";
 import { OakInlineBanner } from "@/components/messaging-and-feedback/OakInlineBanner";
-import { OakSecondaryLink } from "@/components/navigation/OakSecondaryLink";
+import { OakLink } from "@/components/navigation/OakLink";
 
 jest.mock("react-dom", () => {
   return {
@@ -18,9 +18,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -38,9 +38,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -57,9 +57,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -78,9 +78,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -98,9 +98,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -122,9 +122,9 @@ describe(OakInlineBanner, () => {
         canDismiss
         onDismiss={onDismissSpy}
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -143,9 +143,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss={false}
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -162,13 +162,14 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss
         cta={
-          <OakSecondaryLink
+          <OakLink
+            variant="secondary"
             iconName="chevron-right"
             isTrailingIcon
             data-testid="this-link"
           >
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -186,9 +187,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss={false}
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -210,9 +211,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss={false}
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -235,9 +236,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss={false}
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -254,9 +255,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -277,9 +278,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
@@ -296,9 +297,9 @@ describe(OakInlineBanner, () => {
       <OakInlineBanner
         canDismiss
         cta={
-          <OakSecondaryLink iconName="chevron-right" isTrailingIcon>
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
             Link
-          </OakSecondaryLink>
+          </OakLink>
         }
         isOpen
         message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."

--- a/src/components/messaging-and-feedback/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -443,7 +443,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
           class="c23 c9"
         >
           <a
-            class="c24 "
+            class="c24"
           >
             <span
               class="c25"
@@ -921,7 +921,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
           class="c24 c10"
         >
           <a
-            class="c25 "
+            class="c25"
           >
             <span
               class="c26"
@@ -1370,7 +1370,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
           class="c4 c9"
         >
           <a
-            class="c22 "
+            class="c22"
           >
             <span
               class="c23"

--- a/src/components/messaging-and-feedback/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakInlineBanner/__snapshots__/OakInlineBanner.test.tsx.snap
@@ -337,6 +337,7 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
 
 .c24:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c24[disabled] {
@@ -350,6 +351,8 @@ exports[`OakInlineBanner matches snapshot for banner with title 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 
@@ -812,6 +815,7 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
 
 .c25:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c25[disabled] {
@@ -825,6 +829,8 @@ exports[`OakInlineBanner matches snapshot for large variant banner 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 
@@ -1264,6 +1270,7 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
 
 .c22:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c22[disabled] {
@@ -1277,6 +1284,8 @@ exports[`OakInlineBanner matches snapshot for simple banner without title 1`] = 
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/navigation/OakBreadcrumbs/OakBreadcrumbs.tsx
+++ b/src/components/navigation/OakBreadcrumbs/OakBreadcrumbs.tsx
@@ -1,10 +1,10 @@
 import React, { ReactNode } from "react";
 import styled from "styled-components";
 
-import { OakSecondaryLink } from "@/components/navigation";
 import { OakIcon } from "@/components/images-and-icons";
 import { parseFontSize, parseSpacing } from "@/styles";
 import { OakBox, OakBoxProps } from "@/components/layout-and-structure";
+import { OakLink } from "@/components/navigation/OakLink";
 
 export type OakBreadcrumb = {
   text: string;
@@ -84,12 +84,13 @@ export const OakBreadcrumbs = ({
                 </OakBreadcrumbText>
               )}
               {!isLast && (
-                <OakSecondaryLink
+                <OakLink
+                  variant="secondary"
                   href={breadcrumb.href}
                   style={{ overflow: "hidden" }}
                 >
                   <OakBreadcrumbText>{breadcrumb.text}</OakBreadcrumbText>
-                </OakSecondaryLink>
+                </OakLink>
               )}
             </BreadcrumbsLi>
           );

--- a/src/components/navigation/OakBreadcrumbs/__snapshots__/OakBreadcrumbs.test.tsx.snap
+++ b/src/components/navigation/OakBreadcrumbs/__snapshots__/OakBreadcrumbs.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`OakBreadcrumbs matches snapshot 1`] = `
         class="c2"
       >
         <a
-          class="c3 "
+          class="c3"
           href="#test1"
           style="overflow: hidden;"
         >
@@ -166,7 +166,7 @@ exports[`OakBreadcrumbs matches snapshot 1`] = `
           />
         </span>
         <a
-          class="c3 "
+          class="c3"
           href="#test2"
           style="overflow: hidden;"
         >

--- a/src/components/navigation/OakBreadcrumbs/__snapshots__/OakBreadcrumbs.test.tsx.snap
+++ b/src/components/navigation/OakBreadcrumbs/__snapshots__/OakBreadcrumbs.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`OakBreadcrumbs matches snapshot 1`] = `
 
 .c3:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c3[disabled] {
@@ -116,6 +117,8 @@ exports[`OakBreadcrumbs matches snapshot 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/navigation/OakHoverLink/OakHoverLink.stories.tsx
+++ b/src/components/navigation/OakHoverLink/OakHoverLink.stories.tsx
@@ -11,7 +11,7 @@ const controlIconNames = [...oakIconNames].sort((a, b) => a.localeCompare(b));
 const meta: Meta<typeof OakHoverLink> = {
   component: OakHoverLink,
   tags: ["autodocs"],
-  title: "components/Navigation/OakHoverLink",
+  title: "components/Navigation/OakHoverLink (deprecated)",
   argTypes: {
     displayDisabled: { type: "boolean" },
     children: { type: "string" },

--- a/src/components/navigation/OakHoverLink/OakHoverLink.tsx
+++ b/src/components/navigation/OakHoverLink/OakHoverLink.tsx
@@ -36,6 +36,9 @@ const StyleInternalLink = styled(InternalLink)`
 `;
 
 /**
+ * deprecated - use `<OakLink />` instead
+ * @deprecated
+ *
  * A link with an optional icon where underline is shown on hover.
  *
  * Defaulting to a `HTMLAnchorElement` this component is polymorphic and can be rendered as a button or any other element.

--- a/src/components/navigation/OakHoverLink/__snapshots__/OakHoverLink.test.tsx.snap
+++ b/src/components/navigation/OakHoverLink/__snapshots__/OakHoverLink.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`OakHoverLink matches snapshot 1`] = `
 
 .c0:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c0[disabled] {
@@ -63,6 +64,8 @@ exports[`OakHoverLink matches snapshot 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/navigation/OakLink/OakLink.stories.tsx
+++ b/src/components/navigation/OakLink/OakLink.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Meta, StoryObj } from "@storybook/nextjs";
 
 import { OakLink } from "./OakLink";
+import { variantConfig } from "./config";
 
 import { oakIconNames } from "@/components/images-and-icons/OakIcon";
 import { oakAllSpacingTokens } from "@/styles/theme/spacing";
@@ -20,6 +21,7 @@ const meta: Meta<typeof OakLink> = {
     isTrailingIcon: { type: "boolean" },
     iconHeight: { options: Object.keys(oakAllSpacingTokens) },
     iconWidth: { options: Object.keys(oakAllSpacingTokens) },
+    variant: { options: Object.keys(variantConfig) },
   },
   parameters: {
     controls: {
@@ -29,6 +31,7 @@ const meta: Meta<typeof OakLink> = {
         "isTrailingIcon",
         "iconHeight",
         "iconWidth",
+        "variant",
       ],
     },
   },
@@ -41,9 +44,21 @@ export default meta;
 
 type Story = StoryObj<typeof OakLink>;
 
-export const Default: Story = {
+export const DefaultPrimary: Story = {
   args: {
     href: `#${Math.random()}`,
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: "secondary",
+  },
+};
+
+export const SecondaryStrong: Story = {
+  args: {
+    variant: "secondary-strong",
   },
 };
 

--- a/src/components/navigation/OakLink/OakLink.stories.tsx
+++ b/src/components/navigation/OakLink/OakLink.stories.tsx
@@ -56,12 +56,6 @@ export const Secondary: Story = {
   },
 };
 
-export const SecondaryStrong: Story = {
-  args: {
-    variant: "secondary-strong",
-  },
-};
-
 export const AsAButton: Story = {
   args: {
     element: "button",

--- a/src/components/navigation/OakLink/OakLink.tsx
+++ b/src/components/navigation/OakLink/OakLink.tsx
@@ -49,9 +49,9 @@ export const OakLink: OakLinkComponent = forwardRef(
         color={variantDefinition.color}
         hoverColor={variantDefinition.hoverColor}
         activeColor={variantDefinition.activeColor}
-        disabledColor={variantDefinition.disabledColor}
         visitedColor={variantDefinition.visitedColor}
         textDecoration={variantDefinition.textDecoration}
+        disabledColor={"text-disabled"}
         {...props}
         ref={ref}
       />

--- a/src/components/navigation/OakLink/OakLink.tsx
+++ b/src/components/navigation/OakLink/OakLink.tsx
@@ -1,5 +1,7 @@
 import React, { ElementType, forwardRef } from "react";
 
+import { Variant, variantConfig } from "./config";
+
 import { OakAllSpacingToken } from "@/styles";
 import {
   InternalLink,
@@ -16,6 +18,12 @@ export type OakLinkProps = Pick<
 > & {
   iconWidth?: OakAllSpacingToken;
   iconHeight?: OakAllSpacingToken;
+  /**
+   * Style variant of the OakLink component: "primary" | "secondary" | "secondary-strong"
+   *
+   * @default "primary"
+   */
+  variant?: Variant;
 };
 
 type OakLinkComponent = <C extends React.ElementType = "a">(
@@ -23,23 +31,27 @@ type OakLinkComponent = <C extends React.ElementType = "a">(
 ) => React.ReactNode;
 
 /**
- * A blue link with an optional icon and loading state.
+ * A link with an optional icon and loading state.
  *
  * Defaulting to a `HTMLAnchorElement` this component is polymorphic and can be rendered as a button or any other element.
- * ą
  */
 export const OakLink: OakLinkComponent = forwardRef(
   <C extends ElementType = "a">(
     props: PolymorphicPropsWithRef<C> & OakLinkProps,
     ref: PolymorphicRef<C>,
   ) => {
+    const { variant = "primary" } = props;
+    const variantDefinition = variantConfig[variant];
+
     return (
       <InternalLink
-        color="text-link-active"
-        hoverColor="text-link-hover"
-        activeColor="text-link-pressed"
-        disabledColor="text-disabled"
-        visitedColor="text-link-visited"
+        color={variantDefinition.color}
+        hoverColor={variantDefinition.hoverColor}
+        activeColor={variantDefinition.activeColor}
+        disabledColor={variantDefinition.disabledColor}
+        visitedColor={variantDefinition.visitedColor}
+        textDecoration={variantDefinition.textDecoration}
+        font={variantDefinition.font}
         {...props}
         ref={ref}
       />

--- a/src/components/navigation/OakLink/OakLink.tsx
+++ b/src/components/navigation/OakLink/OakLink.tsx
@@ -11,6 +11,7 @@ import {
   PolymorphicPropsWithRef,
   PolymorphicRef,
 } from "@/components/polymorphic";
+import { TypographyStyleProps } from "@/styles/utils/typographyStyle";
 
 export type OakLinkProps = Pick<
   InternalLinkProps,
@@ -19,12 +20,12 @@ export type OakLinkProps = Pick<
   iconWidth?: OakAllSpacingToken;
   iconHeight?: OakAllSpacingToken;
   /**
-   * Style variant of the OakLink component: "primary" | "secondary" | "secondary-strong"
+   * Style variant of the OakLink component: "primary" | "secondary"
    *
    * @default "primary"
    */
   variant?: Variant;
-};
+} & Pick<TypographyStyleProps, "$font">;
 
 type OakLinkComponent = <C extends React.ElementType = "a">(
   props: PolymorphicPropsWithRef<C> & OakLinkProps,
@@ -51,7 +52,6 @@ export const OakLink: OakLinkComponent = forwardRef(
         disabledColor={variantDefinition.disabledColor}
         visitedColor={variantDefinition.visitedColor}
         textDecoration={variantDefinition.textDecoration}
-        font={variantDefinition.font}
         {...props}
         ref={ref}
       />

--- a/src/components/navigation/OakLink/__snapshots__/OakLink.test.tsx.snap
+++ b/src/components/navigation/OakLink/__snapshots__/OakLink.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`OakLink matches snapshot 1`] = `
 
 .c0:active {
   color: #081676;
+  outline: 1px solid #081676;
 }
 
 .c0[disabled] {
@@ -52,6 +53,8 @@ exports[`OakLink matches snapshot 1`] = `
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/navigation/OakLink/config.tsx
+++ b/src/components/navigation/OakLink/config.tsx
@@ -1,7 +1,7 @@
 import { OakUiRoleToken } from "@/styles";
 import { OakFontToken, OakTextDecoration } from "@/styles/theme/typography";
 
-export type Variant = "primary" | "secondary" | "secondary-strong";
+export type Variant = "primary" | "secondary";
 
 export type VariantConfig = {
   color: OakUiRoleToken;
@@ -28,15 +28,6 @@ export const variantConfig: Record<Variant, VariantConfig> = {
     activeColor: "text-primary",
     disabledColor: "text-disabled",
     visitedColor: "text-primary",
-    textDecoration: "none",
-  },
-  "secondary-strong": {
-    color: "text-primary",
-    hoverColor: "text-primary",
-    activeColor: "text-primary",
-    disabledColor: "text-disabled",
-    visitedColor: "text-primary",
-    font: "heading-7",
     textDecoration: "none",
   },
 };

--- a/src/components/navigation/OakLink/config.tsx
+++ b/src/components/navigation/OakLink/config.tsx
@@ -1,0 +1,42 @@
+import { OakUiRoleToken } from "@/styles";
+import { OakFontToken, OakTextDecoration } from "@/styles/theme/typography";
+
+export type Variant = "primary" | "secondary" | "secondary-strong";
+
+export type VariantConfig = {
+  color: OakUiRoleToken;
+  hoverColor: OakUiRoleToken;
+  activeColor: OakUiRoleToken;
+  disabledColor: OakUiRoleToken;
+  visitedColor: OakUiRoleToken;
+  font?: OakFontToken;
+  textDecoration?: OakTextDecoration;
+};
+
+export const variantConfig: Record<Variant, VariantConfig> = {
+  primary: {
+    color: "text-link-active",
+    hoverColor: "text-link-hover",
+    activeColor: "text-link-pressed",
+    disabledColor: "text-disabled",
+    visitedColor: "text-link-visited",
+    textDecoration: "underline",
+  },
+  secondary: {
+    color: "text-primary",
+    hoverColor: "text-primary",
+    activeColor: "text-primary",
+    disabledColor: "text-disabled",
+    visitedColor: "text-primary",
+    textDecoration: "none",
+  },
+  "secondary-strong": {
+    color: "text-primary",
+    hoverColor: "text-primary",
+    activeColor: "text-primary",
+    disabledColor: "text-disabled",
+    visitedColor: "text-primary",
+    font: "heading-7",
+    textDecoration: "none",
+  },
+};

--- a/src/components/navigation/OakLink/config.tsx
+++ b/src/components/navigation/OakLink/config.tsx
@@ -1,5 +1,5 @@
 import { OakUiRoleToken } from "@/styles";
-import { OakFontToken, OakTextDecoration } from "@/styles/theme/typography";
+import { OakTextDecoration } from "@/styles/theme/typography";
 
 export type Variant = "primary" | "secondary";
 
@@ -7,9 +7,7 @@ export type VariantConfig = {
   color: OakUiRoleToken;
   hoverColor: OakUiRoleToken;
   activeColor: OakUiRoleToken;
-  disabledColor: OakUiRoleToken;
   visitedColor: OakUiRoleToken;
-  font?: OakFontToken;
   textDecoration?: OakTextDecoration;
 };
 
@@ -18,7 +16,6 @@ export const variantConfig: Record<Variant, VariantConfig> = {
     color: "text-link-active",
     hoverColor: "text-link-hover",
     activeColor: "text-link-pressed",
-    disabledColor: "text-disabled",
     visitedColor: "text-link-visited",
     textDecoration: "underline",
   },
@@ -26,7 +23,6 @@ export const variantConfig: Record<Variant, VariantConfig> = {
     color: "text-primary",
     hoverColor: "text-primary",
     activeColor: "text-primary",
-    disabledColor: "text-disabled",
     visitedColor: "text-primary",
     textDecoration: "none",
   },

--- a/src/components/navigation/OakPagination/__snapshots__/OakPagination.test.tsx.snap
+++ b/src/components/navigation/OakPagination/__snapshots__/OakPagination.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`OakPagination Component matches snapshot 1`] = `
 
 .c2:active {
   color: #081676;
+  outline: 1px solid #081676;
 }
 
 .c2[disabled] {
@@ -238,6 +239,8 @@ exports[`OakPagination Component matches snapshot 1`] = `
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/navigation/OakSecondaryLink/OakSecondaryLink.stories.tsx
+++ b/src/components/navigation/OakSecondaryLink/OakSecondaryLink.stories.tsx
@@ -6,7 +6,7 @@ import { OakSecondaryLink } from "./OakSecondaryLink";
 const meta: Meta<typeof OakSecondaryLink> = {
   component: OakSecondaryLink,
   tags: ["autodocs"],
-  title: "components/Navigation/OakSecondaryLink",
+  title: "components/Navigation/OakSecondaryLink (deprecated)",
   argTypes: {
     children: { type: "string" },
     displayDisabled: { type: "boolean" },

--- a/src/components/navigation/OakSecondaryLink/OakSecondaryLink.tsx
+++ b/src/components/navigation/OakSecondaryLink/OakSecondaryLink.tsx
@@ -26,6 +26,9 @@ type OakLinkComponent = <C extends React.ElementType = "a">(
 const StyledInternalLink = styled(InternalLink)``;
 
 /**
+ * deprecated - use `<OakLink variant="secondary"/>` instead
+ * @deprecated
+ *
  * A black link with an optional icon and loading state.
  *
  * Defaulting to a `HTMLAnchorElement` this component is polymorphic and can be rendered as a button or any other element.

--- a/src/components/navigation/OakSecondaryLink/__snapshots__/OakSecondaryLink.test.tsx.snap
+++ b/src/components/navigation/OakSecondaryLink/__snapshots__/OakSecondaryLink.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`OakSecondaryLink matches snapshot 1`] = `
 
 .c0:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c0[disabled] {
@@ -52,6 +53,8 @@ exports[`OakSecondaryLink matches snapshot 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/owa/OakFilterDrawer/OakFilterDrawer.tsx
+++ b/src/components/owa/OakFilterDrawer/OakFilterDrawer.tsx
@@ -5,10 +5,10 @@ import { InternalShadowRoundButton } from "@/components/internal-components/Inte
 import { OakBox } from "@/components/layout-and-structure/OakBox";
 import { OakFlex } from "@/components/layout-and-structure/OakFlex";
 import { OakHeading } from "@/components/typography/OakHeading";
-import { OakSecondaryLink } from "@/components/navigation/OakSecondaryLink";
 import { useIsScrolled } from "@/hooks/useIsScrolled";
 import { useMounted } from "@/hooks/useMounted";
 import InternalModalTransition from "@/components/internal-components/InternalModalTransition/InternalModalTransition";
+import { OakLink } from "@/components/navigation/OakLink";
 
 type OakFilterDrawerProps = {
   /**
@@ -105,13 +105,14 @@ export const OakFilterDrawer = ({
         $justifyContent="space-between"
         $alignItems="center"
       >
-        <OakSecondaryLink
+        <OakLink
+          variant="secondary"
           onClick={clearAllInputs}
           aria-label="Clear"
           element="button"
         >
           Clear
-        </OakSecondaryLink>
+        </OakLink>
         <OakHeading $font={"heading-6"} tag="h3">
           Filters
         </OakHeading>

--- a/src/components/owa/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
+++ b/src/components/owa/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
@@ -313,6 +313,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
 
 .c7:active {
   color: #222222;
+  outline: 1px solid #222222;
 }
 
 .c7[disabled] {
@@ -356,6 +357,8 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
     color: #222222;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/owa/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
+++ b/src/components/owa/OakFilterDrawer/__snapshots__/OakFilterDrawer.test.tsx.snap
@@ -279,6 +279,22 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   letter-spacing: 0.0115rem;
 }
 
+.c4 {
+  max-width: 100vw;
+  -webkit-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
+}
+
+.c1 {
+  opacity: 0.25;
+  background-color: black;
+  position: fixed;
+  inset: 0;
+  -webkit-transition: ease;
+  transition: ease;
+}
+
 .c7 {
   display: inline;
   -webkit-align-items: center;
@@ -321,22 +337,6 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   color: #808080;
 }
 
-.c4 {
-  max-width: 100vw;
-  -webkit-transform: translateX(0);
-  -ms-transform: translateX(0);
-  transform: translateX(0);
-}
-
-.c1 {
-  opacity: 0.25;
-  background-color: black;
-  position: fixed;
-  inset: 0;
-  -webkit-transition: ease;
-  transition: ease;
-}
-
 @media (min-width:750px) {
   .c27 {
     -webkit-flex-direction: row;
@@ -351,6 +351,12 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
   }
 }
 
+@media (min-width:768px) {
+  .c4 {
+    max-width: 600px;
+  }
+}
+
 @media (hover:hover) {
   .c7:hover,
   .c7:visited:hover {
@@ -359,12 +365,6 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
     text-decoration: underline;
     -webkit-text-decoration-thickness: 18%;
     text-decoration-thickness: 18%;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    max-width: 600px;
   }
 }
 
@@ -392,7 +392,7 @@ exports[`OakFilterDrawer matches snapshot when mounted 1`] = `
       >
         <button
           aria-label="Clear"
-          class="c7 "
+          class="c7"
         >
           <span
             class="c8"

--- a/src/components/owa/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
+++ b/src/components/owa/OakHeaderHero/__snapshots__/OakHeaderHero.test.tsx.snap
@@ -316,6 +316,7 @@ exports[`OakHeaderHero matches snapshot 1`] = `
 
 .c8:active {
   color: #081676;
+  outline: 1px solid #081676;
 }
 
 .c8[disabled] {
@@ -522,6 +523,8 @@ exports[`OakHeaderHero matches snapshot 1`] = `
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/owa/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
+++ b/src/components/owa/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
@@ -622,6 +622,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 
 .c63:active {
   color: #081676;
+  outline: 1px solid #081676;
 }
 
 .c63[disabled] {
@@ -881,6 +882,8 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
     color: #0a1d9d;
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 

--- a/src/components/owa/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
+++ b/src/components/owa/teacher/OakTertiaryOLNav/__snapshots__/OakTertiaryOLNav.test.tsx.snap
@@ -32,6 +32,10 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
+.c4:active {
+  outline: 1px solid;
+}
+
 .c4[disabled] {
   cursor: not-allowed;
 }
@@ -149,6 +153,8 @@ exports[`Component OakTertiaryOLNav matches snapshot 1`] = `
   .c4:visited:hover {
     -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration-thickness: 18%;
+    text-decoration-thickness: 18%;
   }
 }
 


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Adds `primary` and `secondary` variants to `OakLink` as per standards v3
Introduces `$font` prop to `OakLink` 
Deprecates `OakHoverLink` and `OakSecondaryLink` in favour of new variants above 

## Link to the design doc

https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=21431-11121&m=dev 

## A link to the component in the deployment preview

https://oak-components-storybook-git-feat-adopt-2001update-oak-link.vercel.thenational.academy/?path=/docs/components-navigation-oaklink--docs

## Testing instructions

Also impacted the following components, for regression testing: 
- OakCookieBanner
- OakCookieConsent
- OakCaptionCard
- OakInlineBanner
- OakBreadcrumbs
- OakPagination
- OakFilterDrawer
- OakHeaderHero
- OakTertiaryOLNav

## ACs
