### PR TITLE
Remove `<label/>` from `<OakTagFunctional/>` and use `<div/>` instead

### DIFF
--- a/src/components/messaging-and-feedback/OakTagFunctional/OakTagFunctional.tsx
+++ b/src/components/messaging-and-feedback/OakTagFunctional/OakTagFunctional.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
+import { OakBox } from "@/components/layout-and-structure/OakBox";
 import {
   OakFlex,
   OakFlexProps,
 } from "@/components/layout-and-structure/OakFlex";
 import { OakIcon, OakIconName } from "@/components/images-and-icons/OakIcon";
-import { OakLabel } from "@/components/form-elements/OakLabel";
 
 export type OakTagFunctionalProps = {
   label: string;
@@ -35,7 +35,7 @@ export const OakTagFunctional = (props: OakTagFunctionalProps) => {
       {...oakFlexProps}
     >
       {leadingIcon}
-      <OakLabel as={useSpan ? "span" : undefined}>{label}</OakLabel>
+      <OakBox as={useSpan ? "span" : undefined}>{label}</OakBox>
       {trailingIcon}
     </OakFlex>
   );

--- a/src/components/messaging-and-feedback/OakTagFunctional/__snapshots__/OakTagFunctional.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakTagFunctional/__snapshots__/OakTagFunctional.test.tsx.snap
@@ -17,6 +17,10 @@ exports[`OakTagFunctional matches snapshot 1`] = `
   letter-spacing: 0.0115rem;
 }
 
+.c2 {
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -25,19 +29,15 @@ exports[`OakTagFunctional matches snapshot 1`] = `
   gap: 0.5rem;
 }
 
-.c2 {
-  font-family: --var(google-font),Lexend,sans-serif;
-}
-
 <div>
   <div
     class="c0 c1"
   >
-    <label
+    <div
       class="c2"
     >
       Select one answer
-    </label>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/navigation/OakCard/__snapshots__/OakCard.test.tsx.snap
+++ b/src/components/navigation/OakCard/__snapshots__/OakCard.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c20 {
+.c19 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -110,7 +110,7 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
   gap: 0.5rem;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -155,7 +155,7 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c21 {
+.c20 {
   object-fit: contain;
 }
 
@@ -173,7 +173,7 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
   color: #222222;
 }
 
-.c19 {
+.c18 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -182,10 +182,6 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;
   letter-spacing: 0.0115rem;
-}
-
-.c17 {
-  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -277,26 +273,26 @@ exports[`OakCard matches snapshot when passed all props 1`] = `
           <div
             class="c15 c16"
           >
-            <label
-              class="c17"
+            <div
+              class="c9"
             >
               Test Tag
-            </label>
+            </div>
           </div>
           <div
-            class="c9 c18"
+            class="c9 c17"
           >
             <span
-              class="c19"
+              class="c18"
             >
               Test Link Text
             </span>
             <span
-              class="c20"
+              class="c19"
             >
               <img
                 alt=""
-                class="c21"
+                class="c20"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"
@@ -355,7 +351,7 @@ exports[`OakCard matches snapshot when passed as='li' 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c20 {
+.c19 {
   position: relative;
   width: 1.5rem;
   min-width: 1.5rem;
@@ -422,7 +418,7 @@ exports[`OakCard matches snapshot when passed as='li' 1`] = `
   gap: 0.5rem;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -470,7 +466,7 @@ exports[`OakCard matches snapshot when passed as='li' 1`] = `
   letter-spacing: 0.0115rem;
 }
 
-.c21 {
+.c20 {
   object-fit: contain;
 }
 
@@ -488,7 +484,7 @@ exports[`OakCard matches snapshot when passed as='li' 1`] = `
   color: #222222;
 }
 
-.c19 {
+.c18 {
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -497,10 +493,6 @@ exports[`OakCard matches snapshot when passed as='li' 1`] = `
   -moz-letter-spacing: 0.0115rem;
   -ms-letter-spacing: 0.0115rem;
   letter-spacing: 0.0115rem;
-}
-
-.c17 {
-  font-family: --var(google-font),Lexend,sans-serif;
 }
 
 .c7 {
@@ -592,26 +584,26 @@ exports[`OakCard matches snapshot when passed as='li' 1`] = `
           <div
             class="c15 c16"
           >
-            <label
-              class="c17"
+            <div
+              class="c9"
             >
               Test Tag
-            </label>
+            </div>
           </div>
           <div
-            class="c9 c18"
+            class="c9 c17"
           >
             <span
-              class="c19"
+              class="c18"
             >
               Test Link Text
             </span>
             <span
-              class="c20"
+              class="c19"
             >
               <img
                 alt=""
-                class="c21"
+                class="c20"
                 data-nimg="fill"
                 decoding="async"
                 loading="lazy"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
`<OakTagFunctional/>` incorrectly uses `<label/>` tag within. This replaces that with `<div/>` keeping the original `asSpan` behaviour.

Note: Later on we should also replace `asSpan: boolean` with `as: "div" | "span"` but that will cause a breaking change in a bunch of places, so will do that in another PR.

## Link to the design doc
None

## A link to the component in the deployment preview
https://oak-components-storybook-git-fix-oc-31-invalid-label.vercel.thenational.academy/?path=/docs/components-messaging-and-feedback-oaktagfunctional--docs

## Testing instructions
Regression test `<OakTagFunctional/>`

