### PR TITLE
Feat/pupil 1762/browser view reflow

### DIFF
--- a/src/components/owa/pupil/lesson/OakLessonBottomNav/OakLessonBottomNav.tsx
+++ b/src/components/owa/pupil/lesson/OakLessonBottomNav/OakLessonBottomNav.tsx
@@ -16,6 +16,9 @@ import { OakFlex } from "@/components/layout-and-structure/OakFlex";
  */
 const StyledOakFlex = styled(OakFlex)`
   box-sizing: content-box;
+  @media (min-aspect-ratio: 1/1) {
+    flex-direction: row;
+  }
 `;
 
 export type OakLessonBottomNavProps = {

--- a/src/components/owa/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
+++ b/src/components/owa/pupil/lesson/OakLessonBottomNav/__snapshots__/OakLessonBottomNav.test.tsx.snap
@@ -340,6 +340,14 @@ exports[`OakLessonBottomNav matches snapshot 1`] = `
   }
 }
 
+@media (min-aspect-ratio:1/1) {
+  .c2 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
 <div>
   <div
     class="c0 c1 c2"


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
the pr overrides the media query which makes this component flex-direction colomn for small screens which makes the page unreadable for 400% zoom, by overriding this with a media query for small apect ratio it stay direction row for zoom 400%

## Link to the design doc
<img width="367" height="331" alt="Screenshot 2026-07-30 at 12 23 15" src="https://github.com/user-attachments/assets/bfde8f30-60eb-47b1-9ca5-d8772fd87d11" />
<img width="377" height="518" alt="Screenshot 2026-07-30 at 12 23 27" src="https://github.com/user-attachments/assets/48818150-dfb2-4774-b92d-6aeeeb53537d" />

## A link to the component in the deployment preview
https://oak-components-storybook-git-feat-pupil-1762browser-view-reflow.vercel.thenational.academy/iframe.html?globals=&args=&id=owa-pupil-lesson-oaklessonbottomnav--with-hint-and-button&viewMode=story

## Testing instructions
follow link, zoom to 400%, doesnt wrap
https://oak-components-storybook-git-feat-pupil-1762browser-view-reflow.vercel.thenational.academy/iframe.html?globals=&args=&id=owa-pupil-lesson-oaklessonbottomnav--with-hint-and-button&viewMode=story

## ACs
