### PR TITLE
Fix invalid weights for `body-*-bold` font tokens

### DIFF
--- a/src/components/buttons/OakLeftAlignedButton/__snapshots__/OalLeftAlignedButton.test.tsx.snap
+++ b/src/components/buttons/OakLeftAlignedButton/__snapshots__/OalLeftAlignedButton.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`OakLeftAlignedButton matches snapshot 1`] = `
 
 .c9 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/buttons/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
+++ b/src/components/buttons/OakSmallPrimaryButton/__snapshots__/OakSmallPrimaryButton.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`OakSmallPrimaryButton matches snapshot 1`] = `
 
 .c9 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/buttons/OakSmallPrimaryInvertedButton/__snapshots__/OakSmallPrimaryInvertedButton.test.tsx.snap
+++ b/src/components/buttons/OakSmallPrimaryInvertedButton/__snapshots__/OakSmallPrimaryInvertedButton.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`OakSmallPrimaryInvertedButton matches snapshot 1`] = `
 
 .c9 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/buttons/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
+++ b/src/components/buttons/OakSmallSecondaryButton/__snapshots__/OakSmallSecondaryButton.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`OakSmallSecondaryButton matches snapshot 1`] = `
 
 .c9 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/buttons/OakSmallSecondaryButtonWithDropdown/__snapshots__/OakSmallSecondaryButtonWithDropdown.test.tsx.snap
+++ b/src/components/buttons/OakSmallSecondaryButtonWithDropdown/__snapshots__/OakSmallSecondaryButtonWithDropdown.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`OakSmallSecondaryButtonWithDropdown matches snapshot 1`] = `
 
 .c11 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/buttons/OakSmallSecondaryToggleButton/__snapshots__/OakSmallSecondaryToggleButton.test.tsx.snap
+++ b/src/components/buttons/OakSmallSecondaryToggleButton/__snapshots__/OakSmallSecondaryToggleButton.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`OakSmallSecondaryToggleButton component matches snapshot 1`] = `
 
 .c7 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/cookies/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
+++ b/src/components/cookies/OakCookieBanner/__snapshots__/OakCookieBanner.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 
 .c5 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;
@@ -492,7 +492,7 @@ exports[`OakCookieBanner matches snapshot 1`] = `
 
 @media (min-width:750px) {
   .c5 {
-    font-weight: 700;
+    font-weight: 500;
   }
 }
 

--- a/src/components/cookies/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
+++ b/src/components/cookies/OakCookieConsent/__snapshots__/OakCookieConsent.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 
 .c5 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;
@@ -492,7 +492,7 @@ exports[`OakCookieConsent matches snapshot 1`] = `
 
 @media (min-width:750px) {
   .c5 {
-    font-weight: 700;
+    font-weight: 500;
   }
 }
 

--- a/src/components/form-elements/OakRadioButton/OakRadioButton.test.tsx
+++ b/src/components/form-elements/OakRadioButton/OakRadioButton.test.tsx
@@ -84,7 +84,7 @@ describe("RadioGroup", () => {
     const radio1 = getAllByTestId("radio-1");
     const firstRadio = radio1[0] as HTMLElement;
 
-    expect(firstRadio).toHaveStyle("font-weight: 700");
+    expect(firstRadio).toHaveStyle("font-weight: 500");
     expect(firstRadio).toHaveStyle("font-size: 1.125rem");
     expect(firstRadio).toHaveStyle("line-height: 1.75rem");
     expect(firstRadio).toHaveStyle("letter-spacing: -0.005rem");

--- a/src/components/form-elements/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
+++ b/src/components/form-elements/OakRadioButton/__snapshots__/OakRadioButton.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`RadioGroup matches snapshot 1`] = `
 
 .c3 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1.125rem;
   line-height: 1.75rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/form-elements/OakRadioGroup/OakRadioGroup.test.tsx
+++ b/src/components/form-elements/OakRadioGroup/OakRadioGroup.test.tsx
@@ -252,7 +252,7 @@ describe("RadioGroup", () => {
     const radioGroupLabel = getByText("Select one of the following:");
 
     expect(radioGroupLabel).toHaveStyle("font-size: 1.125rem");
-    expect(radioGroupLabel).toHaveStyle("font-weight: 700");
+    expect(radioGroupLabel).toHaveStyle("font-weight: 500");
     expect(radioGroupLabel).toHaveStyle("line-height: 1.75rem");
     expect(radioGroupLabel).toHaveStyle("letter-spacing: -0.005rem");
 

--- a/src/components/form-elements/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
+++ b/src/components/form-elements/OakRadioGroup/__snapshots__/OakRadioGroup.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`RadioGroup matches snapshot 1`] = `
 
 .c3 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1.125rem;
   line-height: 1.75rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/form-elements/OakSelect/__snapshots__/OakSelect.test.tsx.snap
+++ b/src/components/form-elements/OakSelect/__snapshots__/OakSelect.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`OakSelect disabled select 1`] = `
   color: #222222;
   outline: none;
   font: 1rem;
-  font-weight: 700;
+  font-weight: 500;
   border-radius: 0.125rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -395,7 +395,7 @@ exports[`OakSelect highlighted select 1`] = `
   color: #222222;
   outline: none;
   font: 1rem;
