### PR TITLE
fix: flakey test because generating invalid date on 1st on month

### DIFF
--- a/src/components/house-cat/OakCaptionCard/OakCaptionCard.test.tsx
+++ b/src/components/house-cat/OakCaptionCard/OakCaptionCard.test.tsx
@@ -28,13 +28,8 @@ describe("CaptionCard", () => {
   });
 
   it("matches snapshot", () => {
-    const date = new Date();
-    const dateString =
-      date.getFullYear() +
-      "-" +
-      (date.getMonth() + 1) +
-      "-" +
-      (date.getDate() - 1);
+    const date = new Date(Date.now() - 1000 * 60 * 60 * 24); // 1 day ago
+    const dateString = date.toISOString();
 
     const { container } = renderWithTheme(
       <OakCaptionCard


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Fix because `date.getDate() - 1` would be `0` on the first of the month, which is an invalid date

## Link to the design doc
None

## A link to the component in the deployment preview
https://oak-components-storybook-git-fix-flakey-test.vercel.thenational.academy/

## Testing instructions
Code review only

