### PR TITLE
Feat/support subcopy color & underline hover in oakcard

### DIFF
--- a/src/components/navigation/OakCard/OakCard.stories.tsx
+++ b/src/components/navigation/OakCard/OakCard.stories.tsx
@@ -33,6 +33,9 @@ const meta: Meta<typeof OakCard> = {
     aspectRatio: {
       options: ["1/1", "4/3"],
     },
+    subCopyColor: {
+      options: oakUiRoleTokens,
+    },
     tagBackground: {
       options: oakUiRoleTokens,
     },
@@ -55,6 +58,7 @@ const meta: Meta<typeof OakCard> = {
         "imageAlt",
         "aspectRatio",
         "subCopy",
+        "subCopyColor",
         "tagName",
         "tagBackground",
         "linkText",
@@ -81,6 +85,7 @@ export const Default: Story = {
     imageAlt: "Example Image Alt",
     aspectRatio: "4/3",
     subCopy: "Some subcopy",
+    subCopyColor: "text-subdued",
     tagName: "Tag Name",
     tagBackground: "bg-decorative5-main",
     linkText: "Link Text",

--- a/src/components/navigation/OakCard/OakCard.tsx
+++ b/src/components/navigation/OakCard/OakCard.tsx
@@ -93,8 +93,18 @@ const StyledOakFlex = styled(OakFlex)<StyledFlexProps>`
   gap: ${({ $gap }) => parseSpacing($gap)};
 
   &:hover {
-    h3 {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    span {
       text-decoration: underline;
+    }
+
+    span {
+      text-decoration-thickness: 18%;
     }
   }
 `;
@@ -191,7 +201,7 @@ export const OakCard = ({
             )}
             {linkText && (
               <OakFlex $alignItems={"center"}>
-                <OakSpan>{linkText}</OakSpan>
+                <OakSpan $font={"heading-light-7"}>{linkText}</OakSpan>
                 <OakIcon
                   iconName={linkIconName}
                   alt=""

--- a/src/components/navigation/OakCard/OakCard.tsx
+++ b/src/components/navigation/OakCard/OakCard.tsx
@@ -56,6 +56,10 @@ export type OakCardProps = {
    */
   subCopy?: string;
   /**
+   * The color of the subcopy text.
+   */
+  subCopyColor?: OakUiRoleToken;
+  /**
    * The name of a tag to be displayed in the card.
    */
   tagName?: string;
@@ -130,6 +134,7 @@ export const OakCard = ({
   imageAlt,
   aspectRatio = "1/1",
   subCopy,
+  subCopyColor = "text-primary",
   tagName,
   tagBackground = "bg-decorative3-very-subdued",
   linkText,
@@ -174,7 +179,7 @@ export const OakCard = ({
             <OakHeading tag={headingLevel} $font={"heading-6"}>
               {heading}
             </OakHeading>
-            {subCopy && <OakP>{subCopy}</OakP>}
+            {subCopy && <OakP $color={subCopyColor}>{subCopy}</OakP>}
           </OakFlex>
           <OakFlex
             $flexDirection="row"

--- a/src/components/navigation/OakCard/__snapshots__/OakCard.test.tsx.snap
+++ b/src/components/navigation/OakCard/__snapshots__/OakCard.test.tsx.snap
@@ -181,6 +181,7 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
 
 .c13 {
   font-family: --var(google-font),Lexend,sans-serif;
+  color: #222222;
 }
 
 .c19 {

--- a/src/components/navigation/OakCard/__snapshots__/OakCard.test.tsx.snap
+++ b/src/components/navigation/OakCard/__snapshots__/OakCard.test.tsx.snap
@@ -186,6 +186,13 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
 
 .c19 {
   font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
 }
 
 .c17 {
@@ -200,9 +207,20 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
   gap: 1rem;
 }
 
-.c4:hover h3 {
+.c4:hover h1,
+.c4:hover h2,
+.c4:hover h3,
+.c4:hover h4,
+.c4:hover h5,
+.c4:hover h6,
+.c4:hover span {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c4:hover span {
+  -webkit-text-decoration-thickness: 18%;
+  text-decoration-thickness: 18%;
 }
 
 .c6 {


### PR DESCRIPTION
# Add your PR description below

- add `subCopyColor` prop
- ensure heading underline supports all tag types
- adjust the linkText font and underline on hover (according to updated designs to fit in line with `OakLink`)

Note: unfortunately we can't use OakLink here as it would illegally render an <a> inside an <a> as the whole card needs to be clickable, so best is to match the span styles to OakLink styles

## Link to the design doc
https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=21443-11737&m=dev

## A link to the component in the deployment preview
https://oak-components-storybook-git-feat-support-subcopy-color-6113ed.vercel.thenational.academy/?path=/docs/components-navigation-oakcard--docs

# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

## Testing instructions

## ACs
