### PR TITLE
Match `OakInformativeModal` to designs: title, action buttons, padding

### DIFF
--- a/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.stories.tsx
+++ b/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from "@storybook/nextjs";
 import { useArgs } from "storybook/preview-api";
 import React, { Fragment } from "react";
+import { fn } from "storybook/test";
 
 import { OakInformativeModal } from "./OakInformativeModal";
 import { OakInformativeModalFooter } from "./OakInformativeModalFooter";
@@ -39,6 +40,8 @@ const meta: Meta<typeof OakInformativeModal> = {
         "footerSlot",
         "isOpen",
         "onClose",
+        "actionLabel",
+        "onActionClick",
         "isLeftHandSide",
         "closeOnBackgroundClick",
       ],
@@ -146,5 +149,12 @@ export const LeftHandSide: Story = {
 export const CloseOnBackgroundClick: Story = {
   args: {
     closeOnBackgroundClick: true,
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    actionLabel: "Action",
+    onActionClick: fn(),
   },
 };

--- a/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.stories.tsx
+++ b/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.stories.tsx
@@ -42,6 +42,8 @@ const meta: Meta<typeof OakInformativeModal> = {
         "onClose",
         "actionLabel",
         "onActionClick",
+        "title",
+        "titleTag",
         "isLeftHandSide",
         "closeOnBackgroundClick",
       ],
@@ -154,6 +156,20 @@ export const CloseOnBackgroundClick: Story = {
 
 export const WithAction: Story = {
   args: {
+    actionLabel: "Action",
+    onActionClick: fn(),
+  },
+};
+
+export const WithTitle: Story = {
+  args: {
+    title: "Modal title",
+  },
+};
+
+export const WithTitleAndAction: Story = {
+  args: {
+    title: "Modal title",
     actionLabel: "Action",
     onActionClick: fn(),
   },

--- a/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.test.tsx
+++ b/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.test.tsx
@@ -68,4 +68,25 @@ describe(OakInformativeModal, () => {
 
     expect(getByRole("textbox")).toHaveFocus();
   });
+
+  it("calls onActionClick when the action button is clicked", () => {
+    const onActionClickSpy = jest.fn();
+
+    const { getByText } = renderWithTheme(
+      <OakInformativeModal
+        isOpen
+        onClose={jest.fn()}
+        actionLabel="Action"
+        onActionClick={onActionClickSpy}
+      >
+        Modal content
+      </OakInformativeModal>,
+    );
+
+    act(() => {
+      fireEvent.click(getByText("Action"));
+    });
+
+    expect(onActionClickSpy).toHaveBeenCalled();
+  });
 });

--- a/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.test.tsx
+++ b/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.test.tsx
@@ -75,7 +75,7 @@ describe(OakInformativeModal, () => {
     const { getByText } = renderWithTheme(
       <OakInformativeModal
         isOpen
-        onClose={jest.fn()}
+        onClose={() => {}}
         actionLabel="Action"
         onActionClick={onActionClickSpy}
       >
@@ -88,5 +88,15 @@ describe(OakInformativeModal, () => {
     });
 
     expect(onActionClickSpy).toHaveBeenCalled();
+  });
+
+  it("renders title when provided", () => {
+    const { getByText } = renderWithTheme(
+      <OakInformativeModal title="Example modal" isOpen onClose={() => {}}>
+        Modal content
+      </OakInformativeModal>,
+    );
+
+    expect(getByText("Example modal")).toBeVisible();
   });
 });

--- a/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.test.tsx
+++ b/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.test.tsx
@@ -99,4 +99,14 @@ describe(OakInformativeModal, () => {
 
     expect(getByText("Example modal")).toBeVisible();
   });
+
+  it("uses the title as the dialog's accessible label", () => {
+    const { getByRole } = renderWithTheme(
+      <OakInformativeModal title="Example modal" isOpen onClose={() => {}}>
+        Modal content
+      </OakInformativeModal>,
+    );
+
+    expect(getByRole("dialog")).toHaveAccessibleName("Example modal");
+  });
 });

--- a/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.tsx
+++ b/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.tsx
@@ -7,6 +7,7 @@ import { useIsScrolled } from "@/hooks/useIsScrolled";
 import { useMounted } from "@/hooks/useMounted";
 import InternalModalTransition from "@/components/internal-components/InternalModalTransition/InternalModalTransition";
 import { BorderStyleProps } from "@/styles/utils/borderStyle";
+import { OakLink } from "@/components/navigation/OakLink";
 
 export const OakInformativeModalBorderColor = createContext<
   BorderStyleProps["$borderColor"]
