### PR TITLE
fix(PUPIL-1753): label quiz results toggle by section

### DIFF
--- a/src/components/internal-components/InternalReviewAccordion/InternalReviewAccordion.tsx
+++ b/src/components/internal-components/InternalReviewAccordion/InternalReviewAccordion.tsx
@@ -26,6 +26,11 @@ export type InternalReviewAccordionProps = {
    * The id of the accordion
    */
   id: string;
+  /**
+   * Accessible name for the toggle button.
+   * If omitted, the visible text ("Results") will be used as the accessible name.
+   */
+  toggleButtonAriaLabel?: string;
 } & FlexStyleProps &
   OakBoxProps &
   ColorStyleProps;
@@ -51,7 +56,11 @@ export const StyledAccordionButton = styled(InternalShadowRoundButton)<
  * An accordion component that can be used to show/hide content
  */
 
-const Accordion = ({ children, id }: InternalReviewAccordionProps) => {
+const Accordion = ({
+  children,
+  id,
+  toggleButtonAriaLabel,
+}: InternalReviewAccordionProps) => {
   const { isOpen, setOpen } = useAccordionContext();
 
   return (
@@ -66,6 +75,7 @@ const Accordion = ({ children, id }: InternalReviewAccordionProps) => {
           $isOpen={isOpen}
           onClick={() => setOpen(!isOpen)}
           aria-expanded={isOpen}
+          aria-label={toggleButtonAriaLabel}
           id={id}
           iconName={"chevron-down"}
           defaultTextColor={"text-primary"}

--- a/src/components/owa/pupil/lesson/OakLessonReviewQuiz/OakPupilLessonReviewQuiz.test.tsx
+++ b/src/components/owa/pupil/lesson/OakLessonReviewQuiz/OakPupilLessonReviewQuiz.test.tsx
@@ -19,6 +19,22 @@ describe(OakLessonReviewQuiz, () => {
     expect(container).toMatchSnapshot();
   });
 
+  it("gives the results button an accessible name including the section", () => {
+    const { getByRole } = renderWithTheme(
+      <OakLessonReviewQuiz
+        lessonSectionName="starter-quiz"
+        completed={true}
+        numQuestions={6}
+        grade={0}
+        resultsSlot={<div>Starter quiz results content</div>}
+      />,
+    );
+
+    expect(
+      getByRole("button", { name: "Starter quiz results" }),
+    ).toBeInTheDocument();
+  });
+
   it("renders copy for each lesson section that has not been completed", () => {
     const { getByTestId } = renderWithTheme(
       <>

--- a/src/components/owa/pupil/lesson/OakLessonReviewQuiz/OakPupilLessonReviewQuiz.test.tsx
+++ b/src/components/owa/pupil/lesson/OakLessonReviewQuiz/OakPupilLessonReviewQuiz.test.tsx
@@ -19,20 +19,41 @@ describe(OakLessonReviewQuiz, () => {
     expect(container).toMatchSnapshot();
   });
 
-  it("gives the results button an accessible name including the section", () => {
-    const { getByRole } = renderWithTheme(
-      <OakLessonReviewQuiz
-        lessonSectionName="starter-quiz"
-        completed={true}
-        numQuestions={6}
-        grade={0}
-        resultsSlot={<div>Starter quiz results content</div>}
-      />,
+  it("gives each results button a section-specific accessible name and unique id", () => {
+    const { getByRole, container } = renderWithTheme(
+      <>
+        <OakLessonReviewQuiz
+          lessonSectionName="starter-quiz"
+          completed={true}
+          numQuestions={6}
+          grade={4}
+          resultsSlot={<div>Starter quiz results content</div>}
+        />
+        <OakLessonReviewQuiz
+          lessonSectionName="exit-quiz"
+          completed={true}
+          numQuestions={6}
+          grade={5}
+          resultsSlot={<div>Exit quiz results content</div>}
+        />
+      </>,
     );
 
-    expect(
-      getByRole("button", { name: "Starter quiz results" }),
-    ).toBeInTheDocument();
+    const starterResultsButton = getByRole("button", {
+      name: "Starter quiz results",
+    });
+    const exitResultsButton = getByRole("button", {
+      name: "Exit quiz results",
+    });
+
+    expect(starterResultsButton).toHaveAttribute("aria-expanded", "false");
+    expect(exitResultsButton).toHaveAttribute("aria-expanded", "false");
+    expect(container.querySelector("#quiz-review-accordion-starter-quiz")).toBe(
+      starterResultsButton,
+    );
+    expect(container.querySelector("#quiz-review-accordion-exit-quiz")).toBe(
+      exitResultsButton,
+    );
   });
 
   it("renders copy for each lesson section that has not been completed", () => {

--- a/src/components/owa/pupil/lesson/OakLessonReviewQuiz/OakPupilLessonReviewQuiz.tsx
+++ b/src/components/owa/pupil/lesson/OakLessonReviewQuiz/OakPupilLessonReviewQuiz.tsx
@@ -146,7 +146,7 @@ export const OakLessonReviewQuiz = (props: OakLessonReviewQuizProps) => {
       {completed && (
         <InternalReviewAccordion
           initialOpen={false}
-          id="quiz-review-accordion"
+          id={`quiz-review-accordion-${lessonSectionName}`}
           toggleButtonAriaLabel={resultsToggleAriaLabel}
         >
           {resultsSlot}

--- a/src/components/owa/pupil/lesson/OakLessonReviewQuiz/OakPupilLessonReviewQuiz.tsx
+++ b/src/components/owa/pupil/lesson/OakLessonReviewQuiz/OakPupilLessonReviewQuiz.tsx
@@ -109,6 +109,11 @@ export const OakLessonReviewQuiz = (props: OakLessonReviewQuizProps) => {
       ? `Activate - ${props.numQuestions} questions`
       : `Check - ${props.numQuestions} questions`;
 
+  const resultsToggleAriaLabel =
+    lessonSectionName === "starter-quiz"
+      ? "Starter quiz results"
+      : "Exit quiz results";
+
   return (
     <ReviewItemContainer
       $background={completed ? completedBackgroundColor : "bg-primary"}
@@ -139,7 +144,11 @@ export const OakLessonReviewQuiz = (props: OakLessonReviewQuizProps) => {
         )}
       </OakFlex>
       {completed && (
-        <InternalReviewAccordion initialOpen={false} id="quiz-review-accordion">
+        <InternalReviewAccordion
+          initialOpen={false}
+          id="quiz-review-accordion"
+          toggleButtonAriaLabel={resultsToggleAriaLabel}
+        >
           {resultsSlot}
         </InternalReviewAccordion>
       )}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

## Link to the design doc

n/a — accessibility fix ([PUPIL-1753](https://www.notion.so/oaknationalacademy/Associate-results-button-to-section-programmatically-37526cc4e1b180569be5fd994489fd09))

## A link to the component in the deployment preview

Storybook: `OWA / pupil / lesson / OakLessonReviewQuiz` — set `completed: true` to show the Results toggle.

## Testing instructions

Verified locally in OWA via `yalc` link — supersedes [Oak-Web-Application#4300](https://github.com/oaknational/Oak-Web-Application/pull/4300).


1. Open Storybook and navigate to `OakLessonReviewQuiz`.
2. Set `completed: true` and toggle `lessonSectionName` between `starter-quiz` and `exit-quiz`.
3. Confirm the Results button has `aria-label="Starter quiz results"` / `"Exit quiz results"` and `aria-expanded` toggles on click.
4. With both sections rendered, confirm accordion ids are unique (`quiz-review-accordion-starter-quiz`, `quiz-review-accordion-exit-quiz`).
5. Run `pnpm test:ci OakPupilLessonReviewQuiz`.

<img width="1426" height="589" alt="Screenshot 2026-06-17 at 12 13 52" src="https://github.com/user-attachments/assets/b7419a14-b9ca-4d48-9492-cc12334c1ccd" />
<img width="1426" height="589" alt="Screenshot 2026-06-17 at 12 14 02" src="https://github.com/user-attachments/assets/b51ac131-3049-43bc-a662-c660c6b0aea2" />





## ACs

- [x] Results toggle buttons have section-specific accessible names (e.g. "Starter quiz results", "Exit quiz results")
- [x] Visible label remains "Results"; accessible name provided via `aria-label`
- [x] `aria-expanded` continues to reflect collapsed/expanded state
- [x] Fix implemented in `oak-components` (no OWA DOM workaround)


Made with [Cursor](https://cursor.com)