-  font-weight: 700;
+  font-weight: 500;
   border-radius: 0.125rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -637,7 +637,7 @@ exports[`OakSelect invalid select 1`] = `
   color: #222222;
   outline: none;
   font: 1rem;
-  font-weight: 700;
+  font-weight: 500;
   border-radius: 0.125rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -879,7 +879,7 @@ exports[`OakSelect optgroup select 1`] = `
   color: #222222;
   outline: none;
   font: 1rem;
-  font-weight: 700;
+  font-weight: 500;
   border-radius: 0.125rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -1170,7 +1170,7 @@ exports[`OakSelect plain select 1`] = `
   color: #222222;
   outline: none;
   font: 1rem;
-  font-weight: 700;
+  font-weight: 500;
   border-radius: 0.125rem;
   padding-left: 1rem;
   padding-right: 1rem;

--- a/src/components/house-cat/OakCaptionSearch/__snapshots__/OakCaptionSearch.test.tsx.snap
+++ b/src/components/house-cat/OakCaptionSearch/__snapshots__/OakCaptionSearch.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`OakCaptionSearch should match snapshot 1`] = `
 
 .c6 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.5rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/messaging-and-feedback/OakKbd/__snapshots__/OakKbd.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakKbd/__snapshots__/OakKbd.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`OakKbd matches snapshot 1`] = `
   border-color: #7c9aec;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/OakCopyLinkButton/__snapshots__/OakCopyLinkButton.test.tsx.snap
+++ b/src/components/owa/OakCopyLinkButton/__snapshots__/OakCopyLinkButton.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`OakCopyLinkButton matches snapshot 1`] = `
 
 .c8 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/OakDownloadCard/__snapshots__/OakDownloadCard.test.tsx.snap
+++ b/src/components/owa/OakDownloadCard/__snapshots__/OakDownloadCard.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`OakDownloadCard matches snapshot with fileSizeSlot 1`] = `
 
 .c12 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.5rem;
   -webkit-letter-spacing: -0.005rem;
@@ -385,7 +385,7 @@ exports[`OakDownloadCard matches snapshot without fileSizeSlot 1`] = `
 
 .c12 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.5rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
+++ b/src/components/owa/OakDownloadsJourneyChildSubjectTierSelector/__snapshots__/OakDownloadsJourneyChildSubjectTierSelector.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`OakDownloadsJourneyChildSubjectTierSelector matches snapshot 1`] = `
 
 .c14 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1.125rem;
   line-height: 1.75rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
+++ b/src/components/owa/OakDragAndDropInstructions/__snapshots__/OakDragAndDropInstructions.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`OakDragAndDropInstructions matches snapshot 1`] = `
   border-color: #7c9aec;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
+++ b/src/components/owa/OakDraggable/__snapshots__/OakDraggable.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`OakDraggable matches snapshot 1`] = `
 
 .c7 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1.125rem;
   line-height: 1.75rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
+++ b/src/components/owa/OakDraggableFeedback/__snapshots__/OakDraggableFeedback.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`OakDraggableFeedback matches snapshot 1`] = `
 
 .c7 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1.125rem;
   line-height: 1.75rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/OakFormInputWithLabels/__snapshots__/OakFormInputWithLabels.test.tsx.snap
+++ b/src/components/owa/OakFormInputWithLabels/__snapshots__/OakFormInputWithLabels.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`OakFormInputWithLabels should match snapshot 1`] = `
 
 .c4 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.5rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/OakHomepageTabButton/__snapshots__/OakHomepageTabButton.test.tsx.snap
+++ b/src/components/owa/OakHomepageTabButton/__snapshots__/OakHomepageTabButton.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`OakHomepageTabButton component matches snapshot 1`] = `
 .c8 {
   color: #575757;
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
+++ b/src/components/owa/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`OakPromoTag matches snapshot 1`] = `
   color: #ffe555;
   background: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;
@@ -67,7 +67,7 @@ exports[`OakPromoTag matches snapshot 1`] = `
 
 @media (min-width:750px) {
   .c5 {
-    font-weight: 700;
+    font-weight: 500;
   }
 }
 

