### PR TITLE
Make `@portabletext/react` a peer dep to avoid build issues in OWA

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "next-cloudinary": ">=6.16.0",
     "react": ">=18.2.0",
     "react-dom": ">=18.2.0",
-    "styled-components": ">=5.3.11"
+    "styled-components": ">=5.3.11",
+    "@portabletext/react": ">=4.0.1"
   },
   "engines": {
     "node": "24",
@@ -58,7 +59,6 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@portabletext/react": "^7.0.1",
     "@tiptap/react": "^2.11.0",
     "react-focus-on": "^3.10.2",
     "react-transition-group": "^4.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@18.2.0)
       '@portabletext/react':
-        specifier: ^7.0.1
+        specifier: '>=4.0.1'
         version: 7.0.1(react@18.2.0)
       '@tiptap/react':
         specifier: ^2.11.0


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Make `@portabletext/react` a peer dep to avoid build issues in OWA

## Link to the design doc
None

## A link to the component in the deployment preview

 - https://oak-components-storybook-git-feat-make-portabletext-peer-dep.vercel.thenational.academy/?path=/docs/components-layout-and-structure-oakportabletext--docs
 - https://oak-components-storybook-git-feat-make-portabletext-peer-dep.vercel.thenational.academy/?path=/docs/components-presentational-oakvideo--docs

## Testing instructions
Code review only

## ACs
