### PR TITLE
feat(CON-1972): disclosure dropdown mode and a11y fixes

### DIFF
--- a/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.stories.tsx
+++ b/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.stories.tsx
@@ -9,7 +9,9 @@ import { OakIcon } from "@/components/images-and-icons/OakIcon";
 import { OakSpan } from "@/components/typography/OakSpan";
 import { OakSmallPrimaryInvertedButton } from "@/components/buttons/OakSmallPrimaryInvertedButton";
 import { OakSecondaryButton } from "@/components/buttons/OakSecondaryButton";
-import { OakCheckBox } from "@/components/form-elements";
+import { OakPrimaryButton } from "@/components/buttons/OakPrimaryButton";
+import { OakCheckBox, OakFieldset } from "@/components/form-elements";
+import { OakHeading } from "@/components/typography/OakHeading";
 
 // Generic Dropdown Navigation Button Stories
 const dropdownNavMeta: Meta<typeof OakButtonWithDropdown> = {
@@ -28,6 +30,7 @@ const dropdownNavMeta: Meta<typeof OakButtonWithDropdown> = {
         "ariaLabel",
         "ariaDescription",
         "closeOnChange",
+        "dropdownType",
       ],
     },
   },
@@ -203,7 +206,7 @@ export const CloseOnChange: OakButtonWithDropdownStory = {
 
 export const CloseHandledByChildren: OakButtonWithDropdownStory = {
   render: (args) => (
-    <OakButtonWithDropdown {...args}>
+    <OakButtonWithDropdown {...args} dropdownType="disclosure">
       <ChildrenUsingContext />
     </OakButtonWithDropdown>
   ),
@@ -212,11 +215,21 @@ export const CloseHandledByChildren: OakButtonWithDropdownStory = {
 const ChildrenUsingContext = () => {
   const { onClose } = useDropdownContext();
   return (
-    <>
-      <OakCheckBox id="1" value="1" displayValue="1" />
-      <OakCheckBox id="2" value="2" displayValue="2" />
-      <OakCheckBox id="3" value="3" displayValue="3" />
-      <OakSecondaryButton onClick={onClose}>Close</OakSecondaryButton>
-    </>
+    <OakFieldset $width="spacing-240">
+      <OakFlex $flexDirection="column" $gap="spacing-12">
+        <OakFlex $flexDirection="column" $gap="spacing-16">
+          <OakHeading as="legend" $font="heading-7" tag="h3">
+            Resources available to add
+          </OakHeading>
+          <OakCheckBox id="1" value="1" displayValue="1" />
+          <OakCheckBox id="2" value="2" displayValue="2" />
+          <OakCheckBox id="3" value="3" displayValue="3" />
+        </OakFlex>
+        <OakButtonWithDropdown.Divider />
+        <OakFlex $justifyContent="flex-end">
+          <OakPrimaryButton onClick={onClose}>Add</OakPrimaryButton>
+        </OakFlex>
+      </OakFlex>
+    </OakFieldset>
   );
 };

--- a/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.test.tsx
+++ b/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -29,12 +29,13 @@ const simpleChildren = (
 const ChildrenUsingContext = () => {
   const { onClose } = useDropdownContext();
   return (
-    <>
+    <fieldset>
+      <legend>Resources available to add</legend>
       <OakCheckBox id="1" value="1" displayValue="1" />
       <OakCheckBox id="2" value="2" displayValue="2" />
       <OakCheckBox id="3" value="3" displayValue="3" />
       <OakSecondaryButton onClick={onClose}>Add</OakSecondaryButton>
-    </>
+    </fieldset>
   );
 };
 
@@ -165,6 +166,7 @@ describe("OakButtonWithDropdown", () => {
     await user.click(outsideButton);
 
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(outsideButton).toHaveFocus();
   });
 
   it("toggles dropdown open/closed state", async () => {
@@ -328,6 +330,25 @@ describe("OakButtonWithDropdown", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
   });
 
+  it("runs menu item onClick before closing when closeOnChange is true", async () => {
+    const user = userEvent.setup();
+    const onEdit = jest.fn();
+
+    renderWithTheme(
+      <OakButtonWithDropdown closeOnChange={true} {...defaultProps}>
+        <button role="menuitem" aria-label="Edit" onClick={onEdit}>
+          Edit
+        </button>
+      </OakButtonWithDropdown>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /actions/i }));
+    await user.click(screen.getByText("Edit"));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
   it("closes dropdown on click when closeOnChange is true", async () => {
     const user = userEvent.setup();
 
@@ -372,29 +393,27 @@ describe("OakButtonWithDropdown", () => {
 
   it.each([
     ["enter", "{Enter}"],
-    ["return", "{Return}"],
     ["space", " "],
   ])(
-    "closes dropdown on %s pressed when closeOnChange is true",
+    "runs menu item onClick before closing on %s when closeOnChange is true",
     async (_, keyPressed) => {
       const user = userEvent.setup();
+      const onEdit = jest.fn();
 
       renderWithTheme(
         <OakButtonWithDropdown closeOnChange={true} {...defaultProps}>
-          {simpleChildren}
+          <button role="menuitem" aria-label="Edit" onClick={onEdit}>
+            Edit
+          </button>
         </OakButtonWithDropdown>,
       );
 
-      const primaryButton = screen.getByRole("button", { name: /actions/i });
-      await user.click(primaryButton);
-
-      expect(screen.getByRole("menu")).toBeInTheDocument();
-
-      // Click menu item
+      await user.click(screen.getByRole("button", { name: /actions/i }));
       await user.tab();
       expect(screen.getByText("Edit")).toHaveFocus();
       await user.keyboard(keyPressed);
 
+      expect(onEdit).toHaveBeenCalledTimes(1);
       expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     },
   );
@@ -432,7 +451,7 @@ describe("OakButtonWithDropdown", () => {
     const user = userEvent.setup();
 
     renderWithTheme(
-      <OakButtonWithDropdown {...defaultProps}>
+      <OakButtonWithDropdown {...defaultProps} dropdownType="disclosure">
         <ChildrenUsingContext />
       </OakButtonWithDropdown>,
     );
@@ -440,13 +459,103 @@ describe("OakButtonWithDropdown", () => {
     const primaryButton = screen.getByRole("button", { name: /actions/i });
     await user.click(primaryButton);
 
-    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByRole("group")).toBeInTheDocument();
 
     await user.click(screen.getByDisplayValue("1"));
     await user.click(screen.getByDisplayValue("2"));
 
     await user.click(screen.getByText("Add"));
 
+    expect(screen.queryByRole("group")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(primaryButton).toHaveFocus();
+    });
+  });
+
+  it("returns focus to the trigger when closed with Escape", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <OakButtonWithDropdown {...defaultProps} dropdownType="disclosure">
+        <ChildrenUsingContext />
+      </OakButtonWithDropdown>,
+    );
+
+    const primaryButton = screen.getByRole("button", { name: /actions/i });
+    await user.click(primaryButton);
+
+    await user.tab();
+    expect(screen.getByDisplayValue("1")).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("group")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(primaryButton).toHaveFocus();
+    });
+  });
+
+  it("uses disclosure semantics when dropdownType is disclosure", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <OakButtonWithDropdown {...defaultProps} dropdownType="disclosure">
+        <ChildrenUsingContext />
+      </OakButtonWithDropdown>,
+    );
+
+    const primaryButton = screen.getByRole("button", { name: /actions/i });
+    expect(primaryButton).not.toHaveAttribute("aria-haspopup");
+    expect(primaryButton).not.toHaveAttribute("aria-controls");
+
+    await user.click(primaryButton);
+
+    const panelId = primaryButton.getAttribute("aria-controls");
+    expect(panelId).toBeTruthy();
+    expect(document.getElementById(panelId!)).toBeInTheDocument();
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(primaryButton);
+
+    expect(primaryButton).not.toHaveAttribute("aria-controls");
+  });
+
+  it("provides a default aria-label for menu mode", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <OakButtonWithDropdown {...defaultProps}>
+        {simpleChildren}
+      </OakButtonWithDropdown>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /actions/i }));
+
+    expect(screen.getByRole("menu")).toHaveAttribute(
+      "aria-label",
+      "Dropdown menu. Use arrow keys to navigate, Tab to cycle through items, Escape to close.",
+    );
+  });
+
+  it("does not close disclosure panel on checkbox interaction when closeOnChange is true", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <OakButtonWithDropdown
+        {...defaultProps}
+        dropdownType="disclosure"
+        closeOnChange
+      >
+        <ChildrenUsingContext />
+      </OakButtonWithDropdown>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /actions/i }));
+    expect(screen.getByRole("group")).toBeInTheDocument();
+
+    await user.click(screen.getByDisplayValue("1"));
+    await user.click(screen.getByDisplayValue("2"));
+
+    expect(screen.getByRole("group")).toBeInTheDocument();
   });
 });

