### PR TITLE
Added `inverted` variant to `<OakPromoTag/>` and `showPromo` to `<OakVideo/>` tab

### DIFF
--- a/src/components/navigation/OakTabs/OakTabs.stories.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.stories.tsx
@@ -42,7 +42,7 @@ export const TabsAsButtons: Story = {
     tabs: [
       { label: "Unit sequence", type: "button" },
       { label: "Explainer", type: "button" },
-      { label: "Download", type: "button" },
+      { label: "Download", showPromo: true, type: "button" },
     ],
   },
 };
@@ -58,6 +58,26 @@ export const TabsAsLinks: Story = {
       { label: "Unit sequence", type: "link", href: "https://google.com" },
       { label: "Explainer", type: "link", href: "https://google.com" },
       { label: "Download", type: "link", href: "https://google.com" },
+    ],
+  },
+};
+
+export const WithPromo: Story = {
+  render: function WithPromoStory(args) {
+    return <OakTabs {...args} activeTab="Unit sequence" />;
+  },
+  args: {
+    sizeVariant: "default",
+    colorVariant: "black",
+    tabs: [
+      { label: "Unit sequence", type: "link", href: "https://google.com" },
+      { label: "Explainer", type: "link", href: "https://google.com" },
+      {
+        label: "Download",
+        showPromo: true,
+        type: "link",
+        href: "https://google.com",
+      },
     ],
   },
 };

--- a/src/components/navigation/OakTabs/OakTabs.test.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.test.tsx
@@ -98,4 +98,26 @@ describe("OakTabs", () => {
     await user.click(links[0]);
     expect(onClickCallback).toHaveBeenCalledWith("Tab one");
   });
+  it("renders with showPromo", async () => {
+    renderWithTheme(
+      <OakTabs
+        {...props}
+        tabs={[
+          { label: "Tab one", type: "link", href: "fakeUrl-1.com" },
+          {
+            label: "Tab two",
+            showPromo: true,
+            type: "link",
+            href: "fakeUrl-2.com",
+          },
+          { label: "Tab three", type: "link", href: "fakeUrl-3.com" },
+        ]}
+      />,
+    );
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(3);
+    expect(links[0]).not.toHaveTextContent("New");
+    expect(links[1]).toHaveTextContent("New");
+    expect(links[2]).not.toHaveTextContent("New");
+  });
 });

--- a/src/components/navigation/OakTabs/OakTabs.tsx
+++ b/src/components/navigation/OakTabs/OakTabs.tsx
@@ -9,10 +9,12 @@ import { ResponsiveValues } from "@/styles/utils/responsiveStyle";
 import { InternalButton } from "@/components/internal-components/InternalButton";
 import { OakFlex } from "@/components/layout-and-structure";
 import { OakUiRoleToken } from "@/styles";