--- a/src/components/owa/OakSignLanguageButton/__snapshots__/OakSignLanguageButton.test.tsx.snap
+++ b/src/components/owa/OakSignLanguageButton/__snapshots__/OakSignLanguageButton.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`OakSignLanguageButton matches snapshot 1`] = `
 
 .c8 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
+++ b/src/components/owa/OakVideoTranscript/__snapshots__/OakVideoTranscript.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`OakVideoTranscript matches snapshot 1`] = `
 
 .c9 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
 .c25 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.5rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizFeedback/__snapshots__/OakQuizFeedback.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`OakQuizFeedback matches snapshot 1`] = `
 .c6 {
   margin-top: 0.75rem;
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.5rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizMatch/__snapshots__/OakQuizMatch.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
 
 .c17 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1.125rem;
   line-height: 1.75rem;
   -webkit-letter-spacing: -0.005rem;
@@ -231,7 +231,7 @@ exports[`OakQuizMatch matches snapshot 1`] = `
   border-color: #7c9aec;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
+++ b/src/components/owa/pupil/quiz/OakQuizOrder/__snapshots__/OakQuizOrder.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
 
 .c20 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1.125rem;
   line-height: 1.75rem;
   -webkit-letter-spacing: -0.005rem;
@@ -158,7 +158,7 @@ exports[`OakQuizOrder matches snapshot 1`] = `
   border-color: #7c9aec;
   border-radius: 0.375rem;
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/teacher/OakDownloadsAccordion/__snapshots__/OakDownloadsAccordion.test.tsx.snap
+++ b/src/components/owa/teacher/OakDownloadsAccordion/__snapshots__/OakDownloadsAccordion.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`OakDownloadsAccordion matches snapshot when closed 1`] = `
 
 .c44 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.5rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/owa/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
+++ b/src/components/owa/teacher/OakTeacherNotesModal/__snapshots__/OakTeacherNotesModal.test.tsx.snap
@@ -428,7 +428,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 
 .c42 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;
@@ -579,7 +579,7 @@ exports[`OakTeacherNotesModal matches snapshot 1`] = `
 
 .c26 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 0.875rem;
   line-height: 1.25rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/components/presentational/OakQuote/__snapshots__/OakQuote.test.tsx.snap
+++ b/src/components/presentational/OakQuote/__snapshots__/OakQuote.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`OakQuote component matches snapshot (hasLeftBorder=false) 1`] = `
 
 .c13 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.5rem;
   -webkit-letter-spacing: -0.005rem;
@@ -338,7 +338,7 @@ exports[`OakQuote component matches snapshot 1`] = `
 
 .c15 {
   font-family: --var(google-font),Lexend,sans-serif;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.5rem;
   -webkit-letter-spacing: -0.005rem;

--- a/src/styles/theme/typography.ts
+++ b/src/styles/theme/typography.ts
@@ -12,7 +12,7 @@ export const oakFontSizeTokens = {
 };
 export type OakFontSizeToken = keyof typeof oakFontSizeTokens;
 
-const fontWeights = [300, 400, 600, 700] as const;
+const fontWeights = [300, 400, 500, 600, 700] as const;
 type FontWeight = (typeof fontWeights)[number];
 const lineHeights = [16, 20, 24, 28, 32, 40, 48, 56, 64] as const;
 type LineHeight = (typeof lineHeights)[number];
@@ -45,9 +45,9 @@ export const oakFontTokens = {
   "body-2": ["font-size-3", 24, 300, "-0.005rem"],
   "body-3": ["font-size-2", 20, 300, "-0.005rem"],
   "body-4": ["font-size-1", 16, 300, "-0.005rem"],
-  "body-1-bold": ["font-size-4", 28, 700, "-0.005rem"],
-  "body-2-bold": ["font-size-3", 24, 700, "-0.005rem"],
-  "body-3-bold": ["font-size-2", 20, 700, "-0.005rem"],
+  "body-1-bold": ["font-size-4", 28, 500, "-0.005rem"],
+  "body-2-bold": ["font-size-3", 24, 500, "-0.005rem"],
+  "body-3-bold": ["font-size-2", 20, 500, "-0.005rem"],
   "list-item-1": ["font-size-4", 32, 300, "-0.005rem"],
   "list-item-2": ["font-size-3", 24, 300, "-0.005rem"],
   "code-1": ["font-size-6", 32, 300, "0.0115rem"],


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Fix invalid weights for `body-*-bold` font tokens updating `body-*-bold` weight from `700` to `500`

## Link to the design doc
None

## A link to the component in the deployment preview
https://oak-components-storybook-git-fix-font-sizes-incorrect.vercel.thenational.academy/

## Testing instructions
Check font-weights are now correct 

