### PR TITLE
Allow `as="li"` to be passed to `<OakCard/>` and `<OakFocusIndicator/>`

### DIFF
--- a/src/components/messaging-and-feedback/OakFocusIndicator/OakFocusIndicator.stories.tsx
+++ b/src/components/messaging-and-feedback/OakFocusIndicator/OakFocusIndicator.stories.tsx
@@ -15,6 +15,10 @@ const meta: Meta<typeof OakFocusIndicator> = {
   tags: ["autodocs"],
   title: "components/Messaging and feedback/OakFocusIndicator",
   argTypes: {
+    as: {
+      options: ["div", "li"],
+      defaultValue: "div",
+    },
     hoverBackground: { options: [...oakUiRoleTokens, null] },
     dropShadow: { options: [...Object.keys(oakDropShadowTokens), null] },
     hoverDropShadow: { options: [...Object.keys(oakDropShadowTokens), null] },
@@ -24,6 +28,7 @@ const meta: Meta<typeof OakFocusIndicator> = {
   parameters: {
     controls: {
       include: [
+        "as",
         "hoverBackground",
         "dropShadow",
         "hoverDropShadow",

--- a/src/components/messaging-and-feedback/OakFocusIndicator/OakFocusIndicator.test.tsx
+++ b/src/components/messaging-and-feedback/OakFocusIndicator/OakFocusIndicator.test.tsx
@@ -35,7 +35,6 @@ describe("OakFocusIndicator", () => {
       />,
     );
 
-    // expect(container.tagName).toBe("LI");
     expect(container.firstElementChild!.tagName).toBe("LI");
     expect(container).toMatchSnapshot();
   });

--- a/src/components/messaging-and-feedback/OakFocusIndicator/OakFocusIndicator.test.tsx
+++ b/src/components/messaging-and-feedback/OakFocusIndicator/OakFocusIndicator.test.tsx
@@ -12,7 +12,7 @@ describe("OakFocusIndicator", () => {
   });
 
   test("renders correctly with props set", () => {
-    const { baseElement } = renderWithTheme(
+    const { container } = renderWithTheme(
       <OakFocusIndicator
         hoverBackground="bg-btn-secondary"
         dropShadow="drop-shadow-centered-grey"
@@ -21,6 +21,22 @@ describe("OakFocusIndicator", () => {
       />,
     );
 
-    expect(baseElement).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
+  });
+
+  test("renders correctly with props as='li'", () => {
+    const { container } = renderWithTheme(
+      <OakFocusIndicator
+        as="li"
+        hoverBackground="bg-btn-secondary"
+        dropShadow="drop-shadow-centered-grey"
+        hoverDropShadow="drop-shadow-centered-grey"
+        activeDropShadow="drop-shadow-none"
+      />,
+    );
+
+    // expect(container.tagName).toBe("LI");
+    expect(container.firstElementChild!.tagName).toBe("LI");
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/messaging-and-feedback/OakFocusIndicator/OakFocusIndicator.tsx
+++ b/src/components/messaging-and-feedback/OakFocusIndicator/OakFocusIndicator.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { OakBox } from "@/components/layout-and-structure/OakBox";
+import { OakBox, OakBoxProps } from "@/components/layout-and-structure/OakBox";
 import { OakDropShadowToken, OakUiRoleToken, parseColor } from "@/styles";
 import { parseDropShadow } from "@/styles/helpers/parseDropShadow";
 import { responsiveStyle } from "@/styles/utils/responsiveStyle";
@@ -24,7 +24,8 @@ const fallbackActiveShadow = `${parseDropShadow(
   "drop-shadow-lemon",
 )}, ${parseDropShadow("drop-shadow-grey")}`;
 
-export type OakFocusIndicatorProps = {
+export type OakFocusIndicatorProps = OakBoxProps & {
+  as?: "div" | "li";
   hoverBackground?: OakUiRoleToken;
   dropShadow?: OakDropShadowToken;
   hoverDropShadow?: OakDropShadowToken;
@@ -35,6 +36,15 @@ export type OakFocusIndicatorProps = {
  * Wrap focusable components `<a/>`/`<button/>` and this will add focus styles then the inner element is focused
  */
 export const OakFocusIndicator = styled(OakBox)<OakFocusIndicatorProps>`
+  ${(props) => {
+    if (props.as === "li") {
+      return `
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      `;
+    }
+  }}
   box-shadow: ${(props) =>
     props.dropShadow ? parseDropShadow(props.dropShadow) : "none"};
 

--- a/src/components/messaging-and-feedback/OakFocusIndicator/__snapshots__/OakFocusIndicator.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakFocusIndicator/__snapshots__/OakFocusIndicator.test.tsx.snap
@@ -35,6 +35,43 @@ exports[`OakFocusIndicator default render 1`] = `
 </body>
 `;
 
+exports[`OakFocusIndicator renders correctly with props as='li' 1`] = `
+.c0 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c1:has(a:hover,button:hover) {
+  background-color: #ffffff;
+  box-shadow: 0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c1:has( a, button) {
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c1:has( a, button)  a,
+.c1:has( a, button) button {
+  outline: none;
+}
+
+.c1:has(a:active,button:active) {
+  box-shadow: none;
+}
+
+<div>
+  <li
+    class="c0 c1"
+  />
+</div>
+`;
+
 exports[`OakFocusIndicator renders correctly with props set 1`] = `
 .c0 {
   font-family: --var(google-font),Lexend,sans-serif;
@@ -62,11 +99,9 @@ exports[`OakFocusIndicator renders correctly with props set 1`] = `
   box-shadow: none;
 }
 
-<body>
-  <div>
-    <div
-      class="c0 c1"
-    />
-  </div>
-</body>
+<div>
+  <div
+    class="c0 c1"
+  />
+</div>
 `;

--- a/src/components/navigation/OakCard/OakCard.stories.tsx
+++ b/src/components/navigation/OakCard/OakCard.stories.tsx
@@ -25,6 +25,10 @@ const meta: Meta<typeof OakCard> = {
   component: OakCard,
   tags: ["autodocs"],
   argTypes: {
+    as: {
+      options: ["div", "li"],
+      defaultValue: "div",
+    },
     headingLevel: {
       options: ["h1", "h2", "h3", "h4", "h5", "h6"],
     },
@@ -53,6 +57,7 @@ const meta: Meta<typeof OakCard> = {
   parameters: {
     controls: {
       include: [
+        "as",
         "heading",
         "headingLevel",
         "href",

--- a/src/components/navigation/OakCard/OakCard.stories.tsx
+++ b/src/components/navigation/OakCard/OakCard.stories.tsx
@@ -145,27 +145,26 @@ export const RowOrientationWithRectangularImage: Story = {
 };
 
 export const OakSubjectLinkCard: Story = {
-  render: ({ href = "https://example.com" }) => (
+  render: (args) => (
     <OakBox>
-      <OakCard
-        heading="Check out our new digital literacy lessons!"
-        headingLevel="h1"
-        href={href}
-        cardWidth="100%"
-        imageSrc={generateOakIconURL("subject-digital-literacy")}
-        imageAlt="Illustration representing digital literacy"
-        subCopy="Lessons offering practical knowledge and skills, developed independently of the national curriculum."
-        subCopyColor="text-subdued"
-        tagBackground="bg-decorative1-main"
-        linkText="Go to new digital literacy lessons"
-        linkIconName="chevron-right"
-        cardOrientation={["column", "row"]}
-        imageBackgroundColor="bg-decorative1-main"
-      />
+      <OakCard {...args} />
     </OakBox>
   ),
   args: {
     href: "https://example.com",
+    heading: "Check out our new digital literacy lessons!",
+    headingLevel: "h1",
+    cardWidth: "100%",
+    imageSrc: generateOakIconURL("subject-digital-literacy"),
+    imageAlt: "Illustration representing digital literacy",
+    subCopy:
+      "Lessons offering practical knowledge and skills, developed independently of the national curriculum.",
+    subCopyColor: "text-subdued",
+    tagBackground: "bg-decorative1-main",
+    linkText: "Go to new digital literacy lessons",
+    linkIconName: "chevron-right",
+    cardOrientation: ["column", "row"],
+    imageBackgroundColor: "bg-decorative1-main",
   },
 };
 

--- a/src/components/navigation/OakCard/OakCard.test.tsx
+++ b/src/components/navigation/OakCard/OakCard.test.tsx
@@ -36,6 +36,13 @@ describe("OakCard", () => {
     expect(container).toMatchSnapshot();
   });
 
+  it("matches snapshot when passed as='li'", () => {
+    const { container } = renderWithTheme(<OakCard {...allProps} as="li" />);
+
+    expect(container.firstElementChild!.tagName).toBe("LI");
+    expect(container).toMatchSnapshot();
+  });
+
   it("renders card with only heading and href when passed only required props", () => {
     renderWithTheme(<OakCard {...requiredProps} />);
 

--- a/src/components/navigation/OakCard/OakCard.tsx
+++ b/src/components/navigation/OakCard/OakCard.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/styles/utils/responsiveStyle";
 
 export type OakCardProps = {
+  as?: "div" | "li";
   /**
    * The heading text of the card.
    */
@@ -191,6 +192,7 @@ const StyledOakFlex = styled(OakFlex)<StyledFlexProps>`
  * The image aspect ratio can be set to either 1:1 or 4:3.
  */
 export const OakCard = ({
+  as = "div",
   heading,
   headingLevel = "h3",
   href,
@@ -210,6 +212,7 @@ export const OakCard = ({
 }: OakCardProps) => {
   return (
     <OakFocusIndicator
+      as={as}
       $background={"bg-primary"}
       hoverBackground={hoverBackground}
       $height={"100%"}

--- a/src/components/navigation/OakCard/__snapshots__/OakCard.test.tsx.snap
+++ b/src/components/navigation/OakCard/__snapshots__/OakCard.test.tsx.snap
@@ -311,3 +311,318 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
   </div>
 </div>
 `;
+
+exports[`OakCard matches snapshot when passed as='li' 1`] = `
+.c0 {
+  width: 22.5rem;
+  height: 100%;
+  background: #ffffff;
+  border-radius: 0.5rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c2 {
+  height: 100%;
+  padding: 1rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c5 {
+  position: relative;
+  width: 100%;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c9 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c15 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  background: #ffe555;
+  border-radius: 0.375rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c20 {
+  position: relative;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  display: block;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 1rem;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  box-shadow: none;
+}
+
+.c1:has(a:hover,button:hover) {
+  background-color: #f2f2f2;
+  box-shadow: none;
+}
+
+.c1:has( a, button) {
+  border-radius: 0.5rem;
+  box-shadow: 0 0 0 0.125rem rgba(255,229,85,100%),0 0 0 0.3rem rgba(87,87,87,100%);
+}
+
+.c1:has( a, button)  a,
+.c1:has( a, button) button {
+  outline: none;
+}
+
+.c1:has(a:active,button:active) {
+  box-shadow: 0.125rem 0.125rem 0 rgba(255,229,85,100%),0.25rem 0.25rem 0 rgba(87,87,87,100%);
+}
+
+.c12 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c21 {
+  object-fit: contain;
+}
+
+.c8 {
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHBhdGggZmlsbD0iIzIyMiIgZD0iTTI4Ljc3OSAxOS4xNzZhMjcuMTkxIDI3LjE5MSAwIDAgMC0zLjggMS42IDE2LjcgMTYuNyAwIDAgMC03LjEgOC40YzAgLjEtLjEuMi0uMS4zLS43IDIuNC0uNiAyIDEuMyAyLjMgMS45LjMgMSAuNSAxIDEuMy0uMSA4LjggNC4xIDE1LjEgMTEuNCAxOS42YTEuNSAxLjUgMCAwIDAgMS43LjJjNS43LTIuNiA5LjMtNyAxMC4zLTEzLjJhMSAxIDAgMCAxIDEtMWwzLS4yYy44IDAgMS4zLjIgMS4yIDEuMmExNy45IDE3LjkgMCAwIDEtMy4yIDkuMiAyMy43IDIzLjcgMCAwIDEtMTAuOSA5LjEgNS40MDEgNS40MDEgMCAwIDEtNC41LS4yIDI2LjI5OCAyNi4yOTggMCAwIDEtOC41LTYuNiAyNS45IDI1LjkgMCAwIDEtNi40LTE0LjRjMC0uNi0uMi0uNy0uOC0uOC0yLjUtLjQtMi41LS4xLTIuMy0yLjlhMTkuMyAxOS4zIDAgMCAxIDEwLjgtMTYuNiAzOC45OTkgMzguOTk5IDAgMCAxIDUuNy0yLjEgMi4xIDIuMSAwIDAgMCAuOS0xLjMgMTQuMSAxNC4xIDAgMCAxIDMuNS02LjNsLjMtLjNjMS45LTIgMi42LTIgNC4zLjJsLjQuNWMxLjEgMS4xIDEgMS41LS4xIDIuNmExMS45IDExLjkgMCAwIDAtMy4yIDQuNCAxNi45IDE2LjkgMCAwIDEgNy41IDIuM2M1LjcgMy41IDkuMiA4LjMgOS45IDE1IC4wMTYuOTAxLS4wMTcgMS44MDItLjEgMi43IDAgLjgtLjYgMS0xLjIgMS4yYTE2LjEgMTYuMSAwIDAgMS0xMS0uNyAxNy45MDEgMTcuOTAxIDAgMCAxLTEwLjktMTMuNiA5Ljc5NiA5Ljc5NiAwIDAgMS0uMS0xLjlabTE4LjEgMTIuMmMuNC01LjUtNi45LTEyLjYtMTMtMTIuMS41IDYuNSA3LjYgMTIuOCAxMyAxMi4xWiIgb3BhY2l0eT0iLjEiLz48L3N2Zz4=);
+  background-color: #e7f6f5;
+  background-size: 4rem;
+  background-position: center;
+  background-repeat: no-repeat;
+  object-fit: contain;
+}
+
+.c13 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  color: #222222;
+}
+
+.c19 {
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: 0.0115rem;
+  -moz-letter-spacing: 0.0115rem;
+  -ms-letter-spacing: 0.0115rem;
+  letter-spacing: 0.0115rem;
+}
+
+.c17 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c7 {
+  width: auto;
+  aspect-ratio: 4/3;
+  background: #f2f2f2;
+  border-radius: 0.5rem;
+}
+
+.c7 img {
+  border-radius: inherit;
+  object-fit: cover;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c4 .c6 {
+  height: 15rem;
+}
+
+.c4:hover h1,
+.c4:hover h2,
+.c4:hover h3,
+.c4:hover h4,
+.c4:hover h5,
+.c4:hover h6,
+.c4:hover span {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c4:hover span {
+  -webkit-text-decoration-thickness: 18%;
+  text-decoration-thickness: 18%;
+}
+
+<div>
+  <li
+    class="c0 c1"
+  >
+    <a
+      class="c2 c3 c4"
+      href="https://www.example.com"
+    >
+      <span
+        class="c5 c6 c7"
+      >
+        <img
+          alt="Test image"
+          class="c8"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          sizes="100vw"
+          src="http://localhost/_next/image?url=https%3A%2F%2Fwww.example.com%2Fimage.jpg&w=3840&q=75"
+          srcset="/_next/image?url=https%3A%2F%2Fwww.example.com%2Fimage.jpg&w=640&q=75 640w, /_next/image?url=https%3A%2F%2Fwww.example.com%2Fimage.jpg&w=750&q=75 750w, /_next/image?url=https%3A%2F%2Fwww.example.com%2Fimage.jpg&w=828&q=75 828w, /_next/image?url=https%3A%2F%2Fwww.example.com%2Fimage.jpg&w=1080&q=75 1080w, /_next/image?url=https%3A%2F%2Fwww.example.com%2Fimage.jpg&w=1200&q=75 1200w, /_next/image?url=https%3A%2F%2Fwww.example.com%2Fimage.jpg&w=1920&q=75 1920w, /_next/image?url=https%3A%2F%2Fwww.example.com%2Fimage.jpg&w=2048&q=75 2048w, /_next/image?url=https%3A%2F%2Fwww.example.com%2Fimage.jpg&w=3840&q=75 3840w"
+          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+        />
+      </span>
+      <div
+        class="c9 c10"
+      >
+        <div
+          class="c9 c11"
+        >
+          <h3
+            class="c12"
+          >
+            Test Heading
+          </h3>
+          <p
+            class="c13"
+          >
+            Some Test Subcopy
+          </p>
+        </div>
+        <div
+          class="c9 c14"
+        >
+          <div
+            class="c15 c16"
+          >
+            <label
+              class="c17"
+            >
+              Test Tag
+            </label>
+          </div>
+          <div
+            class="c9 c18"
+          >
+            <span
+              class="c19"
+            >
+              Test Link Text
+            </span>
+            <span
+              class="c20"
+            >
+              <img
+                alt=""
+                class="c21"
+                data-nimg="fill"
+                decoding="async"
+                loading="lazy"
+                src="https://res.cloudinary.com/mock-cloudinary-cloud/image/upload/v1707752509/icons/vk9xxxhnsltsickom6q9.svg"
+                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+              />
+            </span>
+          </div>
+        </div>
+      </div>
+    </a>
+  </li>
+</div>
+`;


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Allow `as="li"` to be passed to `<OakCard/>` and `<OakFocusIndicator/>` components

## Link to the design doc
None

## A link to the component in the deployment preview

 - [OakFocusIndicator](https://oak-components-storybook-git-feat-adopt-2131-allow-as-li-492f88.vercel.thenational.academy/?path=/docs/components-messaging-and-feedback-oakfocusindicator--docs)
 - [OakCard](https://oak-components-storybook-git-feat-adopt-2131-allow-as-li-492f88.vercel.thenational.academy/?path=/docs/components-navigation-oakcard--docs)

## Testing instructions
Check that components are still styled correctly with `as="li"`


## ACs
Regression test