### PR TITLE
ci: suppress sonar deprecated component warning in storybook files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -34,5 +34,8 @@ sonar.cpd.exclusions=\
   src/**/*.test.tsx,\
   src/**/*.stories.tsx
 
-
+# The below suppresses warnings about using deprecated components in storybook files as we want to be able to show the deprecated components in storybook for a while until we remove them.
+sonar.issue.ignore.multicriteria=deprecatedInStories
+sonar.issue.ignore.multicriteria.deprecatedInStories.ruleKey=typescript:S1874
+sonar.issue.ignore.multicriteria.deprecatedInStories.resourceKey=src/**/*.stories.tsx
 


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

This should suppress sonar warnings about the use of deprecated components in storybook files, since we still want to show these stories until the components are fully removed. 

## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
