### PR TITLE
Move functions to own file to allow server side import/usage

### DIFF
--- a/src/components/images-and-icons/OakIcon/OakIcon.tsx
+++ b/src/components/images-and-icons/OakIcon/OakIcon.tsx
@@ -1,16 +1,14 @@
 import React from "react";
 
+import { generateOakIconURL, OakIconName } from "./helpers";
+
 import { OakAllSpacingToken } from "@/styles";
-import { IconName, icons } from "@/image-map";
 import {
   OakImage,
   OakImageProps,
 } from "@/components/images-and-icons/OakImage";
 
-export const oakIconNames = Object.keys(icons) as IconName[];
-
-export type OakIconName = IconName;
-
+export * from "./helpers";
 export type OakIconProps = Omit<OakImageProps, "alt" | "src"> & {
   /**
    * The name of the icon to display
@@ -22,27 +20,6 @@ export type OakIconProps = Omit<OakImageProps, "alt" | "src"> & {
   iconWidth?: OakAllSpacingToken;
   iconHeight?: OakAllSpacingToken;
 };
-
-/**
- * returns true if the given string is a valid `OakIconName`
- */
-export function isValidIconName(iconName: string): iconName is OakIconName {
-  return oakIconNames.includes(iconName as OakIconName);
-}
-
-/**
- * returns a Icon URL from Cloudinary if is a valid icon, otherwise returns undefined
- */
-export function generateOakIconURL(iconName: string) {
-  const urlPath = `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}`;
-  if (isValidIconName(iconName)) {
-    return `${urlPath}/${icons[iconName]}`;
-  } else if (iconName.includes("subject")) {
-    return `${urlPath}/${icons["books"]}`;
-  } else {
-    return `${urlPath}/${icons["question-mark"]}`;
-  }
-}
 
 /**
  * A wrapper around OakImage which uses the image-map.json file to map icon names to image paths.

--- a/src/components/images-and-icons/OakIcon/helpers.ts
+++ b/src/components/images-and-icons/OakIcon/helpers.ts
@@ -1,0 +1,29 @@
+import { IconName, icons } from "@/image-map";
+
+export type OakIconName = IconName;
+export const oakIconNames = Object.keys(icons) as IconName[];
+
+/*
+ * NOTE: This file is separated from OakIcon to allow server side usage in next.js apps
+ */
+
+/**
+ * returns true if the given string is a valid `OakIconName`
+ */
+export function isValidIconName(iconName: string): iconName is OakIconName {
+  return oakIconNames.includes(iconName as OakIconName);
+}
+
+/**
+ * returns a Icon URL from Cloudinary if is a valid icon, otherwise returns undefined
+ */
+export function generateOakIconURL(iconName: string) {
+  const urlPath = `https://${process.env.NEXT_PUBLIC_OAK_ASSETS_HOST}/${process.env.NEXT_PUBLIC_OAK_ASSETS_PATH}`;
+  if (isValidIconName(iconName)) {
+    return `${urlPath}/${icons[iconName]}`;
+  } else if (iconName.includes("subject")) {
+    return `${urlPath}/${icons["books"]}`;
+  } else {
+    return `${urlPath}/${icons["question-mark"]}`;
+  }
+}


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Move functions to own file to allow server side import/usage in next.js app

## Link to the design doc
None

## A link to the component in the deployment preview
https://oak-components-storybook-git-fix-allow-server-side-usage-of-fns.vercel.thenational.academy/

## Testing instructions
Code review only

## ACs
