### PR TITLE
feat: add loading spinner to OakInlineBanner

### DIFF
--- a/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.stories.tsx
+++ b/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.stories.tsx
@@ -45,6 +45,11 @@ const meta: Meta<typeof OakInlineBanner> = {
     icon: {
       options: [undefined, ...oakIconNames],
     },
+    isLoading: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
   parameters: {
     controls: {
@@ -302,6 +307,39 @@ export const OverriddenStylingLarge: Story = {
     $borderColor: "border-decorative4",
     $background: "bg-decorative4-very-subdued",
     iconColorFilter: "icon-success",
+    variant: "large",
+    message: `Provide users with clear, timely, and non-disruptive feedback to support 
+      their understanding of actions and outcomes without interrupting their 
+      flow. Whether confirming a successful task, alerting them to an error, or 
+      informing them of a background process, feedback should be subtle and 
+      contextual—reinforcing confidence without demanding unnecessary attention.`,
+    cta: (
+      <OakPrimaryButton iconName="chevron-right" isTrailingIcon>
+        Button
+      </OakPrimaryButton>
+    ),
+  },
+};
+
+export const LoadingSpinnerNormal: Story = {
+  args: {
+    isLoading: true,
+    type: "neutral",
+  },
+};
+
+export const LoadingSpinnerSimple: Story = {
+  args: {
+    isLoading: true,
+    type: "neutral",
+    title: undefined,
+  },
+};
+
+export const LoadingSpinnerLarge: Story = {
+  args: {
+    isLoading: true,
+    type: "neutral",
     variant: "large",
     message: `Provide users with clear, timely, and non-disruptive feedback to support 
       their understanding of actions and outcomes without interrupting their 

--- a/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.test.tsx
+++ b/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.test.tsx
@@ -312,4 +312,26 @@ describe(OakInlineBanner, () => {
 
     expect(getByTestId("inline-banner-title").tagName).toBe("H3");
   });
+
+  it("shows loading spinner instead of icon when configured by props", () => {
+    const { queryByTestId, getByTestId } = renderWithTheme(
+      <OakInlineBanner
+        canDismiss
+        cta={
+          <OakLink variant="secondary" iconName="chevron-right" isTrailingIcon>
+            Link
+          </OakLink>
+        }
+        isOpen
+        message="Lorem ipsum dolor sit amet consectetur. Arcu proin rhoncus eget aliquet."
+        onDismiss={() => {}}
+        title="Information"
+        type="info"
+        isLoading
+      />,
+    );
+
+    expect(getByTestId("inline-banner-loading-spinner")).toBeInTheDocument();
+    expect(queryByTestId("inline-banner-icon")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.tsx
+++ b/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.tsx
@@ -132,8 +132,8 @@ export const bannerTypes: BannerTypes = {
 
 export type OakInlineBannerVariantProps = {
   [key in OakInlineBannerVariants]: {
-    iconArea: Partial<SizeStyleProps>;
-    loadingSpinner: Partial<OakLoadingSpinnerProps>;
+    defaultIconDimensions: Partial<SizeStyleProps>;
+    loadingSpinnerDimensions: Partial<OakLoadingSpinnerProps>;
     heading: Partial<OakHeadingProps>;
     closeButtonWrapper?: Partial<OakBoxProps>;
     ctaWrapper?: Partial<OakBoxProps>;
@@ -145,11 +145,11 @@ export type OakInlineBannerVariantProps = {
 
 export const bannerVariants: OakInlineBannerVariantProps = {
   regular: {
-    iconArea: {
+    defaultIconDimensions: {
       $width: "spacing-32",
       $height: "spacing-32",
     },
-    loadingSpinner: {
+    loadingSpinnerDimensions: {
       $width: "spacing-24",
     },
     heading: {
@@ -163,11 +163,11 @@ export const bannerVariants: OakInlineBannerVariantProps = {
     textContentGap: "spacing-4",
   },
   large: {
-    iconArea: {
+    defaultIconDimensions: {
       $width: "spacing-40",
       $height: "spacing-40",
     },
-    loadingSpinner: {
+    loadingSpinnerDimensions: {
       $width: "spacing-32",
     },
     heading: {
@@ -227,7 +227,7 @@ export const OakInlineBanner = ({
       <OakIcon
         iconName={icon ?? bannerTypes[type]?.icon ?? "info"}
         $colorFilter={iconColorFilter ?? bannerTypes[type]?.iconColorFilter}
-        {...bannerVariants[variant].iconArea}
+        {...bannerVariants[variant].defaultIconDimensions}
         data-testid="inline-banner-icon"
       />
     </OakBox>
@@ -235,13 +235,13 @@ export const OakInlineBanner = ({
 
   const loader = (
     <OakFlex
-      {...bannerVariants[variant].iconArea}
+      {...bannerVariants[variant].defaultIconDimensions}
       $flexShrink={0}
       $justifyContent="center"
       $alignItems="center"
     >
       <OakLoadingSpinner
-        {...bannerVariants[variant].loadingSpinner}
+        {...bannerVariants[variant].loadingSpinnerDimensions}
         data-testid="inline-banner-loading-spinner"
       />
     </OakFlex>

--- a/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.tsx
+++ b/src/components/messaging-and-feedback/OakInlineBanner/OakInlineBanner.tsx
@@ -1,5 +1,9 @@
 import React, { ReactNode } from "react";
 
+import {
+  OakLoadingSpinner,
+  OakLoadingSpinnerProps,
+} from "@/components/messaging-and-feedback/OakLoadingSpinner";
 import { InternalShadowRoundButton } from "@/components/internal-components/InternalShadowRoundButton";
 import { OakBox, OakBoxProps } from "@/components/layout-and-structure/OakBox";
 import {
@@ -10,14 +14,11 @@ import {
   OakHeading,
   OakHeadingProps,
 } from "@/components/typography/OakHeading";
-import {
-  OakIcon,
-  OakIconName,
-  OakIconProps,
-} from "@/components/images-and-icons/OakIcon";
+import { OakIcon, OakIconName } from "@/components/images-and-icons/OakIcon";
 import { OakUiRoleToken } from "@/styles";
 import { PaddingStyleProps } from "@/styles/utils/spacingStyle";
 import { FlexStyleProps } from "@/styles/utils/flexStyle";
+import { SizeStyleProps } from "@/styles/utils/sizeStyle";
 
 export type OakInlineBannerTypes =
   | "info"
@@ -54,6 +55,10 @@ export type OakInlineBannerProps = OakFlexProps & {
    * The color filter to apply to the icon
    */
   iconColorFilter?: OakUiRoleToken;
+  /**
+   * If true show a loading spinner instead of an icon
+   */
+  isLoading?: boolean;
   /**
    * The optional call to action to display in the banner
    */
@@ -127,7 +132,8 @@ export const bannerTypes: BannerTypes = {
 
 export type OakInlineBannerVariantProps = {
   [key in OakInlineBannerVariants]: {
-    icon: Partial<OakIconProps>;
+    iconArea: Partial<SizeStyleProps>;
+    loadingSpinner: Partial<OakLoadingSpinnerProps>;
     heading: Partial<OakHeadingProps>;
     closeButtonWrapper?: Partial<OakBoxProps>;
     ctaWrapper?: Partial<OakBoxProps>;
@@ -139,9 +145,12 @@ export type OakInlineBannerVariantProps = {
 
 export const bannerVariants: OakInlineBannerVariantProps = {
   regular: {
-    icon: {
+    iconArea: {
       $width: "spacing-32",
       $height: "spacing-32",
+    },
+    loadingSpinner: {
+      $width: "spacing-24",
     },
     heading: {
       $font: ["heading-7"],
@@ -154,9 +163,12 @@ export const bannerVariants: OakInlineBannerVariantProps = {
     textContentGap: "spacing-4",
   },
   large: {
-    icon: {
+    iconArea: {
       $width: "spacing-40",
       $height: "spacing-40",
+    },
+    loadingSpinner: {
+      $width: "spacing-32",
     },
     heading: {
       $font: ["heading-6"],
@@ -186,6 +198,7 @@ export const bannerVariants: OakInlineBannerVariantProps = {
  * - **type?** \-                       Optional type of banner to display (info, neutral, success, alert, error, warning) (default: info)
  * - **icon?** \-                       Optional icon to display in the banner
  * - **iconColorFilter?** \-            Optional color filter to apply to the icon
+ * - **isLoading?** \-                  If true show a loading spinner instead of an icon
  * - **cta?** \-                        Optional call to action to display in the banner (ReactNode)
  * - **canDismiss?** \-                 If true the banner can be dismissed (show close icon) (default: false)
  * - **onDismiss?** \-                  Function called when the banner is dismissed
@@ -198,20 +211,43 @@ export const OakInlineBanner = ({
   title,
   message,
   type = "info",
+  icon,
+  iconColorFilter,
+  isLoading,
   cta,
   canDismiss = false,
   onDismiss = () => {},
-  icon,
-  iconColorFilter,
   closeButtonOverrideProps,
   variant = "regular",
   titleTag = "h1",
   ...props
 }: OakInlineBannerProps) => {
-  const iconResult = icon || bannerTypes[type]?.icon;
-  const iconColorFilterResult =
-    iconColorFilter || bannerTypes[type]?.iconColorFilter;
+  const iconElement = (
+    <OakBox>
+      <OakIcon
+        iconName={icon ?? bannerTypes[type]?.icon ?? "info"}
+        $colorFilter={iconColorFilter ?? bannerTypes[type]?.iconColorFilter}
+        {...bannerVariants[variant].iconArea}
+        data-testid="inline-banner-icon"
+      />
+    </OakBox>
+  );
 
+  const loader = (
+    <OakFlex
+      {...bannerVariants[variant].iconArea}
+      $flexShrink={0}
+      $justifyContent="center"
+      $alignItems="center"
+    >
+      <OakLoadingSpinner
+        {...bannerVariants[variant].loadingSpinner}
+        data-testid="inline-banner-loading-spinner"
+      />
+    </OakFlex>
+  );
+
+  const iconLogic = isLoading ? loader : iconElement;
   return (
     <OakFlex
       data-testid="oak-inline-banner"
@@ -234,14 +270,7 @@ export const OakInlineBanner = ({
         $gap={"spacing-12"}
         $width={"100%"}
       >
-        <OakBox>
-          <OakIcon
-            iconName={iconResult || "info"}
-            $colorFilter={iconColorFilterResult}
-            {...bannerVariants[variant].icon}
-            data-testid="inline-banner-icon"
-          />
-        </OakBox>
+        {iconLogic}
         {canDismiss && (
           <OakFlex $order={2} {...bannerVariants[variant].closeButtonWrapper}>
             <InternalShadowRoundButton


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Enables `OakInlineBanner` to have a loading spinner instead of an icon.

This uses the same API as buttons, where an `isLoading` prop will override the icon and show a spinner instead.

## Link to the design doc

https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=22220-4334&m=dev

This will be used by CON-1838 / CON-1874 in Studio, which have designs here: https://www.figma.com/design/ivKwSUMBANlItvGbT6PIyW/Lesson-journey---updating-a-published-lesson?node-id=7231-5107&p=f&m=dev

## A link to the component in the deployment preview

https://oak-components-storybook-git-feat-oak-inline-banner-load-fb8324.vercel.thenational.academy/?path=/story/components-messaging-and-feedback-oakinlinebanner--loading-spinner-normal

## Testing instructions

1. Open the deployment
2. Watch the spinner spinning