@@ -33,6 +34,14 @@ export type OakInformativeModalProps = {
    * Called when the modal is closed
    */
   onClose: (action?: OakInformativeModalCloseAction) => void;
+  /**
+   * Optional text to show as an action button
+   */
+  actionLabel?: string;
+  /**
+   * Called when the action button is clicked
+   */
+  onActionClick?: () => void;
   /**
    * The DOM container to render the modal portal into.
    *
@@ -76,6 +85,8 @@ export const OakInformativeModal = ({
   domContainer,
   isOpen,
   onClose,
+  actionLabel,
+  onActionClick,
   zIndex,
   isLeftHandSide,
   closeOnBackgroundClick,
@@ -122,9 +133,18 @@ export const OakInformativeModal = ({
         >
           <OakFlex
             $pa="spacing-16"
-            $justifyContent={"flex-end"}
+            $justifyContent={actionLabel ? "space-between" : "flex-end"}
             $alignItems="center"
           >
+            {actionLabel && (
+              <OakLink
+                variant="secondary"
+                element="button"
+                onClick={onActionClick}
+              >
+                {actionLabel}
+              </OakLink>
+            )}
             <OakCloseButton onClose={onCloseButton} />
           </OakFlex>
           <div style={{ display: "contents" }} data-autofocus-inside>

--- a/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.tsx
+++ b/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.tsx
@@ -153,7 +153,8 @@ export const OakInformativeModal = ({
           $height={"100%"}
         >
           <OakFlex
-            $pa="spacing-16"
+            $pt="spacing-16"
+            $ph="spacing-24"
             $justifyContent={actionLabel ? "space-between" : "flex-end"}
             $alignItems="center"
           >

--- a/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.tsx
+++ b/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.tsx
@@ -8,6 +8,7 @@ import { useMounted } from "@/hooks/useMounted";
 import InternalModalTransition from "@/components/internal-components/InternalModalTransition/InternalModalTransition";
 import { BorderStyleProps } from "@/styles/utils/borderStyle";
 import { OakLink } from "@/components/navigation/OakLink";
+import { OakHeading, OakHeadingTag } from "@/components/typography/OakHeading";
 
 export const OakInformativeModalBorderColor = createContext<
   BorderStyleProps["$borderColor"]
@@ -42,6 +43,15 @@ export type OakInformativeModalProps = {
    * Called when the action button is clicked
    */
   onActionClick?: () => void;
+  /**
+   * Optional title for the header of the modal
+   */
+  title?: string;
+  /**
+   * Heading level for the title
+   * @default "h1"
+   */
+  titleTag?: OakHeadingTag;
   /**
    * The DOM container to render the modal portal into.
    *
@@ -87,6 +97,8 @@ export const OakInformativeModal = ({
   onClose,
   actionLabel,
   onActionClick,
+  title,
+  titleTag = "h1",
   zIndex,
   isLeftHandSide,
   closeOnBackgroundClick,
@@ -144,6 +156,11 @@ export const OakInformativeModal = ({
               >
                 {actionLabel}
               </OakLink>
+            )}
+            {title && (
+              <OakHeading tag={titleTag} $font="heading-6" $mh="auto">
+                {title}
+              </OakHeading>
             )}
             <OakCloseButton onClose={onCloseButton} />
           </OakFlex>

--- a/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.tsx
+++ b/src/components/messaging-and-feedback/OakInformativeModal/OakInformativeModal.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, HTMLAttributes, ReactNode, useRef } from "react";
+import React, {
+  createContext,
+  HTMLAttributes,
+  ReactNode,
+  useId,
+  useRef,
+} from "react";
 import { createPortal } from "react-dom";
 
 import { OakCloseButton } from "@/components/buttons/OakCloseButton";
@@ -112,6 +118,8 @@ export const OakInformativeModal = ({
   // `createPortal` is not supported in SSR so we can only render when mounted on the client
   const isMounted = useMounted();
 
+  const titleId = useId();
+
   if (!isMounted) {
     return null;
   }
@@ -136,6 +144,7 @@ export const OakInformativeModal = ({
         isLeftHandSide={isLeftHandSide}
         closeOnBackgroundClick={closeOnBackgroundClick}
         largeScreenMaxWidth={largeScreenMaxWidth}
+        aria-labelledby={title ? titleId : undefined}
         {...rest}
       >
         <OakFlex
@@ -158,7 +167,12 @@ export const OakInformativeModal = ({
               </OakLink>
             )}
             {title && (
-              <OakHeading tag={titleTag} $font="heading-6" $mh="auto">
+              <OakHeading
+                id={titleId}
+                tag={titleTag}
+                $font="heading-6"
+                $mh="auto"
+              >
                 {title}
               </OakHeading>
             )}

--- a/src/components/messaging-and-feedback/OakInformativeModal/__snapshots__/OakInformativeModal.test.tsx.snap
+++ b/src/components/messaging-and-feedback/OakInformativeModal/__snapshots__/OakInformativeModal.test.tsx.snap
@@ -27,7 +27,9 @@ exports[`OakInformativeModal matches snapshot when mounted 1`] = `
 }
 
 .c6 {
-  padding: 1rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-top: 1rem;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below

Update `OakInformativeModal` based on the existing Figma designs.

The designs show a title and an interactive action button in the header. The `OakInformativeModal` implementation didn't allow you to specify either of these. Now it does, through `title`/`titleTag` and `actionLabel`/`onActionClick` props.

<img width="590" height="140" alt="image" src="https://github.com/user-attachments/assets/13dba30f-16fb-45e5-a8d4-90785373b967" />

The title is used as the accessible label for the dialog.

There was also a small discrepancy in the padding between implementation and design, I've tweaked the implementation to match the design. 🚨 This might change snapshots in teams' repos if they use an `OakInformativeModal`.

## Link to the design doc

- Figma: https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=21205-22018&m=dev
- Create Squad ticket: https://app.notion.com/p/oaknationalacademy/Extend-OakInformativeModal-with-title-and-header-action-3a426cc4e1b18040b1befc050532cfd3?source=copy_link

## A link to the component in the deployment preview

https://oak-components-storybook-git-feat-con-2000-informativemo-a0e3a2.vercel.thenational.academy/?path=/docs/components-messaging-and-feedback-oakinformativemodal--doc

## Testing instructions

- Look at the title in the modal
- Click the action button, observe that it's wired up to the "Actions" section in Storybook

## ACs

- [x]  `OakInformativeModal` supports a title
- [x]  `OakInformativeModal` supports an action button in the top-left corner
- [x]  Unit test coverage
- [x]  Accessible: Keyboard Navigation
- [x]  Accessible: Screen Reader