### PR TITLE
Added CSS reset for h6

### DIFF
--- a/src/styles/global/reset.styles.ts
+++ b/src/styles/global/reset.styles.ts
@@ -20,6 +20,7 @@ export const resetGlobalCss = css`
   h3,
   h4,
   h5,
+  h6,
   p,
   figure,
   blockquote,


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Fixes a bug where the styles of `h6` were never reset this caused issues like this where changing the `tag` on a component to `h6` would use the user-agent styles (see https://components.thenational.academy/?path=/docs/components-typography-oakheading--docs)


<img width="1022" height="1021" alt="Screenshot 2026-07-30 at 13 50 31" src="https://github.com/user-attachments/assets/4a75ca91-4156-40c6-9057-25ef45ed12cb" />

I'm 98% sure that this won't cause any issue in any of the code, with one exception of Alia (see https://github.com/oaknational/oak-ai-lesson-assistant/blob/d1c15ea0064e763f928f0b4cd6f038bbb16adb46/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx#L215-L217).

I've essentially had a good search through github with https://github.com/search?q=org%3Aoaknational+%22h6%22&type=code   

## Link to the design doc
None

## A link to the component in the deployment preview
https://oak-components-storybook-git-fix-oc-33-h6-reset.vercel.thenational.academy/?path=/docs/components-typography-oakheading--docs

## Testing instructions
Setting `tag` on https://oak-components-storybook-git-fix-oc-33-h6-reset.vercel.thenational.academy/?path=/docs/components-typography-oakheading--docs to `h6` should no longer change the style.

