### PR TITLE
`<OakQuote/>` improvements

### DIFF
--- a/src/components/presentational/OakQuote/OakQuote.stories.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.stories.tsx
@@ -4,6 +4,7 @@ import { StoryObj, Meta } from "@storybook/nextjs";
 import { OakQuote } from "./OakQuote";
 
 import { OakMaxWidth } from "@/components/layout-and-structure/OakMaxWidth";
+import { colorArgTypes } from "@/storybook-helpers/colorStyleHelpers";
 
 const meta: Meta<typeof OakQuote> = {
   component: OakQuote,
@@ -11,7 +12,7 @@ const meta: Meta<typeof OakQuote> = {
   title: "components/Presentational/OakQuote",
   argTypes: {
     quote: { type: "string" },
-    color: { type: "string" },
+    color: { options: colorArgTypes.$color.options },
     authorName: { type: "string" },
     authorTitle: { type: "string" },
     authorImageSrc: { type: "string" },

--- a/src/components/presentational/OakQuote/OakQuote.stories.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.stories.tsx
@@ -34,6 +34,7 @@ const meta: Meta<typeof OakQuote> = {
     quote:
       "Using AI to support my planning and teaching wasn’t something I’d really considered until I came across Aila. To say I was blown away would be an understatement!",
     color: "bg-decorative1-main",
+    hasLeftBorder: true,
   },
 };
 

--- a/src/components/presentational/OakQuote/OakQuote.stories.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.stories.tsx
@@ -78,6 +78,37 @@ export const MintPageBackground: Story = {
   },
 };
 
+export const MultilineQuote: Story = {
+  render: (args) => (
+    <OakMaxWidth>
+      <OakQuote {...args} />
+    </OakMaxWidth>
+  ),
+  args: {
+    quote: [
+      "Using AI to support my planning and teaching wasn’t something I’d really considered until I came across Aila.",
+      "To say I was blown away would be an understatement!",
+    ],
+  },
+};
+
+export const MultilineQuoteWithAuthor: Story = {
+  render: (args) => (
+    <OakMaxWidth>
+      <OakQuote {...args} />
+    </OakMaxWidth>
+  ),
+  args: {
+    quote: [
+      "Using AI to support my planning and teaching wasn’t something I’d really considered until I came across Aila.",
+      "To say I was blown away would be an understatement!",
+    ],
+    authorName: "Suzanne",
+    authorTitle: "Headteacher at Maple Grove Primary School",
+    authorImageSrc: `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1698336490/test-images/test_quote_author.jpg`,
+  },
+};
+
 export const HiddenLeftBorder: Story = {
   render: (args) => (
     <OakMaxWidth>

--- a/src/components/presentational/OakQuote/OakQuote.stories.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof OakQuote> = {
     authorName: { type: "string" },
     authorTitle: { type: "string" },
     authorImageSrc: { type: "string" },
-    showLeftBorder: { type: "boolean" },
+    hasLeftBorder: { type: "boolean" },
   },
   parameters: {
     controls: {
@@ -25,7 +25,7 @@ const meta: Meta<typeof OakQuote> = {
         "authorName",
         "authorTitle",
         "authorImageSrc",
-        "showLeftBorder",
+        "hasLeftBorder",
       ],
     },
   },
@@ -83,7 +83,7 @@ export const HiddenLeftBorder: Story = {
     </OakMaxWidth>
   ),
   args: {
-    showLeftBorder: false,
+    hasLeftBorder: false,
     authorName: "Suzanne",
     authorTitle: "Headteacher at Maple Grove Primary School",
     authorImageSrc: `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1698336490/test-images/test_quote_author.jpg`,

--- a/src/components/presentational/OakQuote/OakQuote.stories.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.stories.tsx
@@ -15,6 +15,7 @@ const meta: Meta<typeof OakQuote> = {
     authorName: { type: "string" },
     authorTitle: { type: "string" },
     authorImageSrc: { type: "string" },
+    showLeftBorder: { type: "boolean" },
   },
   parameters: {
     controls: {
@@ -24,6 +25,7 @@ const meta: Meta<typeof OakQuote> = {
         "authorName",
         "authorTitle",
         "authorImageSrc",
+        "showLeftBorder",
       ],
     },
   },
@@ -71,5 +73,19 @@ export const MintPageBackground: Story = {
   ),
   args: {
     color: "bg-decorative1-subdued",
+  },
+};
+
+export const HiddenLeftBorder: Story = {
+  render: (args) => (
+    <OakMaxWidth>
+      <OakQuote {...args} />
+    </OakMaxWidth>
+  ),
+  args: {
+    showLeftBorder: false,
+    authorName: "Suzanne",
+    authorTitle: "Headteacher at Maple Grove Primary School",
+    authorImageSrc: `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}/v1698336490/test-images/test_quote_author.jpg`,
   },
 };

--- a/src/components/presentational/OakQuote/OakQuote.test.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.test.tsx
@@ -19,14 +19,14 @@ describe("OakQuote component", () => {
     expect(container).toMatchSnapshot();
   });
 
-  it("matches snapshot (showLeftBorder=false)", () => {
+  it("matches snapshot (hasLeftBorder=false)", () => {
     const { container } = renderWithTheme(
       <OakQuote
         quote="This is a quote"
         authorName="Author Name"
         authorTitle="Author Title"
         authorImageSrc="https://via.placeholder.com/150"
-        showLeftBorder={false}
+        hasLeftBorder={false}
       />,
     );
 

--- a/src/components/presentational/OakQuote/OakQuote.test.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.test.tsx
@@ -18,4 +18,18 @@ describe("OakQuote component", () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it("matches snapshot (showLeftBorder=false)", () => {
+    const { container } = renderWithTheme(
+      <OakQuote
+        quote="This is a quote"
+        authorName="Author Name"
+        authorTitle="Author Title"
+        authorImageSrc="https://via.placeholder.com/150"
+        showLeftBorder={false}
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/components/presentational/OakQuote/OakQuote.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.tsx
@@ -8,7 +8,7 @@ import { OakImage } from "@/components/images-and-icons/OakImage";
 import { OakUiRoleToken } from "@/styles";
 
 export type OakQuoteProps = {
-  quote: string;
+  quote: string | string[];
   color?: OakUiRoleToken;
   authorName?: string;
   authorTitle?: string;
@@ -25,7 +25,7 @@ const StyledAuthorImage = styled(OakImage)`
   }
 `;
 
-const TightLetterSpacing = styled(OakBox)`
+const TightLetterSpacing = styled(OakFlex)`
   letter-spacing: -0.01em;
   @media (min-width: 750px) {
     letter-spacing: -0.02em;
@@ -40,6 +40,8 @@ export const OakQuote = ({
   authorImageSrc,
   hasLeftBorder = true,
 }: OakQuoteProps) => {
+  const quoteLines = Array.isArray(quote) ? quote : [quote];
+
   return (
     <OakFlex $width={"100%"} $maxWidth={"spacing-640"}>
       {hasLeftBorder && (
@@ -52,7 +54,19 @@ export const OakQuote = ({
       )}
       <OakFlex $flexDirection={"column"} $gap={"spacing-16"}>
         <OakBox $font={["heading-7", "heading-6"]} $color={"text-primary"}>
-          <TightLetterSpacing>"{quote}"</TightLetterSpacing>
+          <TightLetterSpacing $flexDirection={"column"} $gap={"spacing-12"}>
+            {quoteLines.map((quoteLine, quoteLineIndex) => {
+              const isFirst = quoteLineIndex === 0;
+              const isLast = quoteLineIndex === quoteLines.length - 1;
+              return (
+                <OakP key={quoteLine}>
+                  {isFirst && "\u201C"}
+                  {quoteLine}
+                  {isLast && "\u201D"}
+                </OakP>
+              );
+            })}
+          </TightLetterSpacing>
         </OakBox>
 
         {authorName ? (

--- a/src/components/presentational/OakQuote/OakQuote.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.tsx
@@ -32,15 +32,14 @@ const TightLetterSpacing = styled(OakBox)`
   }
 `;
 
-export const OakQuote = (props: OakQuoteProps) => {
-  const {
-    quote,
-    color = "bg-decorative1-main",
-    authorName,
-    authorTitle,
-    authorImageSrc,
-    hasLeftBorder = true,
-  } = props;
+export const OakQuote = ({
+  quote,
+  color = "bg-decorative1-main",
+  authorName,
+  authorTitle,
+  authorImageSrc,
+  hasLeftBorder = true,
+}: OakQuoteProps) => {
 
   return (
     <OakFlex $width={"100%"} $maxWidth={"spacing-640"}>

--- a/src/components/presentational/OakQuote/OakQuote.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.tsx
@@ -13,6 +13,7 @@ export type OakQuoteProps = {
   authorName?: string;
   authorTitle?: string;
   authorImageSrc?: string;
+  showLeftBorder?: boolean;
 };
 
 const StyledAuthorImage = styled(OakImage)`
@@ -38,11 +39,12 @@ export const OakQuote = (props: OakQuoteProps) => {
     authorName,
     authorTitle,
     authorImageSrc,
+    showLeftBorder = true,
   } = props;
 
   return (
     <OakFlex $width={"100%"} $maxWidth={"spacing-640"}>
-      {color !== "transparent" && (
+      {showLeftBorder && (
         <OakFlex
           $width={"spacing-8"}
           $background={color}

--- a/src/components/presentational/OakQuote/OakQuote.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.tsx
@@ -40,7 +40,6 @@ export const OakQuote = ({
   authorImageSrc,
   hasLeftBorder = true,
 }: OakQuoteProps) => {
-
   return (
     <OakFlex $width={"100%"} $maxWidth={"spacing-640"}>
       {hasLeftBorder && (

--- a/src/components/presentational/OakQuote/OakQuote.tsx
+++ b/src/components/presentational/OakQuote/OakQuote.tsx
@@ -13,7 +13,7 @@ export type OakQuoteProps = {
   authorName?: string;
   authorTitle?: string;
   authorImageSrc?: string;
-  showLeftBorder?: boolean;
+  hasLeftBorder?: boolean;
 };
 
 const StyledAuthorImage = styled(OakImage)`
@@ -39,12 +39,12 @@ export const OakQuote = (props: OakQuoteProps) => {
     authorName,
     authorTitle,
     authorImageSrc,
-    showLeftBorder = true,
+    hasLeftBorder = true,
   } = props;
 
   return (
     <OakFlex $width={"100%"} $maxWidth={"spacing-640"}>
-      {showLeftBorder && (
+      {hasLeftBorder && (
         <OakFlex
           $width={"spacing-8"}
           $background={color}

--- a/src/components/presentational/OakQuote/__snapshots__/OakQuote.test.tsx.snap
+++ b/src/components/presentational/OakQuote/__snapshots__/OakQuote.test.tsx.snap
@@ -1,5 +1,220 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`OakQuote component matches snapshot (showLeftBorder=false) 1`] = `
+.c0 {
+  width: 100%;
+  max-width: 40rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c2 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c4 {
+  color: #222222;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c7 {
+  position: relative;
+  width: 100%;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c11 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+  color: #222222;
+}
+
+.c12 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+  color: #222222;
+}
+
+.c9 {
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
+  background-color: #e7f6f5;
+  background-size: 4rem;
+  background-position: center;
+  background-repeat: no-repeat;
+  object-fit: contain;
+}
+
+.c8 {
+  width: 54px;
+  height: 54px;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c8 img {
+  border-radius: 50%;
+}
+
+.c5 {
+  -webkit-letter-spacing: -0.01em;
+  -moz-letter-spacing: -0.01em;
+  -ms-letter-spacing: -0.01em;
+  letter-spacing: -0.01em;
+}
+
+@media (min-width:750px) {
+  .c4 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:750px) {
+  .c4 {
+    font-size: 1.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c4 {
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c4 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c5 {
+    -webkit-letter-spacing: -0.02em;
+    -moz-letter-spacing: -0.02em;
+    -ms-letter-spacing: -0.02em;
+    letter-spacing: -0.02em;
+  }
+}
+
+<div>
+  <div
+    class="c0 c1"
+  >
+    <div
+      class="c2 c3"
+    >
+      <div
+        class="c4"
+      >
+        <div
+          class="c2 c5"
+        >
+          "
+          This is a quote
+          "
+        </div>
+      </div>
+      <div
+        class="c2 c6"
+      >
+        <span
+          class="c7 c8"
+          role="presentation"
+        >
+          <img
+            alt=""
+            class="c9"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            sizes="100vw"
+            src="http://localhost/_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=3840&q=75"
+            srcset="/_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=3840&q=75 3840w"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </span>
+        <div
+          class="c2 c10"
+        >
+          <p
+            class="c11"
+          >
+            Author Name
+          </p>
+          <p
+            class="c12"
+          >
+            Author Title
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`OakQuote component matches snapshot 1`] = `
 .c0 {
   width: 100%;

--- a/src/components/presentational/OakQuote/__snapshots__/OakQuote.test.tsx.snap
+++ b/src/components/presentational/OakQuote/__snapshots__/OakQuote.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`OakQuote component matches snapshot (showLeftBorder=false) 1`] = `
+exports[`OakQuote component matches snapshot (hasLeftBorder=false) 1`] = `
 .c0 {
   width: 100%;
   max-width: 40rem;

--- a/src/components/presentational/OakQuote/__snapshots__/OakQuote.test.tsx.snap
+++ b/src/components/presentational/OakQuote/__snapshots__/OakQuote.test.tsx.snap
@@ -23,283 +23,66 @@ exports[`OakQuote component matches snapshot (hasLeftBorder=false) 1`] = `
   letter-spacing: 0.0115rem;
 }
 
+.c9 {
+  position: relative;
+  width: 100%;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
 .c7 {
-  position: relative;
-  width: 100%;
-  display: block;
   font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 1rem;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c11 {
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
-  color: #222222;
-}
-
-.c12 {
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 300;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  -webkit-letter-spacing: -0.005rem;
-  -moz-letter-spacing: -0.005rem;
-  -ms-letter-spacing: -0.005rem;
-  letter-spacing: -0.005rem;
-  color: #222222;
-}
-
-.c9 {
-  background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
-  background-color: #e7f6f5;
-  background-size: 4rem;
-  background-position: center;
-  background-repeat: no-repeat;
-  object-fit: contain;
-}
-
-.c8 {
-  width: 54px;
-  height: 54px;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.c8 img {
-  border-radius: 50%;
-}
-
-.c5 {
-  -webkit-letter-spacing: -0.01em;
-  -moz-letter-spacing: -0.01em;
-  -ms-letter-spacing: -0.01em;
-  letter-spacing: -0.01em;
-}
-
-@media (min-width:750px) {
-  .c4 {
-    font-weight: 600;
-  }
-}
-
-@media (min-width:750px) {
-  .c4 {
-    font-size: 1.25rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c4 {
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c4 {
-    -webkit-letter-spacing: 0.0115rem;
-    -moz-letter-spacing: 0.0115rem;
-    -ms-letter-spacing: 0.0115rem;
-    letter-spacing: 0.0115rem;
-  }
-}
-
-@media (min-width:750px) {
-  .c5 {
-    -webkit-letter-spacing: -0.02em;
-    -moz-letter-spacing: -0.02em;
-    -ms-letter-spacing: -0.02em;
-    letter-spacing: -0.02em;
-  }
-}
-
-<div>
-  <div
-    class="c0 c1"
-  >
-    <div
-      class="c2 c3"
-    >
-      <div
-        class="c4"
-      >
-        <div
-          class="c2 c5"
-        >
-          "
-          This is a quote
-          "
-        </div>
-      </div>
-      <div
-        class="c2 c6"
-      >
-        <span
-          class="c7 c8"
-          role="presentation"
-        >
-          <img
-            alt=""
-            class="c9"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            sizes="100vw"
-            src="http://localhost/_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=3840&q=75"
-            srcset="/_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=3840&q=75 3840w"
-            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-          />
-        </span>
-        <div
-          class="c2 c10"
-        >
-          <p
-            class="c11"
-          >
-            Author Name
-          </p>
-          <p
-            class="c12"
-          >
-            Author Title
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`OakQuote component matches snapshot 1`] = `
-.c0 {
-  width: 100%;
-  max-width: 40rem;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c2 {
-  width: 0.5rem;
-  margin-right: 1.5rem;
-  background: #bef2bd;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c4 {
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c6 {
-  color: #222222;
-  font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25rem;
-  -webkit-letter-spacing: 0.0115rem;
-  -moz-letter-spacing: 0.0115rem;
-  -ms-letter-spacing: 0.0115rem;
-  letter-spacing: 0.0115rem;
-}
-
-.c9 {
-  position: relative;
-  width: 100%;
-  display: block;
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 1rem;
-}
-
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c13 {
@@ -347,7 +130,258 @@ exports[`OakQuote component matches snapshot 1`] = `
   border-radius: 50%;
 }
 
+.c6 {
+  -webkit-letter-spacing: -0.01em;
+  -moz-letter-spacing: -0.01em;
+  -ms-letter-spacing: -0.01em;
+  letter-spacing: -0.01em;
+}
+
+@media (min-width:750px) {
+  .c4 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:750px) {
+  .c4 {
+    font-size: 1.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c4 {
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c4 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c6 {
+    -webkit-letter-spacing: -0.02em;
+    -moz-letter-spacing: -0.02em;
+    -ms-letter-spacing: -0.02em;
+    letter-spacing: -0.02em;
+  }
+}
+
+<div>
+  <div
+    class="c0 c1"
+  >
+    <div
+      class="c2 c3"
+    >
+      <div
+        class="c4"
+      >
+        <div
+          class="c2 c5 c6"
+        >
+          <p
+            class="c7"
+          >
+            “
+            This is a quote
+            ”
+          </p>
+        </div>
+      </div>
+      <div
+        class="c2 c8"
+      >
+        <span
+          class="c9 c10"
+          role="presentation"
+        >
+          <img
+            alt=""
+            class="c11"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            sizes="100vw"
+            src="http://localhost/_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=3840&q=75"
+            srcset="/_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F150&w=3840&q=75 3840w"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </span>
+        <div
+          class="c2 c12"
+        >
+          <p
+            class="c13"
+          >
+            Author Name
+          </p>
+          <p
+            class="c14"
+          >
+            Author Title
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`OakQuote component matches snapshot 1`] = `
+.c0 {
+  width: 100%;
+  max-width: 40rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c2 {
+  width: 0.5rem;
+  margin-right: 1.5rem;
+  background: #bef2bd;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c4 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c6 {
+  color: #222222;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c11 {
+  position: relative;
+  width: 100%;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c15 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+  color: #222222;
+}
+
+.c16 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 300;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+  color: #222222;
+}
+
+.c13 {
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
+  background-color: #e7f6f5;
+  background-size: 4rem;
+  background-position: center;
+  background-repeat: no-repeat;
+  object-fit: contain;
+}
+
+.c12 {
+  width: 54px;
+  height: 54px;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c12 img {
+  border-radius: 50%;
+}
+
+.c8 {
   -webkit-letter-spacing: -0.01em;
   -moz-letter-spacing: -0.01em;
   -ms-letter-spacing: -0.01em;
@@ -382,7 +416,7 @@ exports[`OakQuote component matches snapshot 1`] = `
 }
 
 @media (min-width:750px) {
-  .c7 {
+  .c8 {
     -webkit-letter-spacing: -0.02em;
     -moz-letter-spacing: -0.02em;
     -ms-letter-spacing: -0.02em;
@@ -404,23 +438,27 @@ exports[`OakQuote component matches snapshot 1`] = `
         class="c6"
       >
         <div
-          class="c4 c7"
+          class="c4 c7 c8"
         >
-          "
-          This is a quote
-          "
+          <p
+            class="c9"
+          >
+            “
+            This is a quote
+            ”
+          </p>
         </div>
       </div>
       <div
-        class="c4 c8"
+        class="c4 c10"
       >
         <span
-          class="c9 c10"
+          class="c11 c12"
           role="presentation"
         >
           <img
             alt=""
-            class="c11"
+            class="c13"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -431,15 +469,15 @@ exports[`OakQuote component matches snapshot 1`] = `
           />
         </span>
         <div
-          class="c4 c12"
+          class="c4 c14"
         >
           <p
-            class="c13"
+            class="c15"
           >
             Author Name
           </p>
           <p
-            class="c14"
+            class="c16"
           >
             Author Title
           </p>


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Updates include

 - Use of typographic quotes rather than `"`
 - Support for multiline quotes 
 - Changes from `color="transparent"` to using `hasLeftBorder` to make left border disappear (more obvious)

## Link to the design doc
https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=13405-1531&t=pV3LavHRoOxbLm6t-4

## A link to the component in the deployment preview
https://oak-components-storybook-git-feat-multiline-quote.vercel.thenational.academy/?path=/docs/components-presentational-oakquote--docs

See multiline examples in particular

## Testing instructions
QA against designs in figma and for any regressions

## ACs