-import { OakLI, OakUL } from "@/components/typography";
+import { OakLI, OakSpan, OakUL } from "@/components/typography";
+import { OakPromoTag } from "@/index";
 
 type Tab<T> = {
   label: T;
+  showPromo?: boolean;
 } & ({ type: "button" } | { type: "link"; href: string });
 
 export type OakTabsProps<T extends string> = {
@@ -78,7 +80,7 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
       }
     >
       {tabs.map((tab) => {
-        const { label, type } = tab;
+        const { label, type, showPromo } = tab;
         const isSelected = activeTab === label;
 
         return (
@@ -118,7 +120,16 @@ export function OakTabs<T extends string>(props: Readonly<OakTabsProps<T>>) {
                 $justifyContent={"center"}
                 $whiteSpace={"nowrap"}
               >
-                {label}
+                <OakFlex $alignItems="center" $gap="spacing-8">
+                  <OakSpan>{label}</OakSpan>
+                  {showPromo && (
+                    <OakPromoTag
+                      variant={
+                        colorVariant === "black" ? "inverted" : "default"
+                      }
+                    />
+                  )}
+                </OakFlex>
               </StyledFocusOutline>
             </StyledTabButton>
           </OakLI>

--- a/src/components/owa/OakPromoTag/OakPromoTag.stories.tsx
+++ b/src/components/owa/OakPromoTag/OakPromoTag.stories.tsx
@@ -7,11 +7,24 @@ const meta: Meta<typeof OakPromoTag> = {
   component: OakPromoTag,
   tags: ["autodocs"],
   title: "OWA/OakPromoTag",
+  argTypes: {
+    variant: {
+      control: { type: "radio" },
+      options: ["default", "inverted"],
+    },
+  },
 };
 export default meta;
 
 type Story = StoryObj<typeof OakPromoTag>;
 
 export const Default: Story = {
-  render: () => <OakPromoTag />,
+  render: (args) => <OakPromoTag {...args} />,
+};
+
+export const VariantInverted: Story = {
+  render: (args) => <OakPromoTag {...args} />,
+  args: {
+    variant: "inverted",
+  },
 };

--- a/src/components/owa/OakPromoTag/OakPromoTag.test.tsx
+++ b/src/components/owa/OakPromoTag/OakPromoTag.test.tsx
@@ -11,4 +11,10 @@ describe(OakPromoTag, () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it("matches snapshot for inverted variant", () => {
+    const { container } = renderWithTheme(<OakPromoTag variant="inverted" />);
+
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/components/owa/OakPromoTag/OakPromoTag.tsx
+++ b/src/components/owa/OakPromoTag/OakPromoTag.tsx
@@ -14,6 +14,7 @@ const StyledPromoTag = styled(OakFlex)`
 export type OakPromoTagProps = {
   width?: SizeStyleProps["$width"];
   display?: DisplayStyleProps["$display"];
+  variant?: "default" | "inverted";
 };
 
 /**
@@ -23,6 +24,7 @@ export const OakPromoTag = (props: OakPromoTagProps) => {
   const {
     width = ["spacing-40", "spacing-48", "spacing-56"],
     display = "flex",
+    variant = "default",
   } = props;
 
   return (
@@ -38,7 +40,7 @@ export const OakPromoTag = (props: OakPromoTagProps) => {
         width="100%"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 56 27"
-        $fill="icon-primary"
+        $fill={variant === "default" ? "bg-inverted" : "bg-decorative5-main"}
       >
         <path d="M6.421 0c8.661.839 17.303.834 26.16.714a89.843 89.843 0 0 1 4.834-.013c6.333.32 12.39.317 18.506-.275 0 1.26.178 2.352 0 3.44-.276 1.38-.829 2.759-1.342 4.15-.138.354-.532.706-.808 1.06-.445.248-.63.5-.553.753 1.598 1.093-.256 2.185 0 3.277.276 1.529 1.322 3.058 1.204 4.572-.138 1.771-1.046 3.543-1.973 5.312-.288.4-1.065.792-2.309 1.169-2.288.755-4.103 1.67-11.206 1.965-9.936.417-20.953.385-30.678-.09-2.447-.12-4.38-.532-5.209-.853-1.035-.458-1.52-.929-1.44-1.4C.937 18.988-.109 14.194.01 9.4c0-2.645 1.973-5.29 3.413-7.933.237-.424 1.697-.839 3-1.468Z" />
       </InternalStyledSvg>
@@ -49,8 +51,7 @@ export const OakPromoTag = (props: OakPromoTagProps) => {
         $justifyContent="center"
       >
         <OakSpan
-          $color="text-promo"
-          $background={"icon-primary"}
+          $color={variant === "default" ? "text-promo" : "text-primary"}
           $font={["body-3-bold", "body-3-bold", "heading-7"]}
         >
           New

--- a/src/components/owa/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
+++ b/src/components/owa/OakPromoTag/__snapshots__/OakPromoTag.test.tsx.snap
@@ -34,7 +34,6 @@ exports[`OakPromoTag matches snapshot 1`] = `
 
 .c5 {
   color: #ffe555;
-  background: #222222;
   font-family: --var(google-font),Lexend,sans-serif;
   font-weight: 500;
   font-size: 0.875rem;
@@ -47,6 +46,152 @@ exports[`OakPromoTag matches snapshot 1`] = `
 
 .c3 {
   fill: #222222;
+}
+
+.c2 {
+  aspect-ratio: 2 / 1;
+}
+
+@media (min-width:750px) {
+  .c0 {
+    width: 3rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c0 {
+    width: 3.5rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c5 {
+    font-weight: 500;
+  }
+}
+
+@media (min-width:1280px) {
+  .c5 {
+    font-weight: 600;
+  }
+}
+
+@media (min-width:750px) {
+  .c5 {
+    font-size: 0.875rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c5 {
+    font-size: 1rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c5 {
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c5 {
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:750px) {
+  .c5 {
+    -webkit-letter-spacing: -0.005rem;
+    -moz-letter-spacing: -0.005rem;
+    -ms-letter-spacing: -0.005rem;
+    letter-spacing: -0.005rem;
+  }
+}
+
+@media (min-width:1280px) {
+  .c5 {
+    -webkit-letter-spacing: 0.0115rem;
+    -moz-letter-spacing: 0.0115rem;
+    -ms-letter-spacing: 0.0115rem;
+    letter-spacing: 0.0115rem;
+  }
+}
+
+<div>
+  <div
+    class="c0 c1 c2"
+  >
+    <svg
+      class="c3"
+      height="100%"
+      viewBox="0 0 56 27"
+      width="100%"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M6.421 0c8.661.839 17.303.834 26.16.714a89.843 89.843 0 0 1 4.834-.013c6.333.32 12.39.317 18.506-.275 0 1.26.178 2.352 0 3.44-.276 1.38-.829 2.759-1.342 4.15-.138.354-.532.706-.808 1.06-.445.248-.63.5-.553.753 1.598 1.093-.256 2.185 0 3.277.276 1.529 1.322 3.058 1.204 4.572-.138 1.771-1.046 3.543-1.973 5.312-.288.4-1.065.792-2.309 1.169-2.288.755-4.103 1.67-11.206 1.965-9.936.417-20.953.385-30.678-.09-2.447-.12-4.38-.532-5.209-.853-1.035-.458-1.52-.929-1.44-1.4C.937 18.988-.109 14.194.01 9.4c0-2.645 1.973-5.29 3.413-7.933.237-.424 1.697-.839 3-1.468Z"
+      />
+    </svg>
+    <div
+      class="c4 c1"
+    >
+      <span
+        class="c5"
+      >
+        New
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`OakPromoTag matches snapshot for inverted variant 1`] = `
+.c0 {
+  position: relative;
+  width: 2.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c4 {
+  position: absolute;
+  inset: 0rem;
+  font-family: --var(google-font),Lexend,sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c5 {
+  color: #222222;
+  font-family: --var(google-font),Lexend,sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.005rem;
+  -moz-letter-spacing: -0.005rem;
+  -ms-letter-spacing: -0.005rem;
+  letter-spacing: -0.005rem;
+}
+
+.c3 {
+  fill: #ffe555;
 }
 
 .c2 {


### PR DESCRIPTION
# How to review this PR

_Leave this text block for the reviewer_

- Check [component hierarchy](https://miro.com/app/board/uXjVNnKBgyk=/?share_link_id=59445593794) is followed correctly
- Check the design [Heuristics](https://components.thenational.academy/?path=/docs/docs-howtodesigncomponents--docs#heuristics-for-component-design) have been followed
- Check [naming conventions](https://components.thenational.academy/?path=/docs/docs-namingconventions--docs) have been applied
- Check for these gotchyas:
  - Missing exports for Oak components
  - Accidental export of Internal components
  - Snapshots of unexpected components have been modified
  - Circular dependencies
  - Code duplication (via not using base components)
  - Non-functional storybook for this or related components
  - Sensitve files changed eg. atoms, or style tokens
  - Relative imports
  - Default exports

# Add your PR description below
Added `inverted` variant to `<OakPromoTag/>` and `showPromo` to `<OakVideo/>` tab

**Note** that `OakPromoTag` is missing it's shadow, this is an existing issue, I'll follow up with another PR if we have time as it'll also require more QA across various places it's used.

<img width="514" height="440" alt="Screenshot 2026-08-06 at 13 35 23" src="https://github.com/user-attachments/assets/063cd1db-a4f8-496c-89d2-805bce415ef4" />
<img width="972" height="75" alt="Screenshot 2026-08-06 at 13 35 09" src="https://github.com/user-attachments/assets/650a9a61-9069-42c8-afe3-825b2f96d6c6" />


## Link to the design doc

 - `<OakPromo/>` — <https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=14797-9813&m=dev>
 - `<OakTab/>` — https://www.figma.com/design/YcWQMMhHPVVmc47cHHEEAl/Oak-Design-Kit?node-id=23680-1854&m=dev

## A link to the component in the deployment preview

 - [`<OakPromoTag/>`](https://oak-components-storybook-git-feat-adopt-2200-add-promo-to-tabs.vercel.thenational.academy/?path=/docs/owa-oakpromotag--docs)
 - [`<OakTag/>`](https://oak-components-storybook-git-feat-adopt-2200-add-promo-to-tabs.vercel.thenational.academy/?path=/docs/components-navigation-oaktabs--docs)

## Testing instructions
Check against designs and regression test

## ACs