--- a/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.test.tsx
+++ b/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.test.tsx
@@ -414,7 +414,9 @@ describe("OakButtonWithDropdown", () => {
       await user.keyboard(keyPressed);
 
       expect(onEdit).toHaveBeenCalledTimes(1);
-      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      });
     },
   );
 

--- a/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.tsx
+++ b/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.tsx
@@ -57,7 +57,11 @@ export type OakButtonWithDropdownProps = {
   dropdownProps?: {
     /** The ARIA role for the dropdown panel. Defaults to "menu" in menu mode. Omitted in disclosure mode. */
     role?: React.AriaRole;
-    /** The ARIA label for the dropdown panel. Omitted by default; prefer a visible legend in disclosure mode. */
+    /**
+     * Accessible name for the dropdown panel.
+     * Menu mode: optional; falls back to default keyboard-instruction label if omitted.
+     * Disclosure mode: omitted unless provided; prefer a visible legend instead.
+     */
     "aria-label"?: string;
   };
 };

--- a/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.tsx
+++ b/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.tsx
@@ -91,7 +91,7 @@ export const OakButtonWithDropdown = ({
   const generatedPanelId = useId();
   const dropdownPanelId = dataTestId
     ? `${dataTestId}-dropdown`
-    : generatedPanelId.replace(/:/g, "");
+    : generatedPanelId.replaceAll(":", "");
 
   const isMenuDropdown = dropdownType === "menu";
 
@@ -226,6 +226,13 @@ export const OakButtonWithDropdown = ({
       "Dropdown menu. Use arrow keys to navigate, Tab to cycle through items, Escape to close.")
     : dropdownProps?.["aria-label"];
 
+  let triggerAriaProps: Record<string, string> = {};
+  if (isMenuDropdown) {
+    triggerAriaProps = { "aria-haspopup": "menu" };
+  } else if (isOpen) {
+    triggerAriaProps = { "aria-controls": dropdownPanelId };
+  }
+
   return (
     <OakBox
       as="section"
@@ -247,11 +254,7 @@ export const OakButtonWithDropdown = ({
             disabled={disabled}
             width="max-content"
             aria-expanded={isOpen}
-            {...(isMenuDropdown
-              ? { "aria-haspopup": "menu" as const }
-              : isOpen
-                ? { "aria-controls": dropdownPanelId }
-                : {})}
+            {...triggerAriaProps}
             aria-label={primaryActionText}
             data-testid={
               dataTestId ? `${dataTestId}-primary-action` : undefined

--- a/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.tsx
+++ b/src/components/buttons/OakButtonWithDropdown/OakButtonWithDropdown.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useRef, useEffect, ElementType } from "react";
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  useId,
+  ElementType,
+} from "react";
 
 import { OakButtonWithDropdownProvider } from "./OakButtonWithDropdownProvider";
 
@@ -23,6 +30,8 @@ type ButtonComponent = <C extends React.ElementType = "button">({
 }: OakSecondaryButtonProps &
   PolymorphicPropsWithoutRef<C>) => React.JSX.Element;
 
+export type OakButtonWithDropdownType = "menu" | "disclosure";
+
 export type OakButtonWithDropdownProps = {
   primaryActionText: string;
   primaryActionIcon?: OakIconName;
@@ -40,10 +49,15 @@ export type OakButtonWithDropdownProps = {
   >;
   flexWidth?: ResponsiveValues<OakCombinedSpacingToken | null | undefined>;
   closeOnChange?: boolean;
+  /**
+   * `menu` — menuitem children with arrow-key navigation (default, used by OWA).
+   * `disclosure` — expandable panel for checkbox groups and custom content (e.g. Studio multi-select).
+   */
+  dropdownType?: OakButtonWithDropdownType;
   dropdownProps?: {
-    /** The ARIA role for the dropdown panel. Defaults to "menu". */
+    /** The ARIA role for the dropdown panel. Defaults to "menu" in menu mode. Omitted in disclosure mode. */
     role?: React.AriaRole;
-    /** The ARIA label for the dropdown panel. Defaults to undefined (no label). */
+    /** The ARIA label for the dropdown panel. Omitted by default; prefer a visible legend in disclosure mode. */
     "aria-label"?: string;
   };
 };
@@ -67,13 +81,47 @@ export const OakButtonWithDropdown = ({
   dropdownTopSpacing = "spacing-56",
   flexWidth,
   closeOnChange,
-  dropdownProps = {
-    role: "menu",
-  },
+  dropdownType = "menu",
+  dropdownProps,
 }: OakButtonWithDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
-
+  const wasOpenRef = useRef(false);
+  const shouldRestoreFocusRef = useRef(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const generatedPanelId = useId();
+  const dropdownPanelId = dataTestId
+    ? `${dataTestId}-dropdown`
+    : generatedPanelId.replace(/:/g, "");
+
+  const isMenuDropdown = dropdownType === "menu";
+
+  const getTriggerElement = () =>
+    dropdownRef.current?.querySelector<HTMLElement>("button[aria-expanded]");
+
+  const closeDropdown = useCallback(
+    ({ restoreFocus = false }: { restoreFocus?: boolean } = {}) => {
+      shouldRestoreFocusRef.current = restoreFocus;
+      setIsOpen(false);
+    },
+    [],
+  );
+
+  // Return focus to the trigger only when close was initiated from inside the panel.
+  useEffect(() => {
+    if (!isOpen && wasOpenRef.current && shouldRestoreFocusRef.current) {
+      const trigger = getTriggerElement();
+      if (trigger && document.activeElement !== trigger) {
+        // Defer so the closing keypress does not activate the trigger.
+        requestAnimationFrame(() => {
+          trigger.focus();
+        });
+      }
+    }
+    if (!isOpen) {
+      shouldRestoreFocusRef.current = false;
+    }
+    wasOpenRef.current = isOpen;
+  }, [isOpen]);
 
   // Get all focusable elements within the dropdown
   const getFocusableElements = () => {
@@ -85,16 +133,18 @@ export const OakButtonWithDropdown = ({
     ) as HTMLElement[];
   };
 
-  const handleCloseOnChange = () => {
-    if (closeOnChange) {
-      setIsOpen(false);
-    }
-  };
-
-  // Handle clicks  the dropdown to close it
+  // Handle clicks and keyboard events while the dropdown is open
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!isOpen) return;
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeDropdown({ restoreFocus: true });
+        return;
+      }
+
+      if (!isMenuDropdown) return;
 
       const focusableElements = getFocusableElements();
       const currentIndex = focusableElements.indexOf(
@@ -102,12 +152,6 @@ export const OakButtonWithDropdown = ({
       );
 
       switch (event.key) {
-        case "Escape": {
-          event.preventDefault();
-          setIsOpen(false);
-          break;
-        }
-
         case "ArrowDown": {
           event.preventDefault();
           if (focusableElements.length === 0) return;
@@ -125,47 +169,62 @@ export const OakButtonWithDropdown = ({
           break;
         }
 
-        case "Enter": {
-          handleCloseOnChange();
-          break;
-        }
-
-        case "Return": {
-          handleCloseOnChange();
-          break;
-        }
-
+        case "Enter":
+        case "Return":
         case " ": {
-          handleCloseOnChange();
+          if (closeOnChange) {
+            // Defer close so native button activation (click) runs first.
+            setTimeout(() => closeDropdown({ restoreFocus: true }), 0);
+          }
           break;
         }
+      }
+    };
+
+    const handleMouseDown = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        closeDropdown();
       }
     };
 
     const handleClick = (event: MouseEvent) => {
       if (
-        dropdownRef.current &&
-        (!dropdownRef.current.contains(event.target as Node) || !!closeOnChange)
+        closeOnChange &&
+        isMenuDropdown &&
+        dropdownRef.current?.contains(event.target as Node)
       ) {
-        setIsOpen(false);
+        closeDropdown({ restoreFocus: true });
       }
     };
 
     if (isOpen) {
-      document.addEventListener("mousedown", handleClick);
+      document.addEventListener("mousedown", handleMouseDown);
+      document.addEventListener("click", handleClick);
       document.addEventListener("keydown", handleKeyDown);
     }
 
     return () => {
-      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("click", handleClick);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isOpen, dataTestId]);
+  }, [isOpen, isMenuDropdown, closeOnChange, closeDropdown]);
 
   const handlePrimaryAction = () => {
     setIsOpen(!isOpen);
     onPrimaryAction?.();
   };
+
+  const panelRole = isMenuDropdown
+    ? (dropdownProps?.role ?? "menu")
+    : undefined;
+  const panelAriaLabel = isMenuDropdown
+    ? (dropdownProps?.["aria-label"] ??
+      "Dropdown menu. Use arrow keys to navigate, Tab to cycle through items, Escape to close.")
+    : dropdownProps?.["aria-label"];
 
   return (
     <OakBox
@@ -188,7 +247,11 @@ export const OakButtonWithDropdown = ({
             disabled={disabled}
             width="max-content"
             aria-expanded={isOpen}
-            aria-haspopup="menu"
+            {...(isMenuDropdown
+              ? { "aria-haspopup": "menu" as const }
+              : isOpen
+                ? { "aria-controls": dropdownPanelId }
+                : {})}
             aria-label={primaryActionText}
             data-testid={
               dataTestId ? `${dataTestId}-primary-action` : undefined
@@ -203,23 +266,26 @@ export const OakButtonWithDropdown = ({
 
         {isOpen && (
           <OakBox
+            id={dropdownPanelId}
             $background="bg-primary"
             $borderRadius="border-radius-s"
             $ba="border-solid-m"
             $borderColor="border-primary"
-            $pa="spacing-8"
+            $pa={isMenuDropdown ? "spacing-8" : "spacing-12"}
             $position="absolute"
             $top={dropdownTopSpacing}
             $zIndex="modal-close-button"
-            role={dropdownProps?.["role"] ?? "menu"}
-            aria-label={
-              dropdownProps["aria-label"] ??
-              "Dropdown menu. Use arrow keys to navigate, Tab to cycle through items, Escape to close."
-            }
+            role={panelRole}
+            aria-label={panelAriaLabel}
             data-testid={dataTestId ? `${dataTestId}-dropdown` : undefined}
           >
-            <OakFlex $flexDirection="column" $gap={"spacing-8"}>
-              <OakButtonWithDropdownProvider onClose={() => setIsOpen(false)}>
+            <OakFlex
+              $flexDirection="column"
+              $gap={isMenuDropdown ? "spacing-8" : "spacing-12"}
+            >
+              <OakButtonWithDropdownProvider
+                onClose={() => closeDropdown({ restoreFocus: true })}
+              >
                 {children}
               </OakButtonWithDropdownProvider>
             </OakFlex>

--- a/src/components/buttons/OakButtonWithDropdown/index.ts
+++ b/src/components/buttons/OakButtonWithDropdown/index.ts
@@ -1,5 +1,8 @@
 export { OakButtonWithDropdown } from "./OakButtonWithDropdown";
-export type { OakButtonWithDropdownProps } from "./OakButtonWithDropdown";
+export type {
+  OakButtonWithDropdownProps,
+  OakButtonWithDropdownType,
+} from "./OakButtonWithDropdown";
 export {
   DropdownContext,
   OakButtonWithDropdownProvider,


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

<img width="917" height="527" alt="Screenshot 2026-07-30 at 11 42 12" src="https://github.com/user-attachments/assets/95e4d345-dde6-4719-8e60-c8a287ae4f91" />


# Add your PR description below

Stacked on #747 — extends `OakButtonWithDropdown` with disclosure mode and accessibility fixes raised during design/a11y review of the Studio multi-select dropdown pattern.

## Summary

- Adds `dropdownType`: `"menu"` (default, OWA behaviour unchanged) | `"disclosure"` (checkbox groups / custom panel content)
- Disclosure mode: `aria-controls` on trigger (only while open), no `role="menu"` / `aria-haspopup`, `spacing-12` panel padding
- Returns focus to trigger on intentional panel dismiss (`onClose`, Escape, `closeOnChange` menu selection) — not on outside click
- Fixes `closeOnChange` so menu item `onClick` runs before close (mouse + keyboard)
- Restricts `closeOnChange` auto-close to menu mode only
- Restores default `aria-label` for menu mode panels
- Updates `CloseHandledByChildren` story to match Studio multi-select layout (fieldset legend, divider, Add button)

## Link to the design doc

[Oak Design Kit — Studio multi-select dropdown](https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=20551-718&m=dev&focus-id=20620-6014)

## A link to the component in the deployment preview

Vercel preview will be posted on this PR after push. Check:

- `Components/Buttons/OakButtonWithDropdown` → **CloseHandledByChildren** (disclosure / multi-select pattern)
- Existing menu stories (e.g. OWA dropdown wrappers) should be unchanged

## Testing instructions

- [ ] `npm test -- OakButtonWithDropdown` — 30 tests pass
- [ ] **CloseHandledByChildren** story: open with Space/Enter, Tab through checkboxes, click **Add** — panel closes, focus returns to trigger
- [ ] **CloseHandledByChildren**: Escape from inside panel closes and returns focus
- [ ] Click outside panel — closes without stealing focus from the clicked element
- [ ] **CloseOnChange** story: menu items still close panel; item actions fire
- [ ] axe: no `aria-required-children` violation on disclosure story (checkboxes + button, not `role="menu"`)

## ACs

- [ ] `dropdownType="disclosure"` supports Studio `MultiSelectDropdown` without incorrect menu ARIA
- [ ] Focus returns to trigger when panel closed via `onClose`, Escape, or menu `closeOnChange`
- [ ] Focus is not pulled back to trigger when user dismisses by clicking elsewhere
- [ ] Existing OWA menu dropdown usage (`dropdownType` default) unchanged
- [ ] Bugbot review: no findings


Made with [Cursor](https://cursor.com)