### PR TITLE
fix(PUPIL-1759): announce tooltip content only when opened

### DIFF
--- a/src/components/owa/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
+++ b/src/components/owa/OakCodeRenderer/__snapshots__/OakCodeRenderer.test.tsx.snap
@@ -21,11 +21,6 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
 }
 
 .c15 {
-  display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c20 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -33,7 +28,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c27 {
+.c22 {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -44,7 +39,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c29 {
+.c24 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -53,7 +48,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c30 {
+.c25 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -98,14 +93,14 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   gap: 0.75rem;
 }
 
-.c21 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c26 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -124,7 +119,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   gap: 0rem;
 }
 
-.c28 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -212,7 +207,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c19 {
+.c27 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -223,28 +218,7 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c16 {
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c17 {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: block;
-  padding-left: 0.5rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c18 {
-  display: revert;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-family: --var(google-font),Lexend,sans-serif;
-  display: revert;
-  display: revert;
-}
-
-.c24 {
+.c19 {
   background: none;
   color: inherit;
   border: none;
@@ -258,65 +232,65 @@ exports[`OakCodeRenderer matches snapshot 1`] = `
   color: #222222;
 }
 
-.c24:disabled {
+.c19:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c31 {
+.c26 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c25 {
+.c20 {
   display: inline-block;
   position: relative;
 }
 
-.c25:hover {
+.c20:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
 }
 
-.c25:active {
+.c20:active {
   color: #222222;
 }
 
-.c25:disabled {
+.c20:disabled {
   color: #808080;
 }
 
-.c22 > :first-child:focus-visible .shadow {
+.c17 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c22 > :first-child:hover .shadow {
+.c17 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c22 > :first-child:active .shadow {
+.c17 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c22 > :first-child:disabled .icon-container {
+.c17 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c22 > :first-child:hover .icon-container {
+.c17 > :first-child:hover .icon-container {
   background: #ffe555;
 }
 
-.c22 > :first-child:active .icon-container {
+.c17 > :first-child:active .icon-container {
   background: #ffe555;
 }
 
-.c23:hover .shadow {
+.c18:hover .shadow {
   box-shadow: none !important;
 }
 
-.c23:active .shadow {
+.c18:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%) !important;
 }
 
@@ -514,95 +488,34 @@ have_homework =
         Code colour
       </span>
       <div
-        class="c15"
-        id="oak-code-renderer-tooltip"
-      >
-        <div
-          class="c0 c1"
-        >
-          <p
-            class="c16"
-          >
-            When programmers write code, they use a special tool called an IDE (Integrated Development Environment). In an IDE, different colours are used to help programmers understand the code:
-          </p>
-          <br />
-          <ul
-            class="c17"
-          >
-            <li
-              class="c18"
-            >
-              <span
-                class="c19"
-              >
-                • Blue
-              </span>
-              <span
-                class="c14"
-              >
-                 - numbers and boolean values
-              </span>
-            </li>
-            <li
-              class="c18"
-            >
-              <span
-                class="c19"
-              >
-                • Green
-              </span>
-              <span
-                class="c14"
-              >
-                 - strings
-              </span>
-            </li>
-            <li
-              class="c18"
-            >
-              <span
-                class="c19"
-              >
-                • Purple
-              </span>
-              <span
-                class="c14"
-              >
-                 - keywords
-              </span>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div
         style="display: contents;"
       >
         <div
-          class="c20 c21 c22 c23"
+          class="c15 c16 c17 c18"
         >
           <button
-            aria-describedby="oak-code-renderer-tooltip"
+            aria-expanded="false"
             aria-label="open info tooltip"
-            class="c24 c25"
+            class="c19 c20"
             data-rac="true"
             type="button"
           >
             <div
-              class="c0 c26"
+              class="c0 c21"
             >
               <div
-                class="c27 c28 icon-container"
+                class="c22 c23 icon-container"
               >
                 <div
-                  class="c29 shadow"
+                  class="c24 shadow"
                 />
                 <span
-                  class="c30"
+                  class="c25"
                   data-icon-for="button"
                 >
                   <img
                     alt=""
-                    class="c31"
+                    class="c26"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -612,7 +525,7 @@ have_homework =
                 </span>
               </div>
               <span
-                class="c19"
+                class="c27"
               />
             </div>
           </button>

--- a/src/components/owa/OakInfo/OakInfo.stories.tsx
+++ b/src/components/owa/OakInfo/OakInfo.stories.tsx
@@ -29,6 +29,7 @@ const meta: Meta<typeof OakInfo> = {
   ],
   args: {
     hint: "We've put the lessons in order helping you build on what you've learned before so it’s best to start with the first lesson of a unit.",
+    id: "info-tooltip",
     tooltipPosition: "top-left",
   },
 };

--- a/src/components/owa/OakInfo/OakInfo.test.tsx
+++ b/src/components/owa/OakInfo/OakInfo.test.tsx
@@ -38,7 +38,7 @@ describe("OakInfo", () => {
     expect(button).not.toHaveAttribute("aria-describedby");
   });
 
-  it("announces tooltip content when opened", async () => {
+  it("associates tooltip content with the trigger when opened", async () => {
     const { getByRole, getByTestId } = renderWithTheme(
       <OakInfo
         hint="The answer is right in front of your eyes"
@@ -53,9 +53,8 @@ describe("OakInfo", () => {
     expect(button).toHaveAttribute("aria-expanded", "true");
     expect(button).toHaveAttribute("aria-describedby", "info-tooltip");
 
-    const announcement = getByTestId("info-tooltip-announcement");
-    expect(announcement).toHaveAttribute("aria-live", "polite");
-    expect(announcement).toHaveTextContent(
+    const description = getByTestId("info-tooltip-description");
+    expect(description).toHaveTextContent(
       "The answer is right in front of your eyes",
     );
   });

--- a/src/components/owa/OakInfo/OakInfo.test.tsx
+++ b/src/components/owa/OakInfo/OakInfo.test.tsx
@@ -38,6 +38,31 @@ describe("OakInfo", () => {
     expect(button).not.toHaveAttribute("aria-describedby");
   });
 
+  it("does not allow buttonProps to override controlled ARIA attributes", async () => {
+    const { getByRole } = renderWithTheme(
+      <OakInfo
+        hint="The answer is right in front of your eyes"
+        id="info-tooltip"
+        buttonProps={{
+          "aria-describedby": "consumer-override",
+          "aria-expanded": true,
+          "aria-label": "consumer label",
+        }}
+      />,
+    );
+    const user = userEvent.setup();
+
+    const closedButton = getByRole("button", { name: "open info tooltip" });
+    expect(closedButton).toHaveAttribute("aria-expanded", "false");
+    expect(closedButton).not.toHaveAttribute("aria-describedby");
+
+    await user.click(closedButton);
+
+    const openButton = getByRole("button", { name: "close info tooltip" });
+    expect(openButton).toHaveAttribute("aria-expanded", "true");
+    expect(openButton).toHaveAttribute("aria-describedby", "info-tooltip");
+  });
+
   it("associates tooltip content with the trigger when opened", async () => {
     const { getByRole, getByTestId } = renderWithTheme(
       <OakInfo

--- a/src/components/owa/OakInfo/OakInfo.test.tsx
+++ b/src/components/owa/OakInfo/OakInfo.test.tsx
@@ -38,29 +38,20 @@ describe("OakInfo", () => {
     expect(button).not.toHaveAttribute("aria-describedby");
   });
 
-  it("does not allow buttonProps to override controlled ARIA attributes", async () => {
+  it("allows buttonProps to override default ARIA attributes", () => {
     const { getByRole } = renderWithTheme(
       <OakInfo
         hint="The answer is right in front of your eyes"
         id="info-tooltip"
         buttonProps={{
-          "aria-describedby": "consumer-override",
-          "aria-expanded": true,
-          "aria-label": "consumer label",
+          "aria-label": "custom info label",
         }}
       />,
     );
-    const user = userEvent.setup();
 
-    const closedButton = getByRole("button", { name: "open info tooltip" });
-    expect(closedButton).toHaveAttribute("aria-expanded", "false");
-    expect(closedButton).not.toHaveAttribute("aria-describedby");
-
-    await user.click(closedButton);
-
-    const openButton = getByRole("button", { name: "close info tooltip" });
-    expect(openButton).toHaveAttribute("aria-expanded", "true");
-    expect(openButton).toHaveAttribute("aria-describedby", "info-tooltip");
+    expect(
+      getByRole("button", { name: "custom info label" }),
+    ).toBeInTheDocument();
   });
 
   it("associates tooltip content with the trigger when opened", async () => {

--- a/src/components/owa/OakInfo/OakInfo.test.tsx
+++ b/src/components/owa/OakInfo/OakInfo.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
 
 import { OakInfo } from "./OakInfo";
 
@@ -22,5 +23,40 @@ describe("OakInfo", () => {
     );
 
     expect(container).toMatchSnapshot();
+  });
+
+  it("does not associate tooltip content with the trigger before it is opened", () => {
+    const { getByRole } = renderWithTheme(
+      <OakInfo
+        hint="The answer is right in front of your eyes"
+        id="info-tooltip"
+      />,
+    );
+
+    const button = getByRole("button", { name: "open info tooltip" });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(button).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("announces tooltip content when opened", async () => {
+    const { getByRole, getByTestId } = renderWithTheme(
+      <OakInfo
+        hint="The answer is right in front of your eyes"
+        id="info-tooltip"
+      />,
+    );
+    const user = userEvent.setup();
+
+    await user.click(getByRole("button", { name: "open info tooltip" }));
+
+    const button = getByRole("button", { name: "close info tooltip" });
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(button).toHaveAttribute("aria-describedby", "info-tooltip");
+
+    const announcement = getByTestId("info-tooltip-announcement");
+    expect(announcement).toHaveAttribute("aria-live", "polite");
+    expect(announcement).toHaveTextContent(
+      "The answer is right in front of your eyes",
+    );
   });
 });

--- a/src/components/owa/OakInfo/OakInfo.tsx
+++ b/src/components/owa/OakInfo/OakInfo.tsx
@@ -54,10 +54,8 @@ export const OakInfo = (props: OakInfoProps) => {
       {isOpen && (
         <div
           id={id}
-          aria-live="polite"
-          aria-relevant="all"
           style={{ position: "absolute", left: "-9999px" }}
-          data-testid={`${id}-announcement`}
+          data-testid={`${id}-description`}
         >
           {hint}
         </div>

--- a/src/components/owa/OakInfo/OakInfo.tsx
+++ b/src/components/owa/OakInfo/OakInfo.tsx
@@ -45,10 +45,10 @@ export const OakInfo = (props: OakInfoProps) => {
           isLoading={isLoading}
           disabled={disabled}
           buttonProps={{
-            ...buttonProps,
             "aria-expanded": isOpen,
             "aria-describedby": isOpen ? id : undefined,
             "aria-label": isOpen ? "close info tooltip" : "open info tooltip",
+            ...buttonProps,
           }}
         />
       </OakTooltip>

--- a/src/components/owa/OakInfo/OakInfo.tsx
+++ b/src/components/owa/OakInfo/OakInfo.tsx
@@ -44,10 +44,10 @@ export const OakInfo = (props: OakInfoProps) => {
           isLoading={isLoading}
           disabled={disabled}
           buttonProps={{
+            ...buttonProps,
             "aria-expanded": isOpen,
             "aria-describedby": isOpen ? id : undefined,
             "aria-label": isOpen ? "close info tooltip" : "open info tooltip",
-            ...buttonProps,
           }}
         />
       </OakTooltip>

--- a/src/components/owa/OakInfo/OakInfo.tsx
+++ b/src/components/owa/OakInfo/OakInfo.tsx
@@ -9,6 +9,7 @@ import {
   OakTooltip,
   OakTooltipProps,
 } from "@/components/messaging-and-feedback/OakTooltip";
+import { OakScreenReader } from "@/components/messaging-and-feedback/OakScreenReader";
 import { OakInfoButton } from "@/components/owa/OakInfoButton";
 import { InternalShadowRoundButtonProps } from "@/components/internal-components/InternalShadowRoundButton";
 
@@ -52,13 +53,9 @@ export const OakInfo = (props: OakInfoProps) => {
         />
       </OakTooltip>
       {isOpen && (
-        <div
-          id={id}
-          style={{ position: "absolute", left: "-9999px" }}
-          data-testid={`${id}-description`}
-        >
+        <OakScreenReader as="div" id={id} data-testid={`${id}-description`}>
           {hint}
-        </div>
+        </OakScreenReader>
       )}
     </>
   );

--- a/src/components/owa/OakInfo/OakInfo.tsx
+++ b/src/components/owa/OakInfo/OakInfo.tsx
@@ -10,7 +10,6 @@ import {
   OakTooltipProps,
 } from "@/components/messaging-and-feedback/OakTooltip";
 import { OakInfoButton } from "@/components/owa/OakInfoButton";
-import { OakBox } from "@/components/layout-and-structure/OakBox";
 import { InternalShadowRoundButtonProps } from "@/components/internal-components/InternalShadowRoundButton";
 
 export type OakInfoProps = {
@@ -38,20 +37,31 @@ export const OakInfo = (props: OakInfoProps) => {
 
   return (
     <>
-      <OakBox $display="none" id={id}>
-        {hint}
-      </OakBox>
       <OakTooltip tooltip={hint} isOpen={isOpen} {...tooltipProps}>
         <OakInfoButton
           onClick={handleClick}
           isOpen={isOpen}
+          isLoading={isLoading}
+          disabled={disabled}
           buttonProps={{
-            "aria-describedby": id,
+            "aria-expanded": isOpen,
+            "aria-describedby": isOpen ? id : undefined,
             "aria-label": isOpen ? "close info tooltip" : "open info tooltip",
             ...buttonProps,
           }}
         />
       </OakTooltip>
+      {isOpen && (
+        <div
+          id={id}
+          aria-live="polite"
+          aria-relevant="all"
+          style={{ position: "absolute", left: "-9999px" }}
+          data-testid={`${id}-announcement`}
+        >
+          {hint}
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/owa/OakInfo/__snapshots__/OakInfo.test.tsx.snap
+++ b/src/components/owa/OakInfo/__snapshots__/OakInfo.test.tsx.snap
@@ -2,11 +2,6 @@
 
 exports[`OakInfo matches snapshot 1`] = `
 .c0 {
-  display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c1 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -14,11 +9,11 @@ exports[`OakInfo matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c6 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c8 {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -29,7 +24,7 @@ exports[`OakInfo matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c10 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -38,7 +33,7 @@ exports[`OakInfo matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c11 {
   position: relative;
   width: 2rem;
   min-width: 2rem;
@@ -48,14 +43,14 @@ exports[`OakInfo matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -74,7 +69,7 @@ exports[`OakInfo matches snapshot 1`] = `
   gap: 0rem;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -89,7 +84,7 @@ exports[`OakInfo matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c14 {
+.c13 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -100,7 +95,7 @@ exports[`OakInfo matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c5 {
+.c4 {
   background: none;
   color: inherit;
   border: none;
@@ -114,103 +109,97 @@ exports[`OakInfo matches snapshot 1`] = `
   color: #222222;
 }
 
-.c5:disabled {
+.c4:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c13 {
+.c12 {
   -webkit-filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   filter: invert(10%) sepia(1%) saturate(236%) hue-rotate(314deg) brightness(95%) contrast(91%);
   object-fit: contain;
 }
 
-.c6 {
+.c5 {
   display: inline-block;
   position: relative;
 }
 
-.c6:hover {
+.c5:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
 }
 
-.c6:active {
+.c5:active {
   color: #222222;
 }
 
-.c6:disabled {
+.c5:disabled {
   color: #808080;
 }
 
-.c3 > :first-child:focus-visible .shadow {
+.c2 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c3 > :first-child:hover .shadow {
+.c2 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c3 > :first-child:active .shadow {
+.c2 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c3 > :first-child:disabled .icon-container {
+.c2 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c3 > :first-child:hover .icon-container {
+.c2 > :first-child:hover .icon-container {
   background: #ffe555;
 }
 
-.c3 > :first-child:active .icon-container {
+.c2 > :first-child:active .icon-container {
   background: #ffe555;
 }
 
-.c4:hover .shadow {
+.c3:hover .shadow {
   box-shadow: none !important;
 }
 
-.c4:active .shadow {
+.c3:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%) !important;
 }
 
 <div>
   <div
-    class="c0"
-    id="info-tooltip"
-  >
-    The answer is right in front of your eyes
-  </div>
-  <div
     style="display: contents;"
   >
     <div
-      class="c1 c2 c3 c4"
+      class="c0 c1 c2 c3"
     >
       <button
-        aria-describedby="info-tooltip"
+        aria-expanded="false"
         aria-label="open info tooltip"
-        class="c5 c6"
+        class="c4 c5"
         data-rac="true"
       >
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10 icon-container"
+            class="c8 c9 icon-container"
           >
             <div
-              class="c11 shadow"
+              class="c10 shadow"
             />
             <span
-              class="c12"
+              class="c11"
               data-icon-for="button"
             >
               <img
                 alt=""
-                class="c13"
+                class="c12"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -220,7 +209,7 @@ exports[`OakInfo matches snapshot 1`] = `
             </span>
           </div>
           <span
-            class="c14"
+            class="c13"
           />
         </div>
       </button>

--- a/src/components/owa/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -12,11 +12,6 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 .c5 {
-  display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c6 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -24,7 +19,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c13 {
+.c12 {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -35,7 +30,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c15 {
+.c14 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -44,7 +39,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c16 {
+.c15 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -54,7 +49,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c19 {
+.c18 {
   width: 100%;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -62,7 +57,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c22 {
+.c21 {
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
@@ -71,7 +66,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c23 {
+.c22 {
   position: relative;
   width: 100%;
   min-width: 100%;
@@ -81,7 +76,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c27 {
+.c26 {
   width: 1.5rem;
   height: 1.5rem;
   padding: 0rem;
@@ -112,14 +107,14 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -138,7 +133,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   gap: 0.75rem;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -153,7 +148,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -171,7 +166,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   flex-grow: 1;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -179,7 +174,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   gap: 0.75rem;
 }
 
-.c18 {
+.c17 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -190,7 +185,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c25 {
+.c24 {
   color: #287c34;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -202,7 +197,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c26 {
+.c25 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 700;
@@ -214,7 +209,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c28 {
+.c27 {
   color: #dd0035;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
@@ -226,7 +221,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c29 {
+.c28 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 300;
@@ -238,7 +233,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   letter-spacing: -0.005rem;
 }
 
-.c10 {
+.c9 {
   background: none;
   color: inherit;
   border: none;
@@ -252,69 +247,69 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   color: #222222;
 }
 
-.c10:disabled {
+.c9:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c17 {
+.c16 {
   object-fit: contain;
 }
 
-.c24 {
+.c23 {
   -webkit-filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   filter: invert(98%) sepia(98%) saturate(0%) hue-rotate(328deg) brightness(102%) contrast(102%);
   object-fit: contain;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   position: relative;
 }
 
-.c11:hover {
+.c10:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
 }
 
-.c11:active {
+.c10:active {
   color: #222222;
 }
 
-.c11:disabled {
+.c10:disabled {
   color: #808080;
 }
 
-.c8 > :first-child:focus-visible .shadow {
+.c7 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c8 > :first-child:hover .shadow {
+.c7 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c8 > :first-child:active .shadow {
+.c7 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c8 > :first-child:disabled .icon-container {
+.c7 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c8 > :first-child:hover .icon-container {
+.c7 > :first-child:hover .icon-container {
   background: #ffe555;
 }
 
-.c8 > :first-child:active .icon-container {
+.c7 > :first-child:active .icon-container {
   background: #ffe555;
 }
 
-.c9:hover .shadow {
+.c8:hover .shadow {
   box-shadow: none !important;
 }
 
-.c9:active .shadow {
+.c8:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%) !important;
 }
 
@@ -323,7 +318,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c19 {
+  .c18 {
     width: auto;
   }
 }
@@ -337,7 +332,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c20 {
+  .c19 {
     -webkit-box-pack: end;
     -webkit-justify-content: flex-end;
     -ms-flex-pack: end;
@@ -353,38 +348,32 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       class="c3 c4"
     >
       <div
-        class="c5"
-        id="quiz-hint"
-      >
-        The answer is right in front of your eyes
-      </div>
-      <div
         style="display: contents;"
       >
         <div
-          class="c6 c7 c8 c9"
+          class="c5 c6 c7 c8"
         >
           <button
-            aria-describedby="quiz-hint"
-            class="c10 c11"
+            aria-expanded="false"
+            class="c9 c10"
             data-rac="true"
           >
             <div
-              class="c3 c12"
+              class="c3 c11"
             >
               <div
-                class="c13 c14 icon-container"
+                class="c12 c13 icon-container"
               >
                 <div
-                  class="c15 shadow"
+                  class="c14 shadow"
                 />
                 <span
-                  class="c16"
+                  class="c15"
                   data-icon-for="button"
                 >
                   <img
                     alt=""
-                    class="c17"
+                    class="c16"
                     data-nimg="fill"
                     decoding="async"
                     loading="lazy"
@@ -394,7 +383,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
                 </span>
               </div>
               <span
-                class="c18"
+                class="c17"
               >
                 Need a hint?
               </span>
@@ -404,7 +393,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="c19 c20"
+      class="c18 c19"
     />
   </div>
   <div
@@ -418,18 +407,18 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
         class="c3"
       >
         <div
-          class="c3 c21"
+          class="c3 c20"
           role="alert"
         >
           <div
-            class="c22"
+            class="c21"
           >
             <span
-              class="c23"
+              class="c22"
             >
               <img
                 alt=""
-                class="c24"
+                class="c23"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -439,14 +428,14 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
             </span>
           </div>
           <span
-            class="c25"
+            class="c24"
             role="alert"
           >
             Correct
           </span>
         </div>
         <p
-          class="c26"
+          class="c25"
           role="alert"
         >
           Well done!
@@ -454,7 +443,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="c19 c20"
+      class="c18 c19"
     />
   </div>
   <div
@@ -468,18 +457,18 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
         class="c3"
       >
         <div
-          class="c3 c21"
+          class="c3 c20"
           role="alert"
         >
           <div
-            class="c27"
+            class="c26"
           >
             <span
-              class="c23"
+              class="c22"
             >
               <img
                 alt=""
-                class="c24"
+                class="c23"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -489,14 +478,14 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
             </span>
           </div>
           <span
-            class="c28"
+            class="c27"
             role="alert"
           >
             Incorrect
           </span>
         </div>
         <p
-          class="c29"
+          class="c28"
           role="alert"
         >
           Keep trying
@@ -504,7 +493,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="c19 c20"
+      class="c18 c19"
     />
   </div>
   <div
@@ -518,18 +507,18 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
         class="c3"
       >
         <div
-          class="c3 c21"
+          class="c3 c20"
           role="alert"
         >
           <div
-            class="c22"
+            class="c21"
           >
             <span
-              class="c23"
+              class="c22"
             >
               <img
                 alt=""
-                class="c24"
+                class="c23"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -539,14 +528,14 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
             </span>
           </div>
           <span
-            class="c25"
+            class="c24"
             role="alert"
           >
             Correct
           </span>
         </div>
         <p
-          class="c26"
+          class="c25"
           role="alert"
         >
           Nearly there
@@ -554,7 +543,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="c19 c20"
+      class="c18 c19"
     />
   </div>
 </div>

--- a/src/components/owa/pupil/quiz/OakQuizHint/OakQuizHint.test.tsx
+++ b/src/components/owa/pupil/quiz/OakQuizHint/OakQuizHint.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { OakQuizHint } from "./OakQuizHint";
 
@@ -38,5 +39,40 @@ describe(OakQuizHint, () => {
 
     expect(hintToggled).toHaveBeenCalledTimes(1);
     expect(hintToggled).toHaveBeenCalledWith({ isOpen: true });
+  });
+
+  it("does not associate tooltip content with the trigger before it is opened", () => {
+    const { getByRole } = renderWithTheme(
+      <OakQuizHint
+        hint="The answer is right in front of your eyes"
+        id="quiz-hint"
+      />,
+    );
+
+    const button = getByRole("button", { name: "Need a hint?" });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(button).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("announces tooltip content when opened", async () => {
+    const { getByRole, getByTestId } = renderWithTheme(
+      <OakQuizHint
+        hint="The answer is right in front of your eyes"
+        id="quiz-hint"
+      />,
+    );
+    const user = userEvent.setup();
+
+    await user.click(getByRole("button", { name: "Need a hint?" }));
+
+    const button = getByRole("button", { name: "Close hint" });
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(button).toHaveAttribute("aria-describedby", "quiz-hint");
+
+    const announcement = getByTestId("quiz-hint-announcement");
+    expect(announcement).toHaveAttribute("aria-live", "polite");
+    expect(announcement).toHaveTextContent(
+      "The answer is right in front of your eyes",
+    );
   });
 });

--- a/src/components/owa/pupil/quiz/OakQuizHint/OakQuizHint.test.tsx
+++ b/src/components/owa/pupil/quiz/OakQuizHint/OakQuizHint.test.tsx
@@ -54,7 +54,7 @@ describe(OakQuizHint, () => {
     expect(button).not.toHaveAttribute("aria-describedby");
   });
 
-  it("announces tooltip content when opened", async () => {
+  it("associates tooltip content with the trigger when opened", async () => {
     const { getByRole, getByTestId } = renderWithTheme(
       <OakQuizHint
         hint="The answer is right in front of your eyes"
@@ -69,9 +69,8 @@ describe(OakQuizHint, () => {
     expect(button).toHaveAttribute("aria-expanded", "true");
     expect(button).toHaveAttribute("aria-describedby", "quiz-hint");
 
-    const announcement = getByTestId("quiz-hint-announcement");
-    expect(announcement).toHaveAttribute("aria-live", "polite");
-    expect(announcement).toHaveTextContent(
+    const description = getByTestId("quiz-hint-description");
+    expect(description).toHaveTextContent(
       "The answer is right in front of your eyes",
     );
   });

--- a/src/components/owa/pupil/quiz/OakQuizHint/OakQuizHint.tsx
+++ b/src/components/owa/pupil/quiz/OakQuizHint/OakQuizHint.tsx
@@ -39,10 +39,8 @@ export const OakQuizHint = ({ hint, id, hintToggled }: OakQuizHintProps) => {
       {isOpen && (
         <div
           id={id}
-          aria-live="polite"
-          aria-relevant="all"
           style={{ position: "absolute", left: "-9999px" }}
-          data-testid={`${id}-announcement`}
+          data-testid={`${id}-description`}
         >
           {hint}
         </div>

--- a/src/components/owa/pupil/quiz/OakQuizHint/OakQuizHint.tsx
+++ b/src/components/owa/pupil/quiz/OakQuizHint/OakQuizHint.tsx
@@ -1,6 +1,7 @@
 import React, { MouseEventHandler, ReactNode, useState } from "react";
 
 import { OakTooltip } from "@/components/messaging-and-feedback/OakTooltip";
+import { OakScreenReader } from "@/components/messaging-and-feedback/OakScreenReader";
 import { OakHintButton } from "@/components/owa/pupil/quiz/OakHintButton";
 
 export type OakQuizHintProps = {
@@ -37,13 +38,9 @@ export const OakQuizHint = ({ hint, id, hintToggled }: OakQuizHintProps) => {
         />
       </OakTooltip>
       {isOpen && (
-        <div
-          id={id}
-          style={{ position: "absolute", left: "-9999px" }}
-          data-testid={`${id}-description`}
-        >
+        <OakScreenReader as="div" id={id} data-testid={`${id}-description`}>
           {hint}
-        </div>
+        </OakScreenReader>
       )}
     </>
   );

--- a/src/components/owa/pupil/quiz/OakQuizHint/OakQuizHint.tsx
+++ b/src/components/owa/pupil/quiz/OakQuizHint/OakQuizHint.tsx
@@ -2,7 +2,6 @@ import React, { MouseEventHandler, ReactNode, useState } from "react";
 
 import { OakTooltip } from "@/components/messaging-and-feedback/OakTooltip";
 import { OakHintButton } from "@/components/owa/pupil/quiz/OakHintButton";
-import { OakBox } from "@/components/layout-and-structure/OakBox";
 
 export type OakQuizHintProps = {
   /**
@@ -27,16 +26,27 @@ export const OakQuizHint = ({ hint, id, hintToggled }: OakQuizHintProps) => {
 
   return (
     <>
-      <OakBox $display="none" id={id}>
-        {hint}
-      </OakBox>
       <OakTooltip tooltip={hint} isOpen={isOpen} tooltipPosition="top-left">
         <OakHintButton
           isOpen={isOpen}
           onClick={handleClick}
-          buttonProps={{ "aria-describedby": id }}
+          buttonProps={{
+            "aria-expanded": isOpen,
+            "aria-describedby": isOpen ? id : undefined,
+          }}
         />
       </OakTooltip>
+      {isOpen && (
+        <div
+          id={id}
+          aria-live="polite"
+          aria-relevant="all"
+          style={{ position: "absolute", left: "-9999px" }}
+          data-testid={`${id}-announcement`}
+        >
+          {hint}
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/owa/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizHint/__snapshots__/OakQuizHint.test.tsx.snap
@@ -2,11 +2,6 @@
 
 exports[`OakQuizHint matches snapshot 1`] = `
 .c0 {
-  display: none;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c1 {
   position: relative;
   width: -webkit-max-content;
   width: -moz-max-content;
@@ -14,11 +9,11 @@ exports[`OakQuizHint matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c7 {
+.c6 {
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c9 {
+.c8 {
   position: relative;
   width: 2.5rem;
   min-width: 2.5rem;
@@ -29,7 +24,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c11 {
+.c10 {
   position: absolute;
   top: 0rem;
   width: 100%;
@@ -38,7 +33,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c12 {
+.c11 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -48,14 +43,14 @@ exports[`OakQuizHint matches snapshot 1`] = `
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
-.c2 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -74,7 +69,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   gap: 0.75rem;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -89,7 +84,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   justify-content: center;
 }
 
-.c14 {
+.c13 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 600;
   font-size: 1rem;
@@ -100,7 +95,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c5 {
+.c4 {
   background: none;
   color: inherit;
   border: none;
@@ -114,100 +109,94 @@ exports[`OakQuizHint matches snapshot 1`] = `
   color: #222222;
 }
 
-.c5:disabled {
+.c4:disabled {
   pointer-events: none;
   cursor: default;
 }
 
-.c13 {
+.c12 {
   object-fit: contain;
 }
 
-.c6 {
+.c5 {
   display: inline-block;
   position: relative;
 }
 
-.c6:hover {
+.c5:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #222222;
 }
 
-.c6:active {
+.c5:active {
   color: #222222;
 }
 
-.c6:disabled {
+.c5:disabled {
   color: #808080;
 }
 
-.c3 > :first-child:focus-visible .shadow {
+.c2 > :first-child:focus-visible .shadow {
   box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%), 0 0 0 0.3rem rgba(87,87,87,100%);
 }
 
-.c3 > :first-child:hover .shadow {
+.c2 > :first-child:hover .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%);
 }
 
-.c3 > :first-child:active .shadow {
+.c2 > :first-child:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%);
 }
 
-.c3 > :first-child:disabled .icon-container {
+.c2 > :first-child:disabled .icon-container {
   background: #808080;
 }
 
-.c3 > :first-child:hover .icon-container {
+.c2 > :first-child:hover .icon-container {
   background: #ffe555;
 }
 
-.c3 > :first-child:active .icon-container {
+.c2 > :first-child:active .icon-container {
   background: #ffe555;
 }
 
-.c4:hover .shadow {
+.c3:hover .shadow {
   box-shadow: none !important;
 }
 
-.c4:active .shadow {
+.c3:active .shadow {
   box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%), 0.25rem 0.25rem 0 rgba(87,87,87,100%) !important;
 }
 
 <div>
   <div
-    class="c0"
-    id="quiz-hint"
-  >
-    The answer is right in front of your eyes
-  </div>
-  <div
     style="display: contents;"
   >
     <div
-      class="c1 c2 c3 c4"
+      class="c0 c1 c2 c3"
     >
       <button
-        aria-describedby="quiz-hint"
-        class="c5 c6"
+        aria-expanded="false"
+        class="c4 c5"
         data-rac="true"
       >
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10 icon-container"
+            class="c8 c9 icon-container"
           >
             <div
-              class="c11 shadow"
+              class="c10 shadow"
             />
             <span
-              class="c12"
+              class="c11"
               data-icon-for="button"
             >
               <img
                 alt=""
-                class="c13"
+                class="c12"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -217,7 +206,7 @@ exports[`OakQuizHint matches snapshot 1`] = `
             </span>
           </div>
           <span
-            class="c14"
+            class="c13"
           >
             Need a hint?
           </span>


### PR DESCRIPTION
## Link to the design doc

N/A — accessibility behaviour fix (no visual design change).

Notion: [PUPIL-1759 — Announce tooltip information once tooltip is open](https://www.notion.so/oaknationalacademy/Announce-tooltip-information-once-tooltip-is-open-37526cc4e1b180819667f767045a40ee)

Audit finding: [Tooltip information is announced before opening](https://www.notion.so/oaknationalacademy/Tooltip-information-is-announced-before-opening-33626cc4e1b18118a9d7f76ffb243877)

## A link to the component in the deployment preview

Storybook (Preview Env):
- [OakInfo](https://oak-components-storybook-git-fix-pupil-1759-announce-too-1cb0f2.vercel.thenational.academy/?path=/story/owa-oakinfo--default)
- [OakQuizHint](https://oak-components-storybook-git-fix-pupil-1759-announce-too-1cb0f2.vercel.thenational.academy/?path=/story/owa-pupil-quiz-oakquizhint--default)
- [OakLessonBottomNav with hint](https://oak-components-storybook-git-fix-pupil-1759-announce-too-1cb0f2.vercel.thenational.academy/?path=/story/owa-pupil-lesson-oaklessonbottomnav--with-hint-and-button)

## Why no `aria-live`?

Initial implementation included an off-screen `aria-live="polite"` region (mirroring `OakCopyLinkButton`). Internal a11y QA testing showed the live-region announcement chime never fired — consistent with known behaviour when a live region is mounted **already populated** rather than existing empty and then updating ([Sara Soueidan](https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-2/#make-sure-the-live-region-exists-in-the-dom-as-early-as-possible), [TetraLogical](https://tetralogical.com/blog/2024/05/01/why-are-my-live-regions-not-working/)).

VoiceOver **does** announce hint content on open via disclosure semantics on the focused trigger:

- `aria-expanded` toggles to `true`
- conditional `aria-describedby` points at the off-screen description node (only when open)
- `OakInfo` also updates `aria-label` (`open` → `close info tooltip`)

That matches the interaction model: focus stays on the button, so a live region is unnecessary. The fix for the audit finding is **not** exposing description until open — not a background status update.

The off-screen description `div` remains as the `aria-describedby` target (visible tooltip is portaled separately). A follow-up could point `aria-describedby` at the portaled tooltip to remove duplicate DOM.

## Testing instructions

**Automated**
- [x] `pnpm test:ci` for `OakInfo`, `OakQuizHint`, `OakCodeRenderer`, `OakLessonBottomNav`

**Storybook (screen reader)**
1. Open `OakInfo` and `OakQuizHint` stories above
2. Tab to the trigger — confirm hint text is **not** announced while closed
3. Activate the button — confirm hint is announced via `aria-expanded` / `aria-describedby` (and label change on `OakInfo`); no live-region chime expected
4. Tab away and back while open — confirm hint is available again via `aria-describedby`

**OWA integration** (after release / yalc)
- Pupil listing pages using `OakInfo` (e.g. programme units)
- Starter/exit quiz journeys using `OakQuizHint` via `OakLessonBottomNav`

## Screenshots (Tested with VoiceOver (Mac) and NVDA (Windows)
<img width="1255" height="484" alt="Screenshot 2026-06-22 at 12 32 58" src="https://github.com/user-attachments/assets/645b4a45-4c6d-48df-99c3-2315dbc40bbd" />
<img width="1255" height="484" alt="Screenshot 2026-06-22 at 12 33 03" src="https://github.com/user-attachments/assets/0fbbdb6c-d373-47ff-b4fc-57eb76a880fe" />
<img width="1189" height="472" alt="Screenshot 2026-06-22 at 12 33 58" src="https://github.com/user-attachments/assets/a8868801-8b9b-40ef-8f7d-1215a3d91202" />
<img width="1189" height="472" alt="Screenshot 2026-06-22 at 12 34 05" src="https://github.com/user-attachments/assets/e1f5e17d-f7a2-4e59-88f8-3e67f9be10f7" />


## ACs

- [x] Tooltip content is not exposed to assistive technologies until the user activates the trigger
- [x] On activation, `aria-expanded="true"` is set on the trigger
- [x] On activation, hint content is announced to screen reader users (via disclosure semantics, not `aria-live`)
- [x] While open, users can recover hint text on refocus via conditional `aria-describedby`
- [x] Dismiss by activating the trigger again (unchanged interaction)
- [x] `OakInfo` Storybook story includes required `id` prop
- [x] Manual Screen Reader testing: VoiceOver (internal QA) and NVDA confirm the hint is not announced on focus when closed, and is announced on activation when open.

**Components changed:** `OakInfo`, `OakQuizHint` (`oak-components` only — OWA consumes via version bump after release)

## Reviewer checklist notes

- Snapshots updated for `OakInfo`, `OakQuizHint`, `OakLessonBottomNav`, and `OakCodeRenderer` (embedded `OakInfo` consumer) — expected collateral from markup change
- No new exports, tokens, or internal component leaks
- `aria-live` removed after manual a11y QA; Copilot duplicate-DOM feedback partially addressed (live region attrs gone; description target retained)


Made with [Cursor](https://cursor.com)