### PR TITLE
`<OakVideo/>` component bugs

### DIFF
--- a/src/components/presentational/OakVideo/OakVideo.stories.tsx
+++ b/src/components/presentational/OakVideo/OakVideo.stories.tsx
@@ -36,8 +36,8 @@ const meta: Meta<typeof OakVideo> = {
       options: ["undefined", "short_text", "long_text"],
       mapping: {
         undefined: undefined,
-        short_text: ["Short text", "Short text", "Short text"],
-        long_text: [longText, longText, longText],
+        short_text: new Array(20).fill("Short text"),
+        long_text: new Array(20).fill(longText),
       },
       control: {
         type: "select", // Type 'select' is automatically inferred when 'options' is defined

--- a/src/components/presentational/OakVideo/OakVideo.tsx
+++ b/src/components/presentational/OakVideo/OakVideo.tsx
@@ -81,12 +81,12 @@ export function OakVideo({
         $ba="border-solid-m"
         $borderColor="border-primary"
       >
-        <OakBox $aspectRatio={"30/17"}>{videoSlot}</OakBox>
+        <OakBox $aspectRatio={"16/9"}>{videoSlot}</OakBox>
       </OakFlex>
       <OakFlex
         $flexDirection={"column"}
         $gap={"spacing-8"}
-        $display={!(heading && body) ? "none" : undefined}
+        $display={!heading && !body ? "none" : undefined}
       >
         {heading && (
           <OakHeading
@@ -160,6 +160,7 @@ export function OakVideo({
           $pa={"spacing-16"}
           $borderRadius={"border-radius-s"}
           $gap={"spacing-32"}
+          $flexDirection={"column"}
         >
           <OakFlex
             $gap={"spacing-8"}

--- a/src/components/presentational/OakVideo/__snapshots__/OakVideo.test.tsx.snap
+++ b/src/components/presentational/OakVideo/__snapshots__/OakVideo.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`OakVideo renders correctly with all controls 1`] = `
 }
 
 .c3 {
-  aspect-ratio: 30/17;
+  aspect-ratio: 16/9;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 
@@ -158,6 +158,9 @@ exports[`OakVideo renders correctly with all controls 1`] = `
 
 .c22 {
   display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   gap: 2rem;
 }
 
@@ -706,7 +709,7 @@ exports[`OakVideo renders correctly with just video 1`] = `
 }
 
 .c3 {
-  aspect-ratio: 30/17;
+  aspect-ratio: 16/9;
   font-family: --var(google-font),Lexend,sans-serif;
 }
 


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Fixes

 - video should be 16/9
 - allow `body` without `heading`
 - transcripts should take up full width of container, sometime they weren't with short text


## Link to the design doc

## A link to the component in the deployment preview

## Testing instructions

## ACs
