### PR TITLE
Allow all spacing tokens for padding properties

### DIFF
--- a/src/components/form-elements/OakCheckBox/OakCheckBox.tsx
+++ b/src/components/form-elements/OakCheckBox/OakCheckBox.tsx
@@ -10,11 +10,10 @@ import {
 } from "@/components/internal-components/InternalCheckBoxLabel";
 import { InternalCheckBoxWrapper } from "@/components/internal-components/InternalCheckBoxWrapper";
 import {
-  OakAllSpacingToken,
   OakBorderRadiusToken,
   OakBorderWidthToken,
   OakUiRoleToken,
-  OakInnerPaddingToken,
+  OakAllSpacingToken,
 } from "@/styles";
 
 export type OakCheckBoxProps = BaseCheckBoxProps & {
@@ -26,7 +25,7 @@ export type OakCheckBoxProps = BaseCheckBoxProps & {
   checkedIcon?: React.JSX.Element;
   checkedBackgroundFill?: boolean;
   hoverBorderRadius?: OakBorderRadiusToken;
-  iconPadding?: OakInnerPaddingToken;
+  iconPadding?: OakAllSpacingToken;
   defaultColor?: OakUiRoleToken;
   disabledColor?: OakUiRoleToken;
   displayValue?: string;

--- a/src/components/internal-components/InternalCheckBoxWrapper/InternalCheckBoxWrapper.tsx
+++ b/src/components/internal-components/InternalCheckBoxWrapper/InternalCheckBoxWrapper.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 import { OakBox, OakBoxProps } from "@/components/layout-and-structure/OakBox";
 import { OakIcon } from "@/components/images-and-icons/OakIcon";
-import { OakAllSpacingToken, OakInnerPaddingToken } from "@/styles";
+import { OakAllSpacingToken } from "@/styles";
 import { ResponsiveValues } from "@/styles/utils/responsiveStyle";
 
 const StyledIconContainer = styled(OakBox)<
@@ -20,7 +20,7 @@ const StyledIconContainer = styled(OakBox)<
 export type InternalCheckBoxWrapperProps = {
   size?: ResponsiveValues<OakAllSpacingToken>;
   internalCheckbox: React.JSX.Element;
-  iconPadding?: OakInnerPaddingToken;
+  iconPadding?: OakAllSpacingToken;
   checkedIcon?: React.JSX.Element;
 };
 

--- a/src/components/navigation/OakCard/OakCard.tsx
+++ b/src/components/navigation/OakCard/OakCard.tsx
@@ -12,9 +12,8 @@ import { OakIconName, OakIcon } from "@/components/images-and-icons/OakIcon";
 import { OakSpan } from "@/components/typography/OakSpan";
 import { OakTagFunctional } from "@/components/messaging-and-feedback/OakTagFunctional";
 import {
-  OakAllSpacingToken,
   OakCombinedSpacingToken,
-  OakInnerPaddingToken,
+  OakAllSpacingToken,
   OakUiRoleToken,
 } from "@/styles";
 
@@ -83,7 +82,7 @@ export type OakCardProps = {
 
 type StyledFlexProps = {
   $flexDirection: "row" | "column";
-  $pa: OakInnerPaddingToken;
+  $pa: OakAllSpacingToken;
   $gap: OakAllSpacingToken;
 };
 

--- a/src/docs/spacingTokens.mdx
+++ b/src/docs/spacingTokens.mdx
@@ -3,7 +3,6 @@ import { Meta } from "@storybook/addon-docs/blocks";
 import {
   oakAllSpacingTokens,
   oakSpaceBetweenTokens,
-  oakInnerPaddingTokens,
 } from "@/styles/theme";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
 import { OakLI, OakUL } from "@/components/typography";
@@ -26,17 +25,6 @@ import { OakLI, OakUL } from "@/components/typography";
 
 <OakUL>
   {Object.entries(oakSpaceBetweenTokens).map((token, i) => (
-    <OakLI>
-      {token[0]}, {token[1]}, {oakAllSpacingTokens[token[1]]}px,{" "}
-      {parseSpacing(token[0])}
-    </OakLI>
-  ))}
-</OakUL>
-
-### oakInnerPaddingTokens
-
-<OakUL>
-  {Object.entries(oakInnerPaddingTokens).map((token, i) => (
     <OakLI>
       {token[0]}, {token[1]}, {oakAllSpacingTokens[token[1]]}px,{" "}
       {parseSpacing(token[0])}

--- a/src/storybook-helpers/spacingStyleHelpers.ts
+++ b/src/storybook-helpers/spacingStyleHelpers.ts
@@ -1,10 +1,10 @@
 import {
-  oakInnerPaddingTokens,
+  oakAllSpacingTokens,
   oakSpaceBetweenTokens,
 } from "@/styles/theme/spacing";
 
 export const paddingCtl = {
-  options: Object.keys(oakInnerPaddingTokens),
+  options: Object.keys(oakAllSpacingTokens),
 };
 
 export const marginCtl = {

--- a/src/styles/helpers/parseSpacing.ts
+++ b/src/styles/helpers/parseSpacing.ts
@@ -1,11 +1,9 @@
 import pxToRem from "@/styles/helpers/pxToRem";
 import {
   OakAllSpacingToken,
-  OakInnerPaddingToken,
   OakSpaceBetweenToken,
   OakCombinedSpacingToken,
   oakAllSpacingTokens,
-  oakInnerPaddingTokens,
   oakSpaceBetweenTokens,
 } from "@/styles/theme/spacing";
 
@@ -25,9 +23,8 @@ export function parseSpacing(value?: OakCombinedSpacingToken | null) {
     return `${pxToRem(oakAllSpacingTokens[value as OakAllSpacingToken])}rem`; // NB. type assertion is necessary because the OakAllSpacing type is dervied from oakAllSpacingPx
   }
 
-  if (value in oakInnerPaddingTokens) {
-    const v = oakInnerPaddingTokens[value as OakInnerPaddingToken];
-    return `${pxToRem(oakAllSpacingTokens[v as OakAllSpacingToken])}rem`;
+  if (value in oakAllSpacingTokens) {
+    return `${pxToRem(oakAllSpacingTokens[value as OakAllSpacingToken])}rem`;
   }
 
   if (value in oakSpaceBetweenTokens) {

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -6,16 +6,11 @@ export type {
   OakColorFilterToken,
 } from "./color";
 
-export {
-  oakAllSpacingTokens,
-  oakInnerPaddingTokens,
-  oakSpaceBetweenTokens,
-} from "./spacing";
+export { oakAllSpacingTokens, oakSpaceBetweenTokens } from "./spacing";
 
 export type {
   OakAllSpacingToken,
   OakCombinedSpacingToken,
-  OakInnerPaddingToken,
   OakSpaceBetweenToken,
 } from "./spacing";
 

--- a/src/styles/theme/spacing.ts
+++ b/src/styles/theme/spacing.ts
@@ -30,26 +30,6 @@ export const oakAllSpacingTokens = {
 
 export type OakAllSpacingToken = keyof typeof oakAllSpacingTokens;
 
-export const oakInnerPaddingTokens = {
-  "spacing-0": "spacing-0",
-  "spacing-2": "spacing-2",
-  "spacing-4": "spacing-4",
-  "spacing-8": "spacing-8",
-  "spacing-12": "spacing-12",
-  "spacing-16": "spacing-16",
-  "spacing-20": "spacing-20",
-  "spacing-24": "spacing-24",
-  "spacing-32": "spacing-32",
-  "spacing-40": "spacing-40",
-  "spacing-48": "spacing-48",
-  "spacing-56": "spacing-56",
-  "spacing-64": "spacing-64",
-  "spacing-72": "spacing-72",
-  "spacing-80": "spacing-80",
-};
-
-export type OakInnerPaddingToken = keyof typeof oakInnerPaddingTokens;
-
 export const oakSpaceBetweenTokens = {
   "spacing-0": "spacing-0",
   "spacing-2": "spacing-2",
@@ -90,6 +70,5 @@ export type AdditionalSpacingTypes = keyof typeof additionalSpacingTokens;
 
 export type OakCombinedSpacingToken =
   | OakAllSpacingToken
-  | OakInnerPaddingToken
   | OakSpaceBetweenToken
   | AdditionalSpacingTypes;

--- a/src/styles/utils/spacingStyle.ts
+++ b/src/styles/utils/spacingStyle.ts
@@ -6,11 +6,11 @@ import {
 } from "@/styles/utils/responsiveStyle";
 import { parseSpacing } from "@/styles/helpers/parseSpacing";
 import {
-  OakInnerPaddingToken,
+  OakAllSpacingToken,
   OakSpaceBetweenToken,
 } from "@/styles/theme/spacing";
 
-type PaddingValues = ResponsiveValues<OakInnerPaddingToken | null | undefined>;
+type PaddingValues = ResponsiveValues<OakAllSpacingToken | null | undefined>;
 
 export type PaddingStyleProps = {
   /**


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Allow all spacing tokens for padding properties rather than a subset.

Fixes `ADOPT-2055`

## Link to the design doc
None

## A link to the component in the deployment preview
https://oak-components-storybook-git-feat-adopt-2055-allow-all-s-7f79e8.vercel.thenational.academy/

## Testing instructions
Regression test, there shouldn't be any changes to any components. The should now just be able to use the full range of spacing tokens